### PR TITLE
Adds refresh_token as grant_type to conform to RFC 6749

### DIFF
--- a/lib/auth/auth_controller.dart
+++ b/lib/auth/auth_controller.dart
@@ -27,7 +27,7 @@ class AuthController extends HTTPController {
   /// Content-Type must be application/x-www-form-urlencoded. (Query string in the body, e.g. username=bob&password=password)
   /// Values must be URL percent encoded by client.
   /// When grant_type is 'password', there must be username and password values.
-  /// When grant_type is 'refresh', there must be a refresh_token value.
+  /// When grant_type is 'refresh' or 'refresh_token', there must be a refresh_token value.
   /// When grant_type is 'authorization_code', there must be a authorization_code value.
   @httpPost
   Future<Response> create({
@@ -44,7 +44,7 @@ class AuthController extends HTTPController {
 
       var token = await authenticationServer.authenticate(username, password, basicRecord.username, basicRecord.password);
       return AuthController.tokenResponse(token);
-    } else if (grantType == "refresh") {
+    } else if (grantType == "refresh" || grantType == "refresh_token") {
       if (refreshToken == null) {
         return new Response.badRequest(body: {"error": "missing refresh_token"});
       }

--- a/test/auth/auth_controller_test.dart
+++ b/test/auth/auth_controller_test.dart
@@ -128,25 +128,26 @@ void main() {
       "expires_in" : greaterThan(3500),
       "token_type" : "bearer"
     }));
-	
-    test("Refresh token responds with token on correct input. grant_type=refresh_token version", () async {
-      await createUsers(1);
+  });
 
-      var m = {"grant_type" : "password", "username" : "bob+0@stablekernel.com", "password" : "foobaraxegrind21%"};
+  test("Refresh token responds with token on correct input. grant_type=refresh_token version", () async {
+    await createUsers(1);
 
-      var req = client.clientAuthenticatedRequest("/auth/token")
-        ..formData = m;
-      var json = JSON.decode((await req.post()).body);
-      m = {"grant_type" : "refresh_token", "refresh_token" : json["refresh_token"]};
+    var m = {"grant_type" : "password", "username" : "bob+0@stablekernel.com", "password" : "foobaraxegrind21%"};
 
-      req = client.clientAuthenticatedRequest("/auth/token")
-        ..formData = m;
-      expect(await req.post(), hasResponse(200, {
-        "access_token" : hasLength(greaterThan(0)),
-        "refresh_token" : json["refresh_token"],
-        "expires_in" : greaterThan(3500),
-        "token_type" : "bearer"
-      }));
+    var req = client.clientAuthenticatedRequest("/auth/token")
+      ..formData = m;
+    var json = JSON.decode((await req.post()).body);
+    m = {"grant_type" : "refresh_token", "refresh_token" : json["refresh_token"]};
+
+    req = client.clientAuthenticatedRequest("/auth/token")
+      ..formData = m;
+    expect(await req.post(), hasResponse(200, {
+      "access_token" : hasLength(greaterThan(0)),
+      "refresh_token" : json["refresh_token"],
+      "expires_in" : greaterThan(3500),
+      "token_type" : "bearer"
+    }));
   });
 
   test("Response documentation", () {

--- a/test/auth/auth_controller_test.dart
+++ b/test/auth/auth_controller_test.dart
@@ -128,6 +128,25 @@ void main() {
       "expires_in" : greaterThan(3500),
       "token_type" : "bearer"
     }));
+	
+    test("Refresh token responds with token on correct input. grant_type=refresh_token version", () async {
+      await createUsers(1);
+
+      var m = {"grant_type" : "password", "username" : "bob+0@stablekernel.com", "password" : "foobaraxegrind21%"};
+
+      var req = client.clientAuthenticatedRequest("/auth/token")
+        ..formData = m;
+      var json = JSON.decode((await req.post()).body);
+      m = {"grant_type" : "refresh_token", "refresh_token" : json["refresh_token"]};
+
+      req = client.clientAuthenticatedRequest("/auth/token")
+        ..formData = m;
+      expect(await req.post(), hasResponse(200, {
+        "access_token" : hasLength(greaterThan(0)),
+        "refresh_token" : json["refresh_token"],
+        "expires_in" : greaterThan(3500),
+        "token_type" : "bearer"
+      }));
   });
 
   test("Response documentation", () {


### PR DESCRIPTION
**Changes:**
* Accepts refresh_token as grant_type as described in RFC 6749 which describes OAuth2

* Tests included