### PR TITLE
Allow lists to be included in input JSON, but ignore when trying to i…

### DIFF
--- a/lib/db/model.dart
+++ b/lib/db/model.dart
@@ -249,14 +249,27 @@ class Model {
       if (value is! Map) {
         throw new QueryException(
             400,
-            "Expecting a map for ${MirrorSystem.getName(typeMirror.simpleName)} in the $key field, got $value instead.",
+            "Expecting a Map for ${MirrorSystem.getName(typeMirror.simpleName)} in the $key field, got $value instead.",
             -1);
-
       }
       Model instance =
           (typeMirror as ClassMirror).newInstance(new Symbol(""), []).reflectee;
       instance.readMap(value);
       return instance;
+    } else if (typeMirror.isSubtypeOf(reflectType(List))) {
+      if (value is! List) {
+        throw new QueryException(
+            400,
+            "Expecting a List for ${MirrorSystem.getName(typeMirror.simpleName)} in the $key field, got $value instead.",
+            -1);
+      }
+
+      var listTypeMirror = typeMirror.typeArguments.first;
+      return (value as List).map((v) {
+        Model instance = (listTypeMirror as ClassMirror).newInstance(new Symbol(""), []).reflectee;
+        instance.readMap(v);
+        return instance;
+      }).toList();
     }
 
     if (typeMirror.isSubtypeOf(reflectType(DateTime))) {

--- a/lib/db/postgresql/postgresl_query.dart
+++ b/lib/db/postgresql/postgresl_query.dart
@@ -95,7 +95,13 @@ class _PostgresqlQuery {
 
     valueObject.dynamicBacking.forEach((modelKey, value) {
       var column = columns[modelKey];
-      if (column.relationship != null) {
+      var relationship = column.relationship;
+
+      if (relationship != null) {
+        if (relationship.type == RelationshipType.hasMany) {
+          return;
+        }
+
         var relatedValue = (value as Model).dynamicBacking[column.relationship.destinationModelKey];
 
         if (relatedValue == null) {

--- a/test/base/client_test_test.dart
+++ b/test/base/client_test_test.dart
@@ -5,4 +5,42 @@ import 'dart:convert';
 import 'dart:async';
 
 Future main() async {
+
+  TestClient client = new TestClient(8080);
+
+  var server = null;
+
+  setUpAll(() async {
+    HttpServer
+        .bind("localhost", 8080,
+        v6Only: false, shared: false)
+        .then((s)
+    {
+      server = s;
+
+      server.listen((req) {
+        var resReq = new ResourceRequest(req);
+        var controller = new TestController();
+        controller.deliver(resReq);
+      });
+    });
+  });
+
+  tearDownAll(() async {
+    await server.close();
+  });
+
+
+  test("Client can expect array of JSON", () async {
+    var resp = await client.request("/na").get();
+    expect(resp, hasResponse(200, [], matchesJSON([{
+      "id" : greaterThan(0)
+    }])));
+  });
+}
+
+class TestController extends HttpController {
+  @httpGet get() async {
+    return new Response.ok([{"id" : 1}, {"id" : 2}]);
+  }
 }

--- a/test/db/model_tests.dart
+++ b/test/db/model_tests.dart
@@ -29,16 +29,9 @@ main() {
     }
   });
 
-  test("Accessing model object without field throws exception", () {
+  test("Accessing model object without field should return null", () {
     var user = new User();
-    try {
-      var x = user.name;
-      fail("This should throw an exception.");
-      print("$x");
-    } catch (e) {
-      expect(e.message,
-          "Accessing property name on User, but is currently undefined for this instance.");
-    }
+    expect(user.name, isNull);
   });
 
   test("Getting/setting property that is undeclared throws exception", () {
@@ -182,7 +175,7 @@ main() {
       fail("Should throw");
     } catch (e) {
       expect(e.message,
-          "Expecting a map for User in the owner field, got 12 instead.");
+          "Expecting a Map for User in the owner field, got 12 instead.");
     }
   });
 
@@ -280,7 +273,20 @@ main() {
       expect(e is QueryException, true);
       expect(e.message, "Key outputInt does not exist for TransientTest");
     }
+  });
 
+  test("Reading hasMany relationship from JSON succeeds", () {
+    var u = new User();
+    u.readMap({
+      "name" : "Bob",
+      "id" : 1,
+      "posts" : [
+        {"text" : "Hi", "id" : 1}
+      ]
+    });
+    expect(u.posts.length, 1);
+    expect(u.posts[0].id, 1);
+    expect(u.posts[0].text, "Hi");
   });
 
 }

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -51,15 +51,7 @@ void main() {
 
     expect(item.name, "Joe");
     expect(item.id, id);
-
-    try {
-      var email = item.email;
-      fail("This should throw exception");
-      print("$email");
-    } catch (e) {
-      expect(e.message,
-          "Accessing property email on TestModel, but is currently undefined for this instance.");
-    }
+    expect(item.email, isNull);
   });
 
   test("Ascending sort descriptors work", () async {

--- a/test/db/postgresql/insert_test.dart
+++ b/test/db/postgresql/insert_test.dart
@@ -186,6 +186,31 @@ void main() {
     var result = await q.insert(adapter);
     expect(result.transientValue, null);
   });
+
+  test("JSON -> Insert with List", () async {
+    await generateTemporarySchemaFromModels(adapter, [GenUser, GenPost]);
+
+    var json = {
+      "name" : "Bob",
+      "posts" : [
+        {"text" : "Post"}
+      ]
+    };
+
+    var u = new GenUser()
+      ..readMap(json);
+
+    var q = new Query<GenUser>()
+      ..valueObject = u;
+
+    var result = await q.insert(adapter);
+    expect(result.id, greaterThan(0));
+    expect(result.name, "Bob");
+    expect(result.posts, isNull);
+
+    q = new Query<GenPost>();
+    expect(await q.fetch(adapter), hasLength(0));
+  });
 }
 
 @ModelBacking(TestModelBacking)


### PR DESCRIPTION
…nsert/update to adapter.

I hit this on the wrong branch, so naming is incorrect. Basically, you can now POST/PUT model objects with ModelControllers that have a body that contains hasMany related objects. AKA, I have a User that has a List of Location. The JSON body can contain "locations" : [{"locationID" : 1}]. This will be appropriately parsed into the requestModel object and can be used in the endpoint. However, it should be noted that the (intended) behavior is that trying to insert the 'User' object in this example will NOT insert the embedded Location objects. That would cause all kinds of nightmares.
