### PR TITLE
Jc/fixcatch

### DIFF
--- a/lib/base/request.dart
+++ b/lib/base/request.dart
@@ -34,7 +34,7 @@ class Request implements RequestHandlerResult {
 
   /// Creates an instance of [Request], no need to do so manually.
   Request(this.innerRequest) {
-    connectionInfo  = innerRequest.connectionInfo;
+    connectionInfo = innerRequest.connectionInfo;
   }
 
   /// The internal [HttpRequest] of this [Request].
@@ -185,7 +185,7 @@ class Request implements RequestHandlerResult {
     var builder = new StringBuffer();
     if (innerRequest != null) {
       if (includeRequestIP) {
-        builder.write("${innerRequest.connectionInfo?.remoteAddress?.address} ");
+        builder.write("${connectionInfo?.remoteAddress?.address} ");
       }
       if (includeMethod) {
         builder.write("${innerRequest.method} ");

--- a/lib/base/request.dart
+++ b/lib/base/request.dart
@@ -33,13 +33,18 @@ class Request implements RequestHandlerResult {
   }
 
   /// Creates an instance of [Request], no need to do so manually.
-  Request(this.innerRequest);
+  Request(this.innerRequest) {
+    connectionInfo  = innerRequest.connectionInfo;
+  }
 
   /// The internal [HttpRequest] of this [Request].
   ///
   /// The standard library generated HTTP request object. This contains
   /// all of the request information provided by the client.
   final HttpRequest innerRequest;
+
+  /// Information about the client connection.
+  HttpConnectionInfo connectionInfo;
 
   /// The response object of this [Request].
   ///
@@ -88,10 +93,12 @@ class Request implements RequestHandlerResult {
 
   String get _sanitizedHeaders {
     StringBuffer buf = new StringBuffer("{");
-    innerRequest.headers.forEach((k, v) {
+
+    innerRequest?.headers?.forEach((k, v) {
       buf.write("${_truncatedString(k)} : ${_truncatedString(v.join(","))}\\n");
     });
     buf.write("}");
+
     return buf.toString();
   }
 
@@ -176,23 +183,25 @@ class Request implements RequestHandlerResult {
 
   String toDebugString({bool includeElapsedTime: true, bool includeRequestIP: true, bool includeMethod: true, bool includeResource: true, bool includeStatusCode: true, bool includeContentSize: false, bool includeHeaders: false, bool includeBody: false}) {
     var builder = new StringBuffer();
-    if (includeRequestIP) {
-      builder.write("${innerRequest.connectionInfo.remoteAddress.address} ");
-    }
-    if (includeMethod) {
-      builder.write("${innerRequest.method} ");
-    }
-    if (includeResource) {
-      builder.write("${innerRequest.uri} ");
-    }
-    if (includeElapsedTime && respondDate != null) {
-      builder.write("${respondDate.difference(receivedDate).inMilliseconds}ms ");
-    }
-    if (includeStatusCode) {
-      builder.write("${innerRequest.response.statusCode} ");
-    }
-    if (includeContentSize) {
-      builder.write("${innerRequest.response.contentLength} ");
+    if (innerRequest != null) {
+      if (includeRequestIP) {
+        builder.write("${innerRequest.connectionInfo?.remoteAddress?.address} ");
+      }
+      if (includeMethod) {
+        builder.write("${innerRequest.method} ");
+      }
+      if (includeResource) {
+        builder.write("${innerRequest.uri} ");
+      }
+      if (includeElapsedTime && respondDate != null && receivedDate != null) {
+        builder.write("${respondDate.difference(receivedDate).inMilliseconds}ms ");
+      }
+      if (includeStatusCode) {
+        builder.write("${innerRequest.response?.statusCode} ");
+      }
+      if (includeContentSize) {
+        builder.write("${innerRequest.response?.contentLength} ");
+      }
     }
     if (includeHeaders) {
       builder.write("${_sanitizedHeaders} ");

--- a/lib/base/request_handler.dart
+++ b/lib/base/request_handler.dart
@@ -114,10 +114,7 @@ class RequestHandler extends Object with APIDocumentable {
       } else if (result is Response) {
         _applyCORSHeadersIfNecessary(req, result);
         req.respond(result as Response);
-
-        new Future.delayed(new Duration(seconds: 10)).then((_) {
-          logger.info(req.toDebugString());
-        });
+        logger.info(req.toDebugString());
       }
     } on HTTPResponseException catch (err) {
       _handleResponseException(req, err);

--- a/lib/base/request_handler.dart
+++ b/lib/base/request_handler.dart
@@ -114,18 +114,15 @@ class RequestHandler extends Object with APIDocumentable {
       } else if (result is Response) {
         _applyCORSHeadersIfNecessary(req, result);
         req.respond(result as Response);
-        logger.info(req.toDebugString());
+
+        new Future.delayed(new Duration(seconds: 10)).then((_) {
+          logger.info(req.toDebugString());
+        });
       }
     } on HTTPResponseException catch (err) {
-      var response = err.response();
-      _applyCORSHeadersIfNecessary(req, response);
-      req.respond(response);
-      logger.info("${req.toDebugString(includeHeaders: true, includeBody: true)} ${err.message}");
+      _handleResponseException(req, err);
     } catch (err, st) {
-      var response = new Response.serverError(headers: {HttpHeaders.CONTENT_TYPE: ContentType.JSON}, body: {"error": "${this.runtimeType}: $err.", "stacktrace": st.toString()});
-      _applyCORSHeadersIfNecessary(req, response);
-      req.respond(response);
-      logger.severe("${req.toDebugString(includeHeaders: true, includeBody: true)} $err $st");
+      _handleUncaughtError(req, err, st);
     }
   }
 
@@ -142,6 +139,32 @@ class RequestHandler extends Object with APIDocumentable {
     }
 
     return req;
+  }
+
+  void _handleResponseException(Request request, HTTPResponseException exception) {
+    try {
+      var response = exception.response();
+      _applyCORSHeadersIfNecessary(request, response);
+      request.respond(response);
+
+      logger.info("${request.toDebugString(includeHeaders: true, includeBody: true)} ${exception.message}");
+    } catch (_) {
+      // If we get here, well, there isn't anything else we can do.
+      request.response.close();
+    }
+  }
+
+  void _handleUncaughtError(Request request, dynamic error, StackTrace stack) {
+    try {
+      var response = new Response.serverError(headers: {HttpHeaders.CONTENT_TYPE: ContentType.JSON}, body: {"error": "${this.runtimeType}: $error.", "stacktrace": stack.toString()});
+      _applyCORSHeadersIfNecessary(request, response);
+      request.respond(response);
+
+      logger.severe("${request.toDebugString(includeHeaders: true, includeBody: true)} $error $stack");
+    } catch (_) {
+      // If we get here, well, there isn't anything else we can do.
+      request.response.close();
+    }
   }
 
   RequestHandler _lastRequestHandler() {

--- a/test/base/request_handler_test.dart
+++ b/test/base/request_handler_test.dart
@@ -1,0 +1,89 @@
+import 'package:test/test.dart';
+import 'package:aqueduct/aqueduct.dart';
+import 'dart:async';
+import 'package:http/http.dart' as http;
+import 'dart:io';
+import 'dart:mirrors';
+import 'dart:isolate';
+
+void main() {
+  HttpServer server = null;
+  tearDown(() async {
+    await server.close();
+  });
+
+  test("Logging after socket is closed does not throw exception", () async {
+    var handler = new RequestHandler(requestHandler: (Request req) {
+      req.innerRequest.response.detachSocket().then((s) async {
+        s.destroy();
+
+        req.toDebugString(includeHeaders: true, includeBody: true, includeContentSize: true,
+            includeElapsedTime: true, includeMethod: true, includeRequestIP: true, includeResource: true,
+            includeStatusCode: true);
+      });
+    });
+
+    var ensureExceptionIsCapturedByDeliver = new Completer();
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8000);
+    server
+        .map((req) => new Request(req))
+        .listen((req) async {
+      await handler.deliver(req);
+
+      // We won't get here unless an exception is thrown, and that's what we're testing
+      ensureExceptionIsCapturedByDeliver.complete(true);
+    });
+
+    try {
+      await http.get("http://localhost:8000");
+    } catch (e) {}
+
+    expect(ensureExceptionIsCapturedByDeliver.future, completes);
+  });
+
+  test("Request handler that dies on bad state: header already sent is captured in RequestHandler", () async {
+    var handler = new RequestHandler(requestHandler: (Request req) {
+      req.response.close();
+
+      return new Response.ok(null);
+    });
+
+    var ensureExceptionIsCapturedByDeliver = new Completer();
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8000);
+    server
+        .map((req) => new Request(req))
+        .listen((req) async {
+          await handler.deliver(req);
+
+          // We won't get here unless an exception is thrown, and that's what we're testing
+          ensureExceptionIsCapturedByDeliver.complete(true);
+        });
+
+    await http.get("http://localhost:8000");
+
+    expect(ensureExceptionIsCapturedByDeliver.future, completes);
+  });
+
+  test("Request handler throwing HttpResponseException that dies on bad state: header already sent is captured in RequestHandler", () async {
+    var handler = new RequestHandler(requestHandler: (Request req) {
+      req.response.close();
+
+      throw new HTTPResponseException(400, "whocares");
+    });
+
+    var ensureExceptionIsCapturedByDeliver = new Completer();
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8000);
+    server
+        .map((req) => new Request(req))
+        .listen((req) async {
+      await handler.deliver(req);
+
+      // We won't get here unless an exception is thrown, and that's what we're testing
+      ensureExceptionIsCapturedByDeliver.complete(true);
+    });
+
+    await http.get("http://localhost:8000");
+
+    expect(ensureExceptionIsCapturedByDeliver.future, completes);
+  });
+}


### PR DESCRIPTION
This PR addresses the issue that can cause two isolate crashers: trying to send a 500 response after a response has already been sent and logging after closing a response doesn't crash in strange circumstances.