### PR TITLE
Change paging API

### DIFF
--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -90,3 +90,18 @@ class ManagedMatcherBacking extends ManagedBacking {
     }
   }
 }
+
+class ManagedAccessTrackingBacking extends ManagedBacking {
+  Map<String, dynamic> get valueMap => null;
+  String accessedProperty;
+
+  dynamic valueForProperty(ManagedEntity entity, String propertyName) {
+    accessedProperty = propertyName;
+    return null;
+  }
+
+  void setValueForProperty(
+      ManagedEntity entity, String propertyName, dynamic value) {
+    // no-op
+  }
+}

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -1,6 +1,6 @@
-import '../managed/managed.dart';
 import '../managed/backing.dart';
-
+import '../managed/managed.dart';
+import 'page.dart';
 import 'query.dart';
 
 abstract class QueryMixin<InstanceType extends ManagedObject>
@@ -82,5 +82,27 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     subQueries[attr] = subquery;
 
     return subquery;
+  }
+
+  void pageBy<T>(T propertyIdentifier(InstanceType x), QuerySortOrder order, {T boundingValue}) {
+    var tracker = new ManagedAccessTrackingBacking();
+    var obj = entity.newInstance()..backing = tracker;
+    propertyIdentifier(obj as InstanceType);
+    var propertyName = tracker.accessedProperty;
+
+    var attribute = entity.attributes[propertyName];
+    if (attribute == null) {
+      if (entity.relationships[propertyName] != null) {
+        throw new QueryException(QueryExceptionEvent.internalFailure, message:
+          "Property '${propertyName}' cannot be paged on for ${entity.tableName}. "
+              "Reason: relationship properties cannot be paged on.");
+      } else {
+        throw new QueryException(QueryExceptionEvent.internalFailure, message:
+          "Property '${propertyName}' cannot be paged on for ${entity.tableName}. "
+            "Reason: property does not exist for entity.");
+      }
+
+    }
+    pageDescriptor = new QueryPage(order, propertyName, boundingValue: boundingValue);
   }
 }

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 
 import '../managed/managed.dart';
-import 'page.dart';
 import 'predicate.dart';
 import 'sort_descriptor.dart';
 import 'matcher_expression.dart';
 
 export 'matcher_expression.dart';
-export 'page.dart';
 export 'predicate.dart';
 export 'sort_descriptor.dart';
 export 'error.dart';
@@ -40,8 +38,9 @@ abstract class Query<InstanceType extends ManagedObject> {
     return null;
   }
 
-  Query<T> joinOn<T extends ManagedObject>(T m(InstanceType x));
-  Query<T> joinMany<T extends ManagedObject>(ManagedSet<T> m(InstanceType x));
+  Query<T> joinOn<T extends ManagedObject>(T propertyIdentifier(InstanceType x));
+  Query<T> joinMany<T extends ManagedObject>(ManagedSet<T> propertyIdentifier(InstanceType x));
+  void pageBy<T>(T propertyIdentifier(InstanceType x), QuerySortOrder order, {T boundingValue});
 
   /// The [ManagedEntity] of the [InstanceType].
   ManagedEntity get entity;
@@ -60,6 +59,7 @@ abstract class Query<InstanceType extends ManagedObject> {
   ///       var q = new Query<Employee>()
   ///           ..where.employeeID = greaterThan(1);
   InstanceType get where;
+
 
   /// Confirms that a query has no predicate before executing it.
   ///
@@ -84,11 +84,6 @@ abstract class Query<InstanceType extends ManagedObject> {
   /// The set of rows returned will exclude the first [offset] number of rows selected in the query. Do not
   /// set this property when using [pageDescriptor].
   int offset;
-
-  /// A specifier for a page of results.
-  ///
-  /// Defaults to null. Use a [QueryPage] along with [fetchLimit] when fetching a subset of rows from a large data set.
-  QueryPage pageDescriptor;
 
   /// The order in which rows should be returned.
   ///

--- a/lib/src/http/resource_controller.dart
+++ b/lib/src/http/resource_controller.dart
@@ -264,7 +264,7 @@ class ManagedObjectController<InstanceType extends ManagedObject>
       }
 
       pageValue = _parseValueForProperty(pageValue, pageByProperty);
-      _query.pageDescriptor = new QueryPage(direction, pageBy,
+      _query.pageBy((t) => t[pageBy], direction,
           boundingValue: pageValue == "null" ? null : pageValue);
     }
 

--- a/test/db/postgresql/has_one_fetch_test.dart
+++ b/test/db/postgresql/has_one_fetch_test.dart
@@ -402,7 +402,7 @@ void main() {
     test("Including paging on a join fails", () async {
       var q = new Query<Parent>()
         ..joinOn((p) => p.child)
-        ..pageDescriptor = new QueryPage(QuerySortOrder.ascending, "id");
+        ..pageBy((p) => p.id, QuerySortOrder.ascending);
 
       try {
         await q.fetchOne();

--- a/test/db/postgresql/paging_test.dart
+++ b/test/db/postgresql/paging_test.dart
@@ -106,10 +106,8 @@ void main() {
     test("Ascending from known data set edge, limited to inside data set",
         () async {
       // select * from t where id > 0 order by id asc limit 5;
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "id", boundingValue: 0);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 0)
         ..fetchLimit = 5;
       var res = await req.fetch();
       check([1, 2, 3, 4, 5], res);
@@ -117,10 +115,8 @@ void main() {
 
     test("Ascending from first element, limited to inside data set", () async {
       // select * from t where id > 1 order by id asc limit 5;
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "id", boundingValue: 1);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 1)
         ..fetchLimit = 5;
       var res = await req.fetch();
       check([2, 3, 4, 5, 6], res);
@@ -128,10 +124,8 @@ void main() {
 
     test("Ascending from first element, extended past data set", () async {
       // select * from t where id > 0 order by id asc limit 15;
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "id", boundingValue: 0);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 0)
         ..fetchLimit = 15;
       var res = await req.fetch();
       check([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], res);
@@ -139,10 +133,8 @@ void main() {
 
     test("Ascending from inside data set to known edge", () async {
       // select * from t where id > 6 order by id asc limit 4;
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "id", boundingValue: 6);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 6)
         ..fetchLimit = 4;
       var res = await req.fetch();
       check([7, 8, 9, 10], res);
@@ -150,10 +142,8 @@ void main() {
 
     test("Ascending from inside data set to past edge", () async {
       // select * from t where id > 6 order by id asc limit 5
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "id", boundingValue: 6);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 6)
         ..fetchLimit = 5;
       var res = await req.fetch();
       check([7, 8, 9, 10], res);
@@ -161,10 +151,8 @@ void main() {
 
     test("Ascending from edge of data set into outside data set", () async {
       // select * from t where id > 10 order by id asc limit 5
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "id", boundingValue: 10);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 10)
         ..fetchLimit = 5;
       var res = await req.fetch();
       expect(res.length, 0);
@@ -172,10 +160,8 @@ void main() {
 
     test("Ascending from outside the data set and onward", () async {
       // select * from t where id > 11 order by id asc limit 10
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "id", boundingValue: 11);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 11)
         ..fetchLimit = 10;
       var res = await req.fetch();
       expect(res.length, 0);
@@ -183,9 +169,8 @@ void main() {
 
     test("Ascending from null to all the way outside the data set", () async {
       // select * from t order by id asc limit 15
-      var pageObject = new QueryPage(QuerySortOrder.ascending, "id");
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending)
         ..fetchLimit = 15;
       var res = await req.fetch();
       check([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], res);
@@ -193,9 +178,8 @@ void main() {
 
     test("Ascending from null to halfway into the data set", () async {
       // select * from t order by id asc limit 5;
-      var pageObject = new QueryPage(QuerySortOrder.ascending, "id");
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.ascending)
         ..fetchLimit = 5;
       var res = await req.fetch();
       check([1, 2, 3, 4, 5], res);
@@ -203,10 +187,8 @@ void main() {
 
     test("Descending from beginning of data set to before data set", () async {
       // select * from t where id < 0 order by id desc limit 10
-      var pageObject =
-          new QueryPage(QuerySortOrder.descending, "id", boundingValue: 0);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 0)
         ..fetchLimit = 10;
       var res = await req.fetch();
       expect(res.length, 0);
@@ -215,10 +197,8 @@ void main() {
     test("Descending from first element in data set to before data set",
         () async {
       // select * from t where id < 1 order by id desc limit 10;
-      var pageObject =
-          new QueryPage(QuerySortOrder.descending, "id", boundingValue: 1);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 1)
         ..fetchLimit = 10;
       var res = await req.fetch();
       expect(res.length, 0);
@@ -226,10 +206,8 @@ void main() {
 
     test("Descending from middle of data set to before data set", () async {
       // select * from t where id < 4 order by id desc limit 10;
-      var pageObject =
-          new QueryPage(QuerySortOrder.descending, "id", boundingValue: 4);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 4)
         ..fetchLimit = 10;
       var res = await req.fetch();
       check([3, 2, 1], res);
@@ -237,10 +215,8 @@ void main() {
 
     test("Descending from middle of data set to edge of data set", () async {
       // select * from t where id < 5 order by id desc limit 4;
-      var pageObject =
-          new QueryPage(QuerySortOrder.descending, "id", boundingValue: 5);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 5)
         ..fetchLimit = 4;
       var res = await req.fetch();
       check([4, 3, 2, 1], res);
@@ -250,10 +226,8 @@ void main() {
         "Descending from outside end of data set to beginning edge of data set",
         () async {
       // select * from t where id < 11 order by id desc limit 10;
-      var pageObject =
-          new QueryPage(QuerySortOrder.descending, "id", boundingValue: 11);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 11)
         ..fetchLimit = 10;
       var res = await req.fetch();
       check([10, 9, 8, 7, 6, 5, 4, 3, 2, 1], res);
@@ -262,10 +236,8 @@ void main() {
     test("Descending from last element in data set to middle of data set",
         () async {
       // select * from t where id < 10 order by id desc limit 5;
-      var pageObject =
-          new QueryPage(QuerySortOrder.descending, "id", boundingValue: 10);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 10)
         ..fetchLimit = 5;
       var res = await req.fetch();
       check([9, 8, 7, 6, 5], res);
@@ -274,10 +246,8 @@ void main() {
     test("Descending from outside end of data set to middle of data set",
         () async {
       // select * from t where id < 11 order by id desc limit 5
-      var pageObject =
-          new QueryPage(QuerySortOrder.descending, "id", boundingValue: 11);
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 11)
         ..fetchLimit = 5;
       var res = await req.fetch();
       check([10, 9, 8, 7, 6], res);
@@ -285,9 +255,8 @@ void main() {
 
     test("Descending from null to beginning of data set", () async {
       // select * from t order by id desc limit 10
-      var pageObject = new QueryPage(QuerySortOrder.descending, "id");
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending)
         ..fetchLimit = 10;
       var res = await req.fetch();
       check([10, 9, 8, 7, 6, 5, 4, 3, 2, 1], res);
@@ -295,9 +264,8 @@ void main() {
 
     test("Descending from null to middle of data set", () async {
       // select * from t order by id desc limit 5
-      var pageObject = new QueryPage(QuerySortOrder.descending, "id");
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.id, QuerySortOrder.descending)
         ..fetchLimit = 5;
       var res = await req.fetch();
       check([10, 9, 8, 7, 6], res);
@@ -328,9 +296,9 @@ void main() {
     });
 
     test("Incorrect type for boundingValue", () async {
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "value", boundingValue: 0);
-      var req = new Query<PageableTestModel>()..pageDescriptor = pageObject;
+      var req = new Query<PageableTestModel>()
+        ..pageBy((p) => p.value, QuerySortOrder.ascending, boundingValue: 0);
+
       try {
         var _ = await req.fetch();
         expect(true, false);
@@ -341,24 +309,20 @@ void main() {
     });
 
     test("Page property doesn't exist throws error", () async {
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "foobar", boundingValue: "0");
-      var req = new Query<PageableTestModel>()..pageDescriptor = pageObject;
-
       try {
-        var _ = await req.fetch();
+        var _ = new Query<PageableTestModel>()
+          ..pageBy((p) => p["foobar"], QuerySortOrder.ascending, boundingValue: "0");
+
         expect(true, false);
       } on QueryException catch (e) {
         expect(e.toString(),
-            contains("Property 'foobar' in pageDescriptor does not exist"));
+            contains("Property 'foobar'"));
       }
     });
 
     test("Query when not fetching paging property still succeeds", () async {
-      var pageObject =
-          new QueryPage(QuerySortOrder.ascending, "value", boundingValue: "0");
       var req = new Query<PageableTestModel>()
-        ..pageDescriptor = pageObject
+        ..pageBy((p) => p.value, QuerySortOrder.ascending, boundingValue: "0")
         ..propertiesToFetch = ["id"]
         ..fetchLimit = 5;
       var res = await req.fetch();


### PR DESCRIPTION
Query page's are now set with a similar style to joins, adding safety and a more consistent API.

```
var q = new Query<Thing>()
  ..pageBy((thing) => thing.date, QuerySortOrder.ascending, boundingValue: now);
```