### PR TITLE
Jc/cors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.3
 - Fix to allow Windows user to use `aqueduct setup`.
+- Fix to CORS processing.
+- HTTPControllers now return 405 if there is no responder method match for a request.
 
 ## 1.0.2
 - Fix type checking for transient map and list properties of ManagedObject.

--- a/lib/http/http_controller.dart
+++ b/lib/http/http_controller.dart
@@ -86,7 +86,7 @@ abstract class HTTPController extends RequestController {
     var controllerCache = _HTTPControllerCache.cacheForType(runtimeType);
     var mapper = controllerCache.mapperForRequest(request);
     if (mapper == null) {
-      return new Response.notFound();
+      return new Response(405, null, null);
     }
 
     if (request.innerRequest.contentLength > 0) {

--- a/lib/http/http_controller.dart
+++ b/lib/http/http_controller.dart
@@ -86,7 +86,9 @@ abstract class HTTPController extends RequestController {
     var controllerCache = _HTTPControllerCache.cacheForType(runtimeType);
     var mapper = controllerCache.mapperForRequest(request);
     if (mapper == null) {
-      return new Response(405, null, null);
+      return new Response(405, {
+        "Allow" : controllerCache.allowedMethodsForArity(pathVariables?.length ?? 0)
+      }, null);
     }
 
     if (request.innerRequest.contentLength > 0) {

--- a/lib/http/parameter_matching.dart
+++ b/lib/http/parameter_matching.dart
@@ -103,6 +103,13 @@ class _HTTPControllerCache {
   Map<Symbol, dynamic> propertiesFromRequest(HttpHeaders headers, Map<String, List<String>> queryParameters) {
     return _parseParametersFromRequest(propertyCache, headers, queryParameters);
   }
+
+  List<String> allowedMethodsForArity(int arity) {
+    return methodCache.values
+        .where((m) => m.pathParameters.length == arity)
+        .map((m) => m.httpMethod.method.toUpperCase())
+        .toList();
+  }
 }
 
 class _HTTPControllerCachedMethod {

--- a/lib/http/request.dart
+++ b/lib/http/request.dart
@@ -59,7 +59,7 @@ class Request implements RequestControllerEvent {
   ///
   /// This is true if the request HTTP method is OPTIONS and the headers contains Access-Control-Request-Method.
   bool get isPreflightRequest {
-    return innerRequest.method == "OPTIONS" && innerRequest.headers.value("access-control-request-method") != null;
+    return isCORSRequest && innerRequest.method == "OPTIONS" && innerRequest.headers.value("access-control-request-method") != null;
   }
 
   /// Container for any data a [RequestController] wants to attach to this request for the purpose of being used by a later [RequestController].

--- a/lib/http/request_controller.dart
+++ b/lib/http/request_controller.dart
@@ -126,7 +126,6 @@ class RequestController extends Object with APIDocumentable {
           return;
         }
 
-        logger.info("${req.innerRequest.headers}");
         if (policy != null) {
           if (!policy.validatePreflightRequest(req.innerRequest)) {
             req.respond(new Response.forbidden());

--- a/lib/http/router.dart
+++ b/lib/http/router.dart
@@ -19,6 +19,7 @@ class Router extends RequestController {
   /// Creates a new [Router].
   Router() {
     unhandledRequestController = _handleUnhandledRequest;
+    policy.allowCredentials = false;
   }
 
   List<RouteController> _routeControllers = [];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: aqueduct
-version: 1.0.2
+version: 1.0.3
 description: A fully featured server-side framework built for productivity and testability.
 author: stable|kernel <http://stablekernel.com>
 homepage: https://github.com/stablekernel/aqueduct

--- a/test/base/controller_test.dart
+++ b/test/base/controller_test.dart
@@ -46,12 +46,18 @@ void main() {
     expect(JSON.decode(res.body), "123active");
   });
 
-  test("Unsupported method", () async {
-    server = await enableController("/a", TController);
+  group("Unsupported method", () {
+    test("Returns status code 405 with Allow response header", () async {
+      server = await enableController("/a", TController);
 
-    var res = await http.delete("http://localhost:4040/a");
-    expect(res.statusCode, 404);
-    // expect headers to have Allow: GET, POST, PUT
+      var res = await http.delete("http://localhost:4040/a");
+      expect(res.statusCode, 405);
+      expect(res.headers["allow"], "GET, POST, PUT");
+    });
+
+    test("Only returns allow for specific resource within controller", () async {
+      fail("NYI");
+    });
   });
 
   test("Crashing controller delivers 500", () async {

--- a/test/base/controller_test.dart
+++ b/test/base/controller_test.dart
@@ -52,11 +52,23 @@ void main() {
 
       var res = await http.delete("http://localhost:4040/a");
       expect(res.statusCode, 405);
-      expect(res.headers["allow"], "GET, POST, PUT");
+      expect(res.headers["allow"], "GET, POST");
     });
 
     test("Only returns allow for specific resource within controller", () async {
-      fail("NYI");
+      server = await enableController("/a/[:id/[:flag]]", TController);
+
+      var res = await http.delete("http://localhost:4040/a");
+      expect(res.statusCode, 405);
+      expect(res.headers["allow"], "GET, POST");
+
+      res = await http.delete("http://localhost:4040/a/1");
+      expect(res.statusCode, 405);
+      expect(res.headers["allow"], "GET, PUT");
+
+      res = await http.delete("http://localhost:4040/a/1/foo");
+      expect(res.statusCode, 405);
+      expect(res.headers["allow"], "GET");
     });
   });
 

--- a/test/base/cors_test.dart
+++ b/test/base/cors_test.dart
@@ -24,25 +24,25 @@ void main() {
     test("Controller with no policy returns correctly", () async {
       var resp = await http.get("http://localhost:8000/nopolicy");
       expect(resp.statusCode, 200);
-      expectThatNoCORSProcessingOccured(resp);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Controller with permissive default policy returns correctly", () async {
       var resp = await http.get("http://localhost:8000/defaultpolicy");
       expect(resp.statusCode, 200);
-      expectThatNoCORSProcessingOccured(resp);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Controller with restrict policy returns correctly", () async {
       var resp = await http.get("http://localhost:8000/restrictive");
       expect(resp.statusCode, 200);
-      expectThatNoCORSProcessingOccured(resp);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Invalid resource 404s", () async {
       var resp = await http.get("http://localhost:8000/foobar");
       expect(resp.statusCode, 404);
-      expectThatNoCORSProcessingOccured(resp);
+      expectThatNoCORSProcessingOccurred(resp);
     });
   });
 
@@ -53,7 +53,7 @@ void main() {
         "Origin" : "not this"
       });
       expect(resp.statusCode, 200);
-      expectThatNoCORSProcessingOccured(resp);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Valid endpoint, case match failure", () async {
@@ -61,7 +61,7 @@ void main() {
         "Origin" : "http://Exclusive.com"
       });
       expect(resp.statusCode, 200);
-      expectThatNoCORSProcessingOccured(resp);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Invalid resource gets CORS headers to expose 404 to calling client", () async {
@@ -83,7 +83,7 @@ void main() {
         "Authorization" : "Bearer noauth"
       });
       expect(resp.statusCode, 401);
-      expectThatNoCORSProcessingOccured(resp);
+      expectThatNoCORSProcessingOccurred(resp);
     });
   });
 
@@ -176,11 +176,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-      expect(resp.headers["access-control-allow-headers"], isNull);
-      expect(resp.headers["access-control-allow-methods"], isNull);
-      expect(resp.headers["access-control-expose-headers"], isNull);
-      expect(resp.headers["access-control-allow-credentials"], isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Return 401 if there is an actual endpoint for OPTIONS and request is unauthorized (No CORS Headers)", () async {
@@ -188,11 +184,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 401);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-      expect(resp.headers["access-control-allow-headers"], isNull);
-      expect(resp.headers["access-control-allow-methods"], isNull);
-      expect(resp.headers["access-control-expose-headers"], isNull);
-      expect(resp.headers["access-control-allow-credentials"], isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Return 404 if there is no endpoint for OPTIONS (No CORS Headers)", () async {
@@ -200,11 +192,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 404);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-      expect(resp.headers["access-control-allow-headers"], isNull);
-      expect(resp.headers["access-control-allow-methods"], isNull);
-      expect(resp.headers["access-control-expose-headers"], isNull);
-      expect(resp.headers["access-control-allow-credentials"], isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Return 405 if there is an endpoint, but OPTIONS not supported (No CORS Headers)", () async {
@@ -212,11 +200,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 405);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-      expect(resp.headers["access-control-allow-headers"], isNull);
-      expect(resp.headers["access-control-allow-methods"], isNull);
-      expect(resp.headers["access-control-expose-headers"], isNull);
-      expect(resp.headers["access-control-allow-credentials"], isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
   });
 
@@ -244,11 +228,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 403);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-      expect(resp.headers["access-control-allow-headers"], isNull);
-      expect(resp.headers["access-control-allow-methods"], isNull);
-      expect(resp.headers["access-control-expose-headers"], isNull);
-      expect(resp.headers["access-control-allow-credentials"], isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("If origin is invalid, get 403 from OPTIONS", () async {
@@ -258,11 +238,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 403);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-      expect(resp.headers["access-control-allow-headers"], isNull);
-      expect(resp.headers["access-control-allow-methods"], isNull);
-      expect(resp.headers["access-control-expose-headers"], isNull);
-      expect(resp.headers["access-control-allow-credentials"], isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("If no policy defined, return 403", () async {
@@ -272,11 +248,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 403);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-      expect(resp.headers["access-control-allow-headers"], isNull);
-      expect(resp.headers["access-control-allow-methods"], isNull);
-      expect(resp.headers["access-control-expose-headers"], isNull);
-      expect(resp.headers["access-control-allow-credentials"], isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
   });
 
@@ -289,11 +261,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 403);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-      expect(resp.headers["access-control-allow-headers"], isNull);
-      expect(resp.headers["access-control-allow-methods"], isNull);
-      expect(resp.headers["access-control-expose-headers"], isNull);
-      expect(resp.headers["access-control-allow-credentials"], isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("If allow method is available", () async {
@@ -378,11 +346,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 403);
-      expect(resp.headers.value("access-control-allow-origin"), isNull);
-      expect(resp.headers.value("access-control-allow-headers"), isNull);
-      expect(resp.headers.value("access-control-allow-methods"), isNull);
-      expect(resp.headers.value("access-control-expose-headers"), isNull);
-      expect(resp.headers.value("access-control-allow-credentials"), isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("If one specified allow headers are not available, get a 403", () async {
@@ -393,11 +357,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 403);
-      expect(resp.headers.value("access-control-allow-origin"), isNull);
-      expect(resp.headers.value("access-control-allow-headers"), isNull);
-      expect(resp.headers.value("access-control-allow-methods"), isNull);
-      expect(resp.headers.value("access-control-expose-headers"), isNull);
-      expect(resp.headers.value("access-control-allow-credentials"), isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("If all specified allow headers are not available, get a 403", () async {
@@ -408,11 +368,7 @@ void main() {
       var resp = await req.close();
 
       expect(resp.statusCode, 403);
-      expect(resp.headers.value("access-control-allow-origin"), isNull);
-      expect(resp.headers.value("access-control-allow-headers"), isNull);
-      expect(resp.headers.value("access-control-allow-methods"), isNull);
-      expect(resp.headers.value("access-control-expose-headers"), isNull);
-      expect(resp.headers.value("access-control-allow-credentials"), isNull);
+      expectThatNoCORSProcessingOccurred(resp);
     });
   });
 
@@ -468,12 +424,20 @@ void main() {
   });
 }
 
-expectThatNoCORSProcessingOccured(http.Response resp) {
-  expect(resp.headers["access-control-allow-origin"], isNull);
-  expect(resp.headers["access-control-allow-headers"], isNull);
-  expect(resp.headers["access-control-allow-methods"], isNull);
-  expect(resp.headers["access-control-expose-headers"], isNull);
-  expect(resp.headers["access-control-allow-credentials"], isNull);
+expectThatNoCORSProcessingOccurred(dynamic resp) {
+  if (resp is http.Response) {
+    expect(resp.headers["access-control-allow-origin"], isNull);
+    expect(resp.headers["access-control-allow-headers"], isNull);
+    expect(resp.headers["access-control-allow-methods"], isNull);
+    expect(resp.headers["access-control-expose-headers"], isNull);
+    expect(resp.headers["access-control-allow-credentials"], isNull);
+  } else if (resp is HttpClientResponse) {
+    expect(resp.headers.value("access-control-allow-origin"), isNull);
+    expect(resp.headers.value("access-control-allow-headers"), isNull);
+    expect(resp.headers.value("access-control-allow-methods"), isNull);
+    expect(resp.headers.value("access-control-expose-headers"), isNull);
+    expect(resp.headers.value("access-control-allow-credentials"), isNull);
+  }
 }
 
 class CORSSink extends RequestSink implements AuthServerDelegate<AuthImpl, TokenImpl, AuthCodeImpl> {

--- a/test/base/cors_test.dart
+++ b/test/base/cors_test.dart
@@ -5,200 +5,425 @@ import 'package:http/http.dart' as http;
 import 'package:aqueduct/aqueduct.dart';
 import 'dart:async';
 
+// These tests are based on the specification found at http://www.w3.org/TR/cors/.
 void main() {
-  group("No CORS Policy", () {
-    var app = new Application<CORSSink>();
-    app.configuration.port = 8000;
+  var app = new Application<CORSSink>();
+  app.configuration.port = 8000;
 
-    setUpAll(() async {
-      await app.start(runOnMainIsolate: true);
-    });
-    tearDownAll(() async {
-      await app?.stop();
-    });
+  setUpAll(() async {
+    await app.start(runOnMainIsolate: true);
+  });
 
-    test("Unknown route still returns 404", () async {
-      var resp = await http.get("http://localhost:8000/foobar");
-      expect(resp.statusCode, 404);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
+  tearDownAll(() async {
+    await app?.stop();
+  });
 
-    test("Normal request when no CORS policy", () async {
+  group("Normal/Simple Requests: If the origin header is not present, terminate this set of steps. (No CORS Headers.)", () {
+    // This group ensures that if a controller has or doesn't have a policy, if it is not a CORS request,
+    // no CORS headers/processing occurs.
+    test("Controller with no policy returns correctly", () async {
       var resp = await http.get("http://localhost:8000/nopolicy");
       expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], isNull);
+      expectThatNoCORSProcessingOccured(resp);
     });
 
-    test("Origin request when no CORS policy", () async {
-      var resp = await http.get("http://localhost:8000/nopolicy", headers: {
-        "Origin" : "http://somewhereelse.com"
-      });
-      expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
-
-    test("Preflight request when no CORS policy", () async {
-      var client = new HttpClient();
-      var req = await client.openUrl("OPTIONS", new Uri(scheme: "http", host: "localhost", port: 8000, path: "nopolicy"));
-      var resp = await req.close();
-      expect(resp.statusCode, 404);
-    });
-
-    test("Normal request when no CORS policy + Auth (Success)", () async {
-      var resp = await http.get("http://localhost:8000/nopolicyauth", headers: {"Authorization" : "Bearer auth"});
-      expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
-
-    test("Origin request when no CORS policy + Auth (Success)", () async {
-      var resp = await http.get("http://localhost:8000/nopolicyauth", headers: {
-        "Origin" : "http://somewhereelse.com",
-        "Authorization" : "Bearer auth"
-      });
-      expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
-
-    test("Preflight request when no CORS policy + Auth (Success)", () async {
-      var client = new HttpClient();
-      var req = await client.openUrl("OPTIONS", new Uri(scheme: "http", host: "localhost", port: 8000, path: "nopolicyauth"));
-      var resp = await req.close();
-
-      // Should return 401, the preflight is unsigned and therefore doesn't make it past the authenticator, since it
-      // won't allow OPTIONS thru because it isn't expecting a preflight request.
-      expect(resp.statusCode, 401);
-    });
-
-    test("Normal request when no CORS policy + Auth (Failure)", () async {
-      var resp = await http.get("http://localhost:8000/nopolicyauth", headers: {"Authorization" : "Bearer noauth"});
-      expect(resp.statusCode, 401);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
-
-    test("Origin request when no CORS policy + Auth (Failure)", () async {
-      var resp = await http.get("http://localhost:8000/nopolicyauth", headers: {
-        "Origin" : "http://somewhereelse.com",
-        "Authorization" : "Bearer noauth"
-      });
-      expect(resp.statusCode, 401);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
-
-    test("Endpoint that throws exception returns appropriate value", () async {
-      var resp = await http.post("http://localhost:8000/nopolicyauth", headers: {
-        "Authorization" : "Bearer auth",
-        "Origin" : "http://somewhereelse.com"
-      });
-      expect(resp.statusCode, 400);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
-  });
-
-  group("Default CORS Policy", () {
-    var app = new Application<CORSSink>();
-    app.configuration.port = 8000;
-
-    setUpAll(() async {
-      await app.start(runOnMainIsolate: true);
-    });
-    tearDownAll(() async {
-      await app?.stop();
-    });
-
-    test("Unknown route still returns 404", () async {
-      var resp = await http.get("http://localhost:8000/foobar", headers: {
-        "Origin" : "http://somewhereelse.com"
-      });
-      expect(resp.statusCode, 404);
-      expect(resp.headers["access-control-allow-origin"], "http://somewhereelse.com");
-    });
-
-    test("Normal request", () async {
+    test("Controller with permissive default policy returns correctly", () async {
       var resp = await http.get("http://localhost:8000/defaultpolicy");
       expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], isNull);
+      expectThatNoCORSProcessingOccured(resp);
     });
 
-    test("Origin request, valid", () async {
-      var resp = await http.get("http://localhost:8000/defaultpolicy", headers: {
-        "Origin" : "http://somewhereelse.com"
+    test("Controller with restrict policy returns correctly", () async {
+      var resp = await http.get("http://localhost:8000/restrictive");
+      expect(resp.statusCode, 200);
+      expectThatNoCORSProcessingOccured(resp);
+    });
+
+    test("Invalid resource 404s", () async {
+      var resp = await http.get("http://localhost:8000/foobar");
+      expect(resp.statusCode, 404);
+      expectThatNoCORSProcessingOccured(resp);
+    });
+  });
+
+  group("Normal/Simple Requests: If the value of the Origin header is not a case-sensitive match for any of the values in list of origins, do not add heads and terminate steps", () {
+    // This group ensures that if the Origin is invalid for a resource, that CORS processing aborts.
+    test("Valid endpoint returns correctly, mis-matched origin", () async {
+      var resp = await http.get("http://localhost:8000/restrictive", headers: {
+        "Origin" : "not this"
       });
       expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], "http://somewhereelse.com");
+      expectThatNoCORSProcessingOccured(resp);
     });
 
-    test("Preflight request, valid", () async {
-      var client = new HttpClient();
-      var req = await client.openUrl("OPTIONS", new Uri(scheme: "http", host: "localhost", port: 8000, path: "defaultpolicy"));
-      req.headers.add("Origin", "http://localhost");
-      req.headers.add("Access-Control-Request-Method", "POST");
-      req.headers.add("Access-Control-Request-Headers", "authorization,x-requested-with");
-      req.headers.add("Accept", "*/*");
-
-      var resp = await req.close();
-      expect(resp.statusCode, 200);
-      expect(resp.contentLength, 0);
-      expect(resp.headers.value("access-control-allow-origin"), "http://localhost");
-      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
-      expect(resp.headers.value("access-control-allow-headers"), "authorization, x-requested-with, x-forwarded-for");
-    });
-
-    /////////
-    test("Normal request + Auth (Success)", () async {
-      var resp = await http.get("http://localhost:8000/defaultpolicyauth", headers: {"Authorization" : "Bearer auth"});
-      expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
-
-    test("Origin request + Auth (Success)", () async {
-      var resp = await http.get("http://localhost:8000/defaultpolicyauth", headers: {
-        "Origin" : "http://somewhereelse.com",
-        "Authorization" : "Bearer auth"
+    test("Valid endpoint, case match failure", () async {
+      var resp = await http.get("http://localhost:8000/restrictive", headers: {
+        "Origin" : "http://Exclusive.com"
       });
       expect(resp.statusCode, 200);
-      expect(resp.headers["access-control-allow-origin"], "http://somewhereelse.com");
+      expectThatNoCORSProcessingOccured(resp);
     });
 
-    test("Preflight request + Auth (Success)", () async {
-      var client = new HttpClient();
-      var req = await client.openUrl("OPTIONS", new Uri(scheme: "http", host: "localhost", port: 8000, path: "defaultpolicyauth"));
-      req.headers.add("Origin", "http://localhost");
-      req.headers.add("Access-Control-Request-Method", "POST");
-      req.headers.add("Access-Control-Request-Headers", "authorization,x-requested-with");
-      req.headers.add("Accept", "*/*");
-
-      var resp = await req.close();
-      expect(resp.statusCode, 200);
-      expect(resp.contentLength, 0);
-      expect(resp.headers.value("access-control-allow-origin"), "http://localhost");
-      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
-      expect(resp.headers.value("access-control-allow-headers"), "authorization, x-requested-with, x-forwarded-for");
+    test("Invalid resource gets CORS headers to expose 404 to calling client", () async {
+      // In this case, there is no 'resource', so we add the origin so the calling client can see the 404. Not sure on this behavior.
+      var resp = await http.get("http://localhost:8000/foobar", headers: {
+        "Origin" : "http://abc.com"
+      });
+      expect(resp.statusCode, 404);
+      expect(resp.headers["access-control-allow-origin"], "http://abc.com");
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
     });
 
-    test("Normal request + Auth (Failure)", () async {
-      var resp = await http.get("http://localhost:8000/defaultpolicyauth", headers: {"Authorization" : "Bearer noauth"});
-      expect(resp.statusCode, 401);
-      expect(resp.headers["access-control-allow-origin"], isNull);
-    });
-
-    test("Origin request + Auth (Failure)", () async {
-      var resp = await http.get("http://localhost:8000/defaultpolicyauth", headers: {
-        "Origin" : "http://somewhereelse.com",
+    test("Unauthorized resource with invalid origin does not attach CORS headers", () async {
+      var resp = await http.get("http://localhost:8000/restrictive_auth", headers: {
+        "Origin" : "http://Exclusive.com",
         "Authorization" : "Bearer noauth"
       });
       expect(resp.statusCode, 401);
-      expect(resp.headers["access-control-allow-origin"], "http://somewhereelse.com");
-    });
-
-    test("Endpoint that throws exception returns appropriate value", () async {
-      var resp = await http.post("http://localhost:8000/defaultpolicyauth", headers: {
-        "Authorization" : "Bearer auth",
-        "Origin" : "http://somewhereelse.com"
-      });
-      expect(resp.statusCode, 400);
-      expect(resp.headers["access-control-allow-origin"], "http://somewhereelse.com");
+      expectThatNoCORSProcessingOccured(resp);
     });
   });
+
+  group("Normal/Simple Requests: If the resource supports credentials add a single Access-Control-Allow-Origin header...", () {
+    // This group ensures that requests with a valid Origin attach that origin and that allow-credentials is added if correct.
+    test("Origin and credentials are returned if credentials are supported and origin is specific, origin must be non-*", () async {
+      var resp = await http.get("http://localhost:8000/restrictive", headers: {
+        "Origin" : "http://exclusive.com"
+      });
+      expect(resp.statusCode, 200);
+      expect(resp.headers["access-control-allow-origin"], "http://exclusive.com");
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], "foobar, x-foo");
+      expect(resp.headers["access-control-allow-credentials"], "true");
+    });
+
+    test("Normal/Simple Requests: Origin and credentials are returned if credentials are supported and origin is catch-all, origin must be non-*", () async {
+      var resp = await http.get("http://localhost:8000/defaultpolicy", headers: {
+        "Origin" : "http://foobar.com"
+      });
+      expect(resp.statusCode, 200);
+      expect(resp.headers["access-control-allow-origin"], "http://foobar.com");
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], "true");
+    });
+
+    test("Normal/Simple Requests: If credentials are not supported and origin is valid, only set origin", () async {
+      var resp = await http.get("http://localhost:8000/restrictive_nocreds", headers: {
+        "Origin" : "http://exclusive.com"
+      });
+      expect(resp.statusCode, 200);
+      expect(resp.headers["access-control-allow-origin"], "http://exclusive.com");
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], "foobar");
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+  });
+
+  group("Normal/Simple Requests: If the list of exposed headers is not empty, add one or more Access-Control-Expose-Headers...", () {
+    // This group ensures that headers are exposed correctly
+    test("Empty exposed headers returns no header to indicate them", () async {
+      var resp = await http.get("http://localhost:8000/defaultpolicy", headers: {
+        "Origin" : "http://foobar.com"
+      });
+      expect(resp.statusCode, 200);
+      expect(resp.headers["access-control-allow-origin"], "http://foobar.com");
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], "true");
+    });
+
+    test("If one exposed header, return it in ACEH", () async {
+      var resp = await http.get("http://localhost:8000/restrictive_nocreds", headers: {
+        "Origin" : "http://exclusive.com"
+      });
+      expect(resp.statusCode, 200);
+      expect(resp.headers["access-control-allow-origin"], "http://exclusive.com");
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], "foobar");
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+
+    test("If multiple exposed headers, return them in ACEH", () async {
+      var resp = await http.get("http://localhost:8000/restrictive", headers: {
+        "Authorization" : "Bearer auth",
+        "Origin" : "http://exclusive.com"
+      });
+
+      expect(resp.statusCode, 200);
+      expect(resp.headers["access-control-allow-origin"], "http://exclusive.com");
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], "foobar, x-foo");
+      expect(resp.headers["access-control-allow-credentials"], "true");
+    });
+  });
+
+  // Make sure preflights don't get exposed headers
+  group("Preflight: If the origin header is not present", () {
+    // This group ensures that an OPTIONS request without CORS headers gets treated like a normal OPTIONS request
+    test("Return 200 if there is an actual endpoint for OPTIONS (No CORS Headers)", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "opts"));
+      req.headers.set("Authorization", "Bearer auth");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 200);
+      expect(resp.headers["access-control-allow-origin"], isNull);
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+
+    test("Return 401 if there is an actual endpoint for OPTIONS and request is unauthorized (No CORS Headers)", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "opts"));
+      var resp = await req.close();
+
+      expect(resp.statusCode, 401);
+      expect(resp.headers["access-control-allow-origin"], isNull);
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+
+    test("Return 404 if there is no endpoint for OPTIONS (No CORS Headers)", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "foobar"));
+      var resp = await req.close();
+
+      expect(resp.statusCode, 404);
+      expect(resp.headers["access-control-allow-origin"], isNull);
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+
+    test("Return 405 if there is an endpoint, but OPTIONS not supported (No CORS Headers)", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "nopolicy"));
+      var resp = await req.close();
+
+      expect(resp.statusCode, 405);
+      expect(resp.headers["access-control-allow-origin"], isNull);
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+  });
+
+  group("Preflight: If the value of Origin header is not a case-sensitive match for list of origins...", () {
+    // This group ensures that if the Origin is invalid, we return a 403.
+
+    test("If origin is correct, get 200 from OPTIONS", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "restrictive"));
+      req.headers.set("Origin", "http://exclusive.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 200);
+      expect(resp.headers.value("access-control-allow-origin"), "http://exclusive.com");
+      expect(resp.headers.value("access-control-allow-headers"), "authorization, x-requested-with, x-forwarded-for, content-type");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-expose-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-credentials"), "true");
+    });
+
+    test("If origin is invalid because of case-sensitivity, get 403 from OPTIONS", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "restrictive"));
+      req.headers.set("Origin", "http://Exclusive.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 403);
+      expect(resp.headers["access-control-allow-origin"], isNull);
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+
+    test("If origin is invalid, get 403 from OPTIONS", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "restrictive"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 403);
+      expect(resp.headers["access-control-allow-origin"], isNull);
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+
+    test("If no policy defined, return 403", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "nopolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 403);
+      expect(resp.headers["access-control-allow-origin"], isNull);
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+  });
+
+  group("Preflight: Validate headers and methods", ()  {
+    // This group ensures that if the Origin is valid, but there is no Access-Control-Request-Method, we return a 403.
+    test("If allow method is not available", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "PATCH");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 403);
+      expect(resp.headers["access-control-allow-origin"], isNull);
+      expect(resp.headers["access-control-allow-headers"], isNull);
+      expect(resp.headers["access-control-allow-methods"], isNull);
+      expect(resp.headers["access-control-expose-headers"], isNull);
+      expect(resp.headers["access-control-allow-credentials"], isNull);
+    });
+
+    test("If allow method is available", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 200);
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-headers"), "authorization, x-requested-with, x-forwarded-for, content-type");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-expose-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-credentials"), "true");
+    });
+
+    test("If one allow header is available", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      req.headers.set("Access-Control-Request-Headers", "authorization");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 200);
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-headers"), "authorization, x-requested-with, x-forwarded-for, content-type");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-expose-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-credentials"), "true");
+    });
+
+    test("If multiple allow header is available", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      req.headers.set("Access-Control-Request-Headers", "authorization, x-requested-with, x-forwarded-for, content-type");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 200);
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-headers"), "authorization, x-requested-with, x-forwarded-for, content-type");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-expose-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-credentials"), "true");
+    });
+
+    test("If allow header is a simple header, return 200", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      req.headers.set("Access-Control-Request-Headers", "accept, authorization");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 200);
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-headers"), "authorization, x-requested-with, x-forwarded-for, content-type");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-expose-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-credentials"), "true");
+    });
+
+    test("If one allow header is not available, but others are, get a 403", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      req.headers.set("Access-Control-Request-Headers", "authorization, x-requested-with, x-forwarded-for, content-type, x-foo");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 403);
+      expect(resp.headers.value("access-control-allow-origin"), isNull);
+      expect(resp.headers.value("access-control-allow-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-methods"), isNull);
+      expect(resp.headers.value("access-control-expose-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-credentials"), isNull);
+    });
+
+    test("If one specified allow headers are not available, get a 403", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      req.headers.set("Access-Control-Request-Headers", "x-foo");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 403);
+      expect(resp.headers.value("access-control-allow-origin"), isNull);
+      expect(resp.headers.value("access-control-allow-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-methods"), isNull);
+      expect(resp.headers.value("access-control-expose-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-credentials"), isNull);
+    });
+
+    test("If all specified allow headers are not available, get a 403", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      req.headers.set("Origin", "http://foobar.com");
+      req.headers.set("Access-Control-Request-Method", "POST");
+      req.headers.set("Access-Control-Request-Headers", "x-foo, x-bar");
+      var resp = await req.close();
+
+      expect(resp.statusCode, 403);
+      expect(resp.headers.value("access-control-allow-origin"), isNull);
+      expect(resp.headers.value("access-control-allow-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-methods"), isNull);
+      expect(resp.headers.value("access-control-expose-headers"), isNull);
+      expect(resp.headers.value("access-control-allow-credentials"), isNull);
+    });
+  });
+
+  group("Preflight: Add Access-Control-Allow-Origin and Access-Control-Allow-Credentials", () {
+    // This group ensures that if we have a valid origin, we add the allow-origin and optionally allow-credentials
+  });
+
+  group("Preflight: Optionally add a single Acces-Control-Max-Age header", () {
+    // This group ensures that we add Access-Control-Max-Age if defined and everything else is valid
+  });
+
+  group("Preflight: Add one or more Access-Control-Allow-Methods", () {
+    // This group ensures that the appropriate allowed methods are returned if everything else is valid.
+  });
+
+  group("Preflight: Add one or more Access-Control-Allow-Headers", () {
+    // This group ensures that allowed headers (other than simple headers) are added if everything else is valid.
+  });
+}
+
+expectThatNoCORSProcessingOccured(http.Response resp) {
+  expect(resp.headers["access-control-allow-origin"], isNull);
+  expect(resp.headers["access-control-allow-headers"], isNull);
+  expect(resp.headers["access-control-allow-methods"], isNull);
+  expect(resp.headers["access-control-expose-headers"], isNull);
+  expect(resp.headers["access-control-allow-credentials"], isNull);
 }
 
 class CORSSink extends RequestSink implements AuthServerDelegate<AuthImpl, TokenImpl, AuthCodeImpl> {
@@ -209,6 +434,10 @@ class CORSSink extends RequestSink implements AuthServerDelegate<AuthImpl, Token
   AuthServer<AuthImpl, TokenImpl, AuthCodeImpl> authServer;
 
   void setupRouter(Router router) {
+    router.route("/opts").pipe(new Authorizer(authServer)).generate(() => new OptionsController());
+    router.route("/restrictive").generate(() => new RestrictiveOriginController());
+    router.route("/restrictive_auth").pipe(new Authorizer(authServer)).generate(() => new RestrictiveOriginController());
+    router.route("/restrictive_nocreds").generate(() => new RestrictiveNoCredsOriginController());
     router.route("/nopolicy").generate(() => new NoPolicyController());
     router.route("/defaultpolicy").generate(() => new DefaultPolicyController());
     router.route("/nopolicyauth")
@@ -327,5 +556,43 @@ class DefaultPolicyController extends HTTPController {
   }
   @httpPost throwException() async {
     throw new HTTPResponseException(400, "Foobar");
+  }
+}
+
+class RestrictiveNoCredsOriginController extends HTTPController {
+  RestrictiveNoCredsOriginController() {
+    policy.allowedOrigins = ["http://exclusive.com"];
+    policy.allowCredentials = false;
+    policy.exposedResponseHeaders = ["foobar"];
+  }
+
+  @httpGet getAll() async {
+    return new Response.ok("getAll");
+  }
+  @httpPost makeThing() async {
+    return new Response.ok("makeThing");
+  }
+}
+
+class RestrictiveOriginController extends HTTPController {
+  RestrictiveOriginController() {
+    policy.allowedOrigins = ["http://exclusive.com"];
+    policy.exposedResponseHeaders = ["foobar", "x-foo"];
+  }
+  @httpGet getAll() async {
+    return new Response.ok("getAll");
+  }
+  @httpPost makeThing() async {
+    return new Response.ok("makeThing");
+  }
+}
+
+class OptionsController extends HTTPController {
+  OptionsController() {
+    policy = null;
+  }
+
+  @HTTPMethod("options") getThing() async {
+    return new Response.ok("getThing");
   }
 }


### PR DESCRIPTION
This PR:

1. Updates CORS tests and improves behavior according to the specification.
2. Changes behavior of unimplemented HTTP methods in HTTPController to return a 405 status code with Allow header instead of a 404.