### PR TITLE
Git remove migration files from example default template migrations folder.

### DIFF
--- a/example/templates/default/.gitignore
+++ b/example/templates/default/.gitignore
@@ -12,3 +12,8 @@ workspace.xml
 Dart_Packages.xml
 .DS_Store
 .idea/dictionaries
+migrations/migration.yaml
+error.log
+.aqueductpid
+.aqueductsignal
+api.log*

--- a/example/templates/default/README.md
+++ b/example/templates/default/README.md
@@ -33,6 +33,13 @@ This will print a JSON OpenAPI specification to stdout.
 ## Generating the Database Schema
 
 Configure the connection information for the database in `migrations/migration.yaml`. The specified username must have the privileges to create tables.
+(The file `migrations/migration.yaml.src` is a template for `migrations/migration.yaml`.)
+
+You may copy and edit the migration template file:
+
+```
+cp migrations/migration.yaml.src migrations/migration.yaml
+```
 
 Run the migration generation tool:
 
@@ -55,6 +62,12 @@ aqueduct db validate
 ## Running wildfire
 
 Ensure that a `config.yaml` file exists in this directory. (The file `config.yaml.src` is a template for `config.yaml`.)
+
+You may copy and edit config template file:
+
+```
+cp config.yaml.src config.yaml
+```
 
 Give executable permissions for the application script:
 

--- a/example/templates/default/migrations/migration.yaml.src
+++ b/example/templates/default/migrations/migration.yaml.src
@@ -1,0 +1,5 @@
+username: dart
+password: dart
+host: localhost
+port: 5432
+databaseName: test


### PR DESCRIPTION
Git remove error.log.
Git remove migration.yaml. Add migration default file. Extend docs.
Git remove .aqueductpid, .aqueductsignal and all api.log.*.
Add description for default config.