### PR TITLE
GIT Url from git: -> https:// on pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,10 +2,7 @@ name: monadart
 version: 0.0.1
 description: A pipeline for building web services
 dependencies:
-  safe_config:
-    git:
-      url: git@github.com:stablekernel/safe_config.git
-      ref: master
+  safe_config: "^1.0.2"
   yaml: any
   matcher: any
   http_server: any


### PR DESCRIPTION
To prepare econet to be dockerized, it would be advisable to avoid git/ssh combinations for dependencies after all. 
Therefore this PR will change the dependencies to safe_config towards using https instead of using the git protocol
