### PR TITLE
Change propertiesToFetch to mirror sortBy, pageBy, etc.

### DIFF
--- a/lib/managed_auth.dart
+++ b/lib/managed_auth.dart
@@ -175,7 +175,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
   Future<T> fetchAuthenticatableByUsername(AuthServer server, String username) {
     var query = new Query<T>(context)
       ..where.username = username
-      ..propertiesToFetch = ["id", "hashedPassword", "salt"];
+      ..returningProperties((t) => [t.id, t.hashedPassword, t.salt]);
 
     return query.fetchOne();
   }
@@ -270,7 +270,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
       ..sortBy((t) => t.expirationDate, QuerySortOrder.descending)
       ..offset = tokenLimit
       ..fetchLimit = 1
-      ..propertiesToFetch = ["expirationDate"];
+      ..returningProperties((t) => [t.expirationDate]);
 
     var results = await oldTokenQuery.fetch();
     if (results.length == 1) {

--- a/lib/src/db/managed/attributes.dart
+++ b/lib/src/db/managed/attributes.dart
@@ -120,7 +120,7 @@ class ManagedColumnAttributes {
   /// Whether or not fetching an instance of this type should include this property.
   ///
   /// By default, all properties on a [ManagedObject] are returned if not specified (unless they are to-many relationship properties).
-  /// This flag will remove the associated property from the result set unless it is explicitly specified by [Query.propertiesToFetch].
+  /// This flag will remove the associated property from the result set unless it is explicitly specified by [Query.returningProperties].
   final bool shouldOmitByDefault;
 
   /// Indicate to the underlying database to use a serial counter when inserted an instance.

--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -93,12 +93,8 @@ class ManagedMatcherBacking extends ManagedBacking {
 
 class ManagedAccessTrackingBacking extends ManagedBacking {
   Map<String, dynamic> get valueMap => null;
-  String accessedProperty;
 
-  dynamic valueForProperty(ManagedEntity entity, String propertyName) {
-    accessedProperty = propertyName;
-    return null;
-  }
+  dynamic valueForProperty(ManagedEntity entity, String propertyName) => propertyName;
 
   void setValueForProperty(
       ManagedEntity entity, String propertyName, dynamic value) {

--- a/lib/src/db/managed/entity.dart
+++ b/lib/src/db/managed/entity.dart
@@ -101,7 +101,7 @@ class ManagedEntity {
   /// The list of default properties returned when querying an instance of this type.
   ///
   /// By default, a [Query] will return all the properties named in this list. You may specify
-  /// a different set of properties by setting the [Query.propertiesToFetch] value. The default
+  /// a different set of properties by setting the [Query.returningProperties] value. The default
   /// set of properties is a list of all attributes that do not have the [omitByDefault] flag
   /// set in their [ManagedColumnAttributes] and all [ManagedRelationshipType.belongsTo] relationships.
   List<String> get defaultProperties {

--- a/lib/src/db/managed/property_description.dart
+++ b/lib/src/db/managed/property_description.dart
@@ -73,10 +73,10 @@ abstract class ManagedPropertyDescription {
   /// Defaults to false.
   final bool isNullable;
 
-  /// Whether or not this property is returned in the default set of [Query.propertiesToFetch].
+  /// Whether or not this property is returned in the default set of [Query.returningProperties].
   ///
-  /// This defaults to true. If true, when executing a [Query] that does not explicitly specify [Query.propertiesToFetch],
-  /// this property will be returned. If false, you must explicitly specify this property in [Query.propertiesToFetch] to retrieve it from persistent storage.
+  /// This defaults to true. If true, when executing a [Query] that does not explicitly specify [Query.returningProperties],
+  /// this property will be returned. If false, you must explicitly specify this property in [Query.returningProperties] to retrieve it from persistent storage.
   final bool isIncludedInDefaultResultSet;
 
   /// Whether or not this property should use an auto-incrementing scheme.

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -52,10 +52,9 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   Query<T> joinOn<T extends ManagedObject>(T m(InstanceType x)) {
     subQueries ??= {};
 
-    var property = m(where);
-    var matchingKey = entity.relationships.keys.firstWhere((key) {
-      return identical(where.backingMap[key], property);
-    });
+    var tracker = new ManagedAccessTrackingBacking();
+    var obj = entity.newInstance()..backing = tracker;
+    var matchingKey = m(obj as InstanceType) as String;
 
     var attr = entity.relationships[matchingKey];
     var subquery = new Query<T>(context);
@@ -68,10 +67,9 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   Query<T> joinMany<T extends ManagedObject>(ManagedSet<T> m(InstanceType x)) {
     subQueries ??= {};
 
-    var property = m(where);
-    var matchingKey = entity.relationships.keys.firstWhere((key) {
-      return identical(where.backingMap[key], property);
-    });
+    var tracker = new ManagedAccessTrackingBacking();
+    var obj = entity.newInstance()..backing = tracker;
+    var matchingKey = m(obj as InstanceType) as String;
 
     var attr = entity.relationships[matchingKey];
     var subquery = new Query<T>(context);

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -21,18 +21,14 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   Map<ManagedRelationshipDescription, Query> subQueries;
   QueryPredicate predicate;
 
-  List<String> _resultProperties;
   InstanceType _whereBuilder;
   InstanceType _valueObject;
 
   bool get hasWhereBuilder => _whereBuilder?.backingMap?.isNotEmpty ?? false;
 
+  List<String> _propertiesToFetch;
   List<String> get propertiesToFetch =>
-      _resultProperties ?? entity.defaultProperties;
-
-  void set propertiesToFetch(List<String> props) {
-    _resultProperties = props;
-  }
+      _propertiesToFetch ?? entity.defaultProperties;
 
   InstanceType get values {
     if (_valueObject == null) {
@@ -89,8 +85,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
       {T boundingValue}) {
     var tracker = new ManagedAccessTrackingBacking();
     var obj = entity.newInstance()..backing = tracker;
-    propertyIdentifier(obj as InstanceType);
-    var propertyName = tracker.accessedProperty;
+    var propertyName = propertyIdentifier(obj as InstanceType) as String;
 
     var attribute = entity.attributes[propertyName];
     if (attribute == null) {
@@ -114,8 +109,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   void sortBy<T>(T propertyIdentifier(InstanceType x), QuerySortOrder order) {
     var tracker = new ManagedAccessTrackingBacking();
     var obj = entity.newInstance()..backing = tracker;
-    propertyIdentifier(obj as InstanceType);
-    var propertyName = tracker.accessedProperty;
+    var propertyName = propertyIdentifier(obj as InstanceType) as String;
 
     var attribute = entity.attributes[propertyName];
     if (attribute == null) {
@@ -135,4 +129,13 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     sortDescriptors ??= <QuerySortDescriptor>[];
     sortDescriptors.add(new QuerySortDescriptor(propertyName, order));
   }
+
+  void returningProperties(List<dynamic> propertyIdentifiers(InstanceType x)) {
+    var tracker = new ManagedAccessTrackingBacking();
+    var obj = entity.newInstance()..backing = tracker;
+    var propertyNames = propertyIdentifiers(obj as InstanceType) as List<String>;
+
+    _propertiesToFetch = propertyNames;
+  }
+
 }

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -116,7 +116,7 @@ abstract class Query<InstanceType extends ManagedObject> {
   ///
   /// By default, this property is null, which indicates that the default properties of [InstanceType] should be fetched.
   /// See [ManagedEntity.defaultProperties] for more details.
-  List<String> propertiesToFetch;
+  void returningProperties(List<dynamic> propertyIdentifiers(InstanceType x));
 
   /// Inserts an [InstanceType] into the underlying database.
   ///

--- a/test/db/postgresql/delete_test.dart
+++ b/test/db/postgresql/delete_test.dart
@@ -135,7 +135,8 @@ void main() {
     var count = await testModelReq.delete();
     expect(count, 1);
 
-    refModelReq = new Query<RefModel>()..propertiesToFetch = ["id", "test"];
+    refModelReq = new Query<RefModel>()
+      ..returningProperties((r) => [r.id, r.test]);
     refObj = await refModelReq.fetchOne();
     expect(refObj.test, null);
   });

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     req = new Query<TestModel>()
       ..predicate = new QueryPredicate("id = @id", {"id": item.id})
-      ..propertiesToFetch = ["id", "name"];
+      ..returningProperties((t) => [t.id, t.name]);
 
     item = await req.fetchOne();
 
@@ -153,8 +153,8 @@ void main() {
     var req = new Query<TestModel>()..values = m;
     await req.insert();
 
-    req = new Query<TestModel>();
-    req.propertiesToFetch = ["id", "badkey"];
+    req = new Query<TestModel>()
+      ..returningProperties((t) => [t.id, t["badkey"]]);
 
     var successful = false;
     try {
@@ -278,13 +278,15 @@ void main() {
           ..values.owner = u1)
         .insert();
 
-    var q = new Query<GenPost>()..propertiesToFetch = ["id", "owner"];
+    var q = new Query<GenPost>()
+      ..returningProperties((p) => [p.id, p.owner]);
 
     var result = await q.fetchOne();
     expect(result.owner.id, 1);
     expect(result.owner.backingMap.length, 1);
 
-    q = new Query<GenPost>()..propertiesToFetch = ["id", "owner_id"];
+    q = new Query<GenPost>()
+      ..returningProperties((p) => [p.id, p["owner_id"]]);
     try {
       await q.fetchOne();
       expect(true, false);

--- a/test/db/postgresql/has_many_fetch_test.dart
+++ b/test/db/postgresql/has_many_fetch_test.dart
@@ -432,7 +432,7 @@ void main() {
 
     test("Trying to fetch hasMany relationship through resultProperties fails",
         () async {
-      var q = new Query<Parent>()..propertiesToFetch = ["id", "children"];
+      var q = new Query<Parent>()..returningProperties((p) => [p.id, p.children]);
       try {
         await q.fetchOne();
       } on QueryException catch (e) {
@@ -445,7 +445,7 @@ void main() {
 
     test("Trying to fetch hasMany relationship through resultProperties fails",
         () async {
-      var q = new Query<Parent>()..propertiesToFetch = ["id", "children"];
+      var q = new Query<Parent>()..returningProperties((p) => [p.id, p.children]);
       try {
         await q.fetchOne();
         expect(true, false);
@@ -457,7 +457,7 @@ void main() {
       }
 
       q = new Query<Parent>();
-      q.joinMany((p) => p.children)..propertiesToFetch = ["id", "vaccinations"];
+      q.joinMany((p) => p.children)..returningProperties((p) => [p.id, p.vaccinations]);
 
       try {
         await q.fetchOne();

--- a/test/db/postgresql/has_one_fetch_test.dart
+++ b/test/db/postgresql/has_one_fetch_test.dart
@@ -289,10 +289,10 @@ void main() {
 
     test("Can fetch graph when omitting foreign or primary keys from query",
         () async {
-      var q = new Query<Parent>()..propertiesToFetch = ["name"];
+      var q = new Query<Parent>()..returningProperties((p) => [p.name]);
 
-      var childQuery = q.joinOn((p) => p.child)..propertiesToFetch = ["name"];
-      childQuery.joinMany((c) => c.vaccinations)..propertiesToFetch = ["kind"];
+      var childQuery = q.joinOn((p) => p.child)..returningProperties((c) => [c.name]);
+      childQuery.joinMany((c) => c.vaccinations)..returningProperties((v) => [v.kind]);
 
       var parents = await q.fetch();
       for (var p in parents) {
@@ -314,11 +314,11 @@ void main() {
     });
 
     test("Can specify result keys for all joined objects", () async {
-      var q = new Query<Parent>()..propertiesToFetch = ["id"];
+      var q = new Query<Parent>()..returningProperties((p) => [p.id]);
 
-      var childQuery = q.joinOn((p) => p.child)..propertiesToFetch = ["id"];
+      var childQuery = q.joinOn((p) => p.child)..returningProperties((c) => [c.id]);
 
-      childQuery.joinMany((c) => c.vaccinations)..propertiesToFetch = ["id"];
+      childQuery.joinMany((c) => c.vaccinations)..returningProperties((v) => [v.id]);
 
       var parents = await q.fetch();
       for (var p in parents) {
@@ -374,7 +374,7 @@ void main() {
 
     test("Trying to fetch hasOne relationship through resultProperties fails",
         () async {
-      var q = new Query<Parent>()..propertiesToFetch = ["id", "child"];
+      var q = new Query<Parent>()..returningProperties((p) => [p.id, p.child]);
       try {
         await q.fetchOne();
         expect(true, false);
@@ -386,7 +386,7 @@ void main() {
       }
 
       q = new Query<Parent>();
-      q.joinOn((p) => p.child)..propertiesToFetch = ["id", "toy"];
+      q.joinOn((p) => p.child)..returningProperties((c) => [c.id, c.toy]);
 
       try {
         await q.fetchOne();

--- a/test/db/postgresql/insert_test.dart
+++ b/test/db/postgresql/insert_test.dart
@@ -135,7 +135,7 @@ void main() {
 
     var insertReq = new Query<TestModel>()
       ..valueMap = {"id": 20, "name": "Bob"}
-      ..propertiesToFetch = ["id", "name"];
+      ..returningProperties((t) => [t.id, t.name]);
 
     var value = await insertReq.insert();
     expect(value.id, 20);
@@ -144,7 +144,7 @@ void main() {
 
     insertReq = new Query<TestModel>()
       ..valueMap = {"id": 21, "name": "Bob"}
-      ..propertiesToFetch = ["id", "name", "emailAddress"];
+      ..returningProperties((t) => [t.id, t.name, t.emailAddress]);
 
     value = await insertReq.insert();
     expect(value.id, 21);

--- a/test/db/postgresql/paging_test.dart
+++ b/test/db/postgresql/paging_test.dart
@@ -321,7 +321,7 @@ void main() {
     test("Query when not fetching paging property still succeeds", () async {
       var req = new Query<PageableTestModel>()
         ..pageBy((p) => p.value, QuerySortOrder.ascending, boundingValue: "0")
-        ..propertiesToFetch = ["id"]
+        ..returningProperties((p) => [p.id])
         ..fetchLimit = 5;
       var res = await req.fetch();
       check([2, 3, 4, 5, 6], res);

--- a/test/db/postgresql/tiered_where_test.dart
+++ b/test/db/postgresql/tiered_where_test.dart
@@ -142,9 +142,9 @@ void main() {
 
     test("Query can specify resultProperties values when explicitly joined",
         () async {
-      var q = new Query<RootObject>()..propertiesToFetch = ["id"];
+      var q = new Query<RootObject>()..returningProperties((r) => [r.id]);
 
-      q.joinOn((r) => r.child)..propertiesToFetch = ["id"];
+      q.joinOn((r) => r.child)..returningProperties((c) => [c.id]);
 
       var results = await q.fetch();
       for (var r in results) {
@@ -162,11 +162,11 @@ void main() {
     test(
         "Query with nested explicit joins can specify resultProperties for all objects",
         () async {
-      var q = new Query<RootObject>()..propertiesToFetch = ["id"];
+      var q = new Query<RootObject>()..returningProperties((r) => [r.id]);
 
-      var cq = q.joinOn((r) => r.child)..propertiesToFetch = ["id"];
+      var cq = q.joinOn((r) => r.child)..returningProperties((c) => [c.id]);
 
-      cq.joinOn((c) => c.grandChild)..propertiesToFetch = ["id"];
+      cq.joinOn((c) => c.grandChild)..returningProperties((g) => [g.id]);
 
       var results = await q.fetch();
       for (var r in results) {
@@ -405,7 +405,7 @@ void main() {
         () async {
       var q = new Query<RootObject>()..where.child.value1 = whereGreaterThan(0);
 
-      q.joinOn((r) => r.child)..propertiesToFetch = ["id"];
+      q.joinOn((r) => r.child)..returningProperties((c) => [c.id]);
 
       var results = await q.fetch();
       for (var r in results) {


### PR DESCRIPTION
Rebase w/ #201.

```
var q = new Query<User>()
  ..returningProperties((t) => [t.id, t.name, t.email]);
```

Removes referencing properties by their string name.