### PR TITLE
Git remove migration files from example default template migrations folder.

### DIFF
--- a/example/templates/default/.gitignore
+++ b/example/templates/default/.gitignore
@@ -12,3 +12,8 @@ workspace.xml
 Dart_Packages.xml
 .DS_Store
 .idea/dictionaries
+migrations/migration.yaml
+error.log
+.aqueductpid
+.aqueductsignal
+api.log*

--- a/example/templates/default/README.md
+++ b/example/templates/default/README.md
@@ -34,6 +34,12 @@ This will print a JSON OpenAPI specification to stdout.
 
 Configure the connection information for the database in `migrations/migration.yaml`. The specified username must have the privileges to create tables.
 
+Copy the migration default file:
+
+```
+cp migrations/migration.default.yaml migrations/migration.yaml
+```
+
 Run the migration generation tool:
 
 ```
@@ -50,6 +56,12 @@ You may create subsequent migration files with `aqueduct db generate`. Note that
 
 ```
 aqueduct db validate
+```
+
+Copy and edit config default file:
+
+```
+cp config.yaml.src config.yaml
 ```
 
 ## Running wildfire

--- a/example/templates/default/migrations/migration.default.yaml
+++ b/example/templates/default/migrations/migration.default.yaml
@@ -1,0 +1,5 @@
+username: dart
+password: dart
+host: localhost
+port: 5432
+databaseName: test


### PR DESCRIPTION
Git remove error.log.
Git remove migration.yaml. Add migration default file. Extend docs.
Git remove .aqueductpid, .aqueductsignal and all api.log.*.
Add description for default config.