### PR TITLE
Allow exceptions to escape request controllers during debugging

### DIFF
--- a/example/templates/default/test/harness/app.dart
+++ b/example/templates/default/test/harness/app.dart
@@ -38,6 +38,8 @@ class TestApplication {
   ///
   /// You must call [stop] on this instance when tearing down your tests.
   Future start() async {
+    RequestController.letUncaughtExceptionsEscape = true;
+
     await logger.start();
 
     application = new Application<WildfireSink>();

--- a/lib/src/application/application_server.dart
+++ b/lib/src/application/application_server.dart
@@ -82,11 +82,13 @@ class ApplicationServer {
 
     await sink.willOpen();
 
-    server.map((baseReq) => new Request(baseReq)).listen((Request req) async {
-      logger.fine("Request received $req.", req);
-      await sink.willReceiveRequest(req);
-      sink.receive(req);
-    });
+    server
+        .map((baseReq) => new Request(baseReq))
+        .listen((Request req) async {
+          logger.fine("Request received $req.", req);
+          await sink.willReceiveRequest(req);
+          sink.receive(req);
+        });
 
     sink.didOpen();
   }


### PR DESCRIPTION
During testing, programmer errors that result in exceptions will escape RequestControllers and bubble up to the test script. Makes debugging a lot easier.