### PR TITLE
Jc/content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # aqueduct changelog
 
+## 1.0.4
+- Added new `Response.contentType` property. Adding "Content-Type" to the headers of a `Response` no longer has any effect; use this property instead.
+
 ## 1.0.3
 - Fix to allow Windows user to use `aqueduct setup`.
 - Fix to CORS processing.

--- a/lib/http/http_controller.dart
+++ b/lib/http/http_controller.dart
@@ -46,11 +46,10 @@ abstract class HTTPController extends RequestController {
     _applicationWWWFormURLEncodedContentType
   ];
 
-  /// The content type of responses from this [HTTPController].
+  /// The default content type of responses from this [HTTPController].
   ///
-  /// This type will automatically be written to this response's
-  /// HTTP header. Defaults to "application/json". This value determines how the body data returned from this controller
-  /// in a [Response] is encoded.
+  /// If the [Response.contentType] has not explicitly been set by a responder method in this controller, the controller will set
+  /// that property with this value. Defaults to "application/json".
   ContentType responseContentType = ContentType.JSON;
 
   /// The HTTP request body object, after being decoded.

--- a/lib/http/http_controller.dart
+++ b/lib/http/http_controller.dart
@@ -149,7 +149,7 @@ abstract class HTTPController extends RequestController {
         .reflectee as Future<Response>;
 
     var response = await eventualResponse;
-    if (response._contentType == null) {
+    if (!response.hasExplicitlySetContentType) {
       response.contentType = responseContentType;
     }
 

--- a/lib/http/http_controller.dart
+++ b/lib/http/http_controller.dart
@@ -149,7 +149,10 @@ abstract class HTTPController extends RequestController {
         .reflectee as Future<Response>;
 
     var response = await eventualResponse;
-    response.headers[HttpHeaders.CONTENT_TYPE] = responseContentType;
+    if (response._contentType == null) {
+      response.contentType = responseContentType;
+    }
+
     willSendResponse(response);
 
     return response;

--- a/lib/http/http_response_exception.dart
+++ b/lib/http/http_response_exception.dart
@@ -18,5 +18,6 @@ class HTTPResponseException implements Exception {
   final int statusCode;
 
   /// A [Response] object derived from this exception.
-  Response get response => new Response(statusCode, null, {"error": message})..contentType = ContentType.JSON;
+  Response get response => new Response(statusCode, null, {"error": message})
+    ..contentType = ContentType.JSON;
 }

--- a/lib/http/http_response_exception.dart
+++ b/lib/http/http_response_exception.dart
@@ -18,6 +18,5 @@ class HTTPResponseException implements Exception {
   final int statusCode;
 
   /// A [Response] object derived from this exception.
-  Response get response => new Response(statusCode,
-      {HttpHeaders.CONTENT_TYPE: ContentType.JSON}, {"error": message});
+  Response get response => new Response(statusCode, null, {"error": message})..contentType = ContentType.JSON;
 }

--- a/lib/http/request.dart
+++ b/lib/http/request.dart
@@ -146,7 +146,8 @@ class Request implements RequestControllerEvent {
     }
 
     if (encodedBody != null) {
-      response.headers.add(HttpHeaders.CONTENT_TYPE, responseObject.contentType.toString());
+      response.headers
+          .add(HttpHeaders.CONTENT_TYPE, responseObject.contentType.toString());
       response.write(encodedBody);
     }
 

--- a/lib/http/request_controller.dart
+++ b/lib/http/request_controller.dart
@@ -223,8 +223,8 @@ class RequestController extends Object with APIDocumentable {
           };
         }
 
-        var response = new Response.serverError(
-            headers: {HttpHeaders.CONTENT_TYPE: ContentType.JSON}, body: body);
+        var response = new Response.serverError(body: body)
+          ..contentType = ContentType.JSON;
 
         _applyCORSHeadersIfNecessary(request, response);
         request.respond(response);

--- a/lib/http/response.dart
+++ b/lib/http/response.dart
@@ -122,9 +122,6 @@ class Response implements RequestControllerEvent {
   /// Whether or nor this instance has explicitly has its [contentType] property.
   ///
   /// This value indicates whether or not [contentType] has been set, or is still using its default value.
-  ///
-  /// Some [RequestController]s might provide a value for this instance's Content-Type. For example,
-  /// an [HTTPController] has a [HTTPController.responseContentType] that it applies
   bool get hasExplicitlySetContentType => _contentType != null;
 
   /// The default constructor.

--- a/lib/http/response.dart
+++ b/lib/http/response.dart
@@ -41,9 +41,7 @@ class Response implements RequestControllerEvent {
     "application": {
       "json": (v) => JSON.encode(v),
     },
-    "text" : {
-      "*" : (Object v) => v.toString()
-    }
+    "text": {"*": (Object v) => v.toString()}
   };
 
   /// An object representing the body of the [Response], which will be encoded when used to [Request.respond].
@@ -91,7 +89,8 @@ class Response implements RequestControllerEvent {
     }
 
     if (encoder == null) {
-      throw new HTTPResponseException(500, "Could not encode body as ${contentType.toString()}.");
+      throw new HTTPResponseException(
+          500, "Could not encode body as ${contentType.toString()}.");
     }
 
     return encoder(_body);
@@ -117,6 +116,7 @@ class Response implements RequestControllerEvent {
   void set contentType(ContentType t) {
     _contentType = t;
   }
+
   ContentType _contentType;
 
   /// Whether or nor this instance has explicitly has its [contentType] property.

--- a/lib/http/response.dart
+++ b/lib/http/response.dart
@@ -13,8 +13,16 @@ class Response implements RequestControllerEvent {
 
   /// Adds an HTTP Response Body encoder to list of available encoders for all [Request]s.
   ///
-  /// By default, 'application/json' and 'text/plain' are implemented. If you wish to add another encoder
-  /// to your application, use this method. The [encoder] must take one argument of any type, and return a value
+  /// When the [contentType] of an instance is set, an encoder function is applied to the data. This method
+  /// adds an encoder function for [type].
+  ///
+  /// By default, 'application/json' and 'text/*' are available. A [Response] with "application/json" [contentType]
+  /// will be encoded by invoking [JSON.decode] on the instance's [body]. The default encoder for [ContentType]s whose primary type is "text" will invoke [toString]
+  /// on the instance's [body].
+  ///
+  /// [type] can have a '*' [ContentType.subType] that matches all subtypes for a primary type.
+  ///
+  /// An [encoder] must take one argument of any type, and return a value
   /// that will become the HTTP response body.
   ///
   /// The return value is written to the response with [IOSink.write] and so it must either be a [String] or its [toString]

--- a/lib/http/response.dart
+++ b/lib/http/response.dart
@@ -59,13 +59,46 @@ class Response implements RequestControllerEvent {
 
   dynamic _body;
 
+  /// Returns the encoded [body] according to [contentType].
+  ///
+  /// If there is no [body] present, this property is null. This property will use the encoders available through [addEncoder]. If
+  /// no encoder is found, [toString] is called on the body.
+  dynamic get encodedBody {
+    if (_body == null) {
+      return null;
+    }
+
+    var encoder = null;
+    var topLevel = _encoders[contentType.primaryType];
+    if (topLevel != null) {
+      encoder = topLevel[contentType.subType];
+    }
+
+    encoder ??= (Object value) => value.toString();
+
+    return encoder(_body);
+  }
+
   /// Map of headers to send in this response.
   ///
-  /// Where the key is the Header name and value is the Header value.
+  /// Where the key is the Header name and value is the Header value. Values may be any type and by default will have [toString] invoked
+  /// on them. For [DateTime] values, the value will be converted into an HTTP date format. For [List] values, each value will be
+  /// have [toString] invoked on it and the resulting outputs will be joined together with the "," character.
+  ///
+  /// Adding a Content-Type header through this property has no effect. Use [contentType] instead.
   Map<String, dynamic> headers;
 
   /// The HTTP status code of this response.
   int statusCode;
+
+  /// The content type of the body of this response.
+  ///
+  /// Defaults to [ContentType.JSON]. This response's will be encoded according to this value prior to the response being sent.
+  ContentType get contentType => _contentType ?? ContentType.JSON;
+  void set contentType(ContentType t) {
+    _contentType = t;
+  }
+  ContentType _contentType;
 
   /// The default constructor.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: aqueduct
-version: 1.0.3
+version: 1.0.4
 description: A fully featured server-side framework built for productivity and testability.
 author: stable|kernel <http://stablekernel.com>
 homepage: https://github.com/stablekernel/aqueduct

--- a/test/base/controller_test.dart
+++ b/test/base/controller_test.dart
@@ -258,11 +258,19 @@ void main() {
     expect(resp.body, '"false"');
   });
 
+  test("Content-Type defaults to application/json", () async {
+    server = await enableController("/a", TController);
+    var resp = await http.get("http://localhost:4040/a?param");
+    expect(resp.statusCode, 200);
+    expect(ContentType.parse(resp.headers["content-type"]).primaryType, "application");
+    expect(ContentType.parse(resp.headers["content-type"]).subType, "json");
+  });
+
   test("Content-Type can be set adjusting responseContentType", () async {
     server = await enableController("/a", ContentTypeController);
     var resp = await http.get("http://localhost:4040/a?opt=responseContentType");
     expect(resp.statusCode, 200);
-    expect(resp.headers["content-type"], "foo/bar");
+    expect(resp.headers["content-type"], "text/plain");
     expect(resp.body, "body");
   });
 
@@ -270,7 +278,7 @@ void main() {
     server = await enableController("/a", ContentTypeController);
     var resp = await http.get("http://localhost:4040/a?opt=direct");
     expect(resp.statusCode, 200);
-    expect(resp.headers["content-type"], "a/b");
+    expect(resp.headers["content-type"], "text/plain");
     expect(resp.body, "body");
   });
 
@@ -599,11 +607,11 @@ class ModelEncodeController extends HTTPController {
 class ContentTypeController extends HTTPController {
   @httpGet getThing(@HTTPQuery("opt") String opt) async {
     if (opt == "responseContentType") {
-      responseContentType = new ContentType("foo", "bar");
+      responseContentType = new ContentType("text", "plain");
       return new Response.ok("body");
     } else if (opt == "direct") {
       return new Response.ok("body")
-        ..contentType = new ContentType("a", "b");
+        ..contentType = new ContentType("text", "plain");
     }
   }
 }

--- a/test/base/controller_test.dart
+++ b/test/base/controller_test.dart
@@ -11,7 +11,6 @@ import '../helpers.dart';
 
 void main() {
   HttpServer server;
-
   ManagedDataModel dm = new ManagedDataModel([TestModel]);
   ManagedContext _ = new ManagedContext(dm, new DefaultPersistentStore());
 
@@ -259,6 +258,22 @@ void main() {
     expect(resp.body, '"false"');
   });
 
+  test("Content-Type can be set adjusting responseContentType", () async {
+    server = await enableController("/a", ContentTypeController);
+    var resp = await http.get("http://localhost:4040/a?opt=responseContentType");
+    expect(resp.statusCode, 200);
+    expect(resp.headers["content-type"], "foo/bar");
+    expect(resp.body, "body");
+  });
+
+  test("Content-Type set directly on Response overrides responseContentType", () async {
+    server = await enableController("/a", ContentTypeController);
+    var resp = await http.get("http://localhost:4040/a?opt=direct");
+    expect(resp.statusCode, 200);
+    expect(resp.headers["content-type"], "a/b");
+    expect(resp.body, "body");
+  });
+
   group("Annotated HTTP parameters", () {
     test("are supplied correctly", () async {
       server = await enableController("/a", HTTPParameterController);
@@ -421,6 +436,9 @@ class FilteringController extends HTTPController {
 }
 
 class TController extends HTTPController {
+  TController() {
+
+  }
   @httpGet
   Future<Response> getAll() async {
     return new Response.ok("getAll");
@@ -574,6 +592,18 @@ class ModelEncodeController extends HTTPController {
 
     if (thing == "null") {
       return new Response.ok(null);
+    }
+  }
+}
+
+class ContentTypeController extends HTTPController {
+  @httpGet getThing(@HTTPQuery("opt") String opt) async {
+    if (opt == "responseContentType") {
+      responseContentType = new ContentType("foo", "bar");
+      return new Response.ok("body");
+    } else if (opt == "direct") {
+      return new Response.ok("body")
+        ..contentType = new ContentType("a", "b");
     }
   }
 }

--- a/test/base/controller_test.dart
+++ b/test/base/controller_test.dart
@@ -260,7 +260,7 @@ void main() {
 
   test("Content-Type defaults to application/json", () async {
     server = await enableController("/a", TController);
-    var resp = await http.get("http://localhost:4040/a?param");
+    var resp = await http.get("http://localhost:4040/a");
     expect(resp.statusCode, 200);
     expect(ContentType.parse(resp.headers["content-type"]).primaryType, "application");
     expect(ContentType.parse(resp.headers["content-type"]).subType, "json");

--- a/test/utilities/test_client_test.dart
+++ b/test/utilities/test_client_test.dart
@@ -355,13 +355,14 @@ void main() {
 
     test("Can match text object", () async {
       var defaultTestClient = new TestClient.onPort(4000);
-      server.queueResponse(
-          new Response.ok("text", headers: {"Content-Type": "text/plain"}));
+
+      server.queueResponse(new Response.ok("text")..contentType = ContentType.TEXT);
       var response = await defaultTestClient.request("/foo").get();
       expect(response, hasBody("text"));
 
-      server.queueResponse(
-          new Response.ok("text", headers: {"Content-Type": "text/plain"}));
+      server.queueResponse(new Response.ok("text")..contentType = ContentType.TEXT);
+
+
       response = await defaultTestClient.request("/foo").get();
       try {
         expect(response, hasBody("foobar"));
@@ -375,13 +376,12 @@ void main() {
     test("Can match JSON Object", () async {
       var defaultTestClient = new TestClient.onPort(4000);
 
-      server.queueResponse(new Response.ok({"foo": "bar"},
-          headers: {"Content-Type": "application/json"}));
+
+      server.queueResponse(new Response.ok({"foo" : "bar"})..contentType = ContentType.JSON);
       var response = await defaultTestClient.request("/foo").get();
       expect(response, hasBody(isNotNull));
 
-      server.queueResponse(new Response.ok({"foo": "bar"},
-          headers: {"Content-Type": "application/json"}));
+      server.queueResponse(new Response.ok({"foo" : "bar"})..contentType = ContentType.JSON);
       response = await defaultTestClient.request("/foo").get();
       try {
         expect(response, hasBody({"foo": "notbar"}));
@@ -391,9 +391,8 @@ void main() {
         expect(e.toString(), contains('Body: {"foo":"bar"}'));
       }
 
-      server.queueResponse(new Response.ok(
-          {"nocontenttype": "thatsaysthisisjson"},
-          headers: {"Content-Type": "text/plain"}));
+      server.queueResponse(new Response.ok({"nocontenttype" : "thatsaysthisisjson"})..contentType = ContentType.TEXT);
+
       response = await defaultTestClient.request("/foo").get();
       try {
         expect(response,
@@ -524,8 +523,8 @@ void main() {
     test("Omit status code ignores it", () async {
       var defaultTestClient = new TestClient.onPort(4000);
 
-      server.queueResponse(new Response.ok({"foo": "bar"},
-          headers: {"content-type": "application/json"}));
+      server.queueResponse(new Response.ok({"foo" : "bar"})..contentType = ContentType.JSON);
+
       var response = await defaultTestClient.request("/foo").get();
       expect(
           response,


### PR DESCRIPTION
1. Adds contentType property to Request. Makes setting the content type a lot more obvious than just including it as a header.
2. Allows a Response to override the responseContentType of an HTTPController if explicitly set.
3. Allows default content type of all Responses to be set by the user.
4. Made text/* a default encoder and allows for match-all character to be used in a content-type encoder key.

This should address issues uncovered by #129 