### PR TITLE
Change AuthServer.verify to return null instead of throw exception

### DIFF
--- a/lib/src/auth/authorization_server.dart
+++ b/lib/src/auth/authorization_server.dart
@@ -139,16 +139,15 @@ class AuthServer extends Object with APIDocumentable implements AuthValidator {
   /// Returns a [Authorization] for [accessToken].
   ///
   /// This method obtains an [AuthToken] for [accessToken] from [storage] and then verifies that the token is valid.
-  /// If the token is valid, an [Authorization] object is returned. Otherwise, an [AuthServerException]
-  /// with [AuthRequestError.invalidToken] is thrown.
+  /// If the token is valid, an [Authorization] object is returned. Otherwise, [null] is returned.
   Future<Authorization> verify(String accessToken) async {
     if (accessToken == null) {
-      throw new AuthServerException(AuthRequestError.invalidToken, null);
+      return null;
     }
 
     AuthToken t = await storage.fetchTokenByAccessToken(this, accessToken);
     if (t == null || t.isExpired) {
-      throw new AuthServerException(AuthRequestError.invalidToken, null);
+      return null;
     }
 
     return new Authorization(t.clientID, t.resourceOwnerIdentifier, this);
@@ -371,7 +370,7 @@ class AuthServer extends Object with APIDocumentable implements AuthValidator {
   @override
   Future<Authorization> fromBearerToken(
       String bearerToken, List<String> scopesRequired) {
-    return verify(bearerToken).catchError((_) => null);
+    return verify(bearerToken);
   }
 
   @override

--- a/test/auth/authenticate_test.dart
+++ b/test/auth/authenticate_test.dart
@@ -195,13 +195,7 @@ void main() {
     });
 
     test("Cannot verify token that doesn't exist", () async {
-      try {
-        await auth.verify("nonsense");
-        expect(true, false);
-      } on AuthServerException catch (e) {
-        expect(e.client, isNull);
-        expect(e.reason, AuthRequestError.invalidToken);
-      }
+      expect(await auth.verify("nonsense"), isNull);
     });
 
     test("Expired token cannot be verified", () async {
@@ -214,12 +208,7 @@ void main() {
 
       sleep(new Duration(seconds: 1));
 
-      try {
-        await auth.verify(token.accessToken);
-        expect(true, false);
-      } on AuthServerException catch (e) {
-        expect(e.reason, AuthRequestError.invalidToken);
-      }
+      expect(await auth.verify(token.accessToken), isNull);
     });
   });
 
@@ -273,10 +262,7 @@ void main() {
     test("After refresh, the previous token cannot be used", () async {
       await auth.refresh(
           initialToken.refreshToken, "com.stablekernel.app1", "kilimanjaro");
-      try {
-        await auth.verify(initialToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(initialToken.accessToken), isNull);
     });
 
     test("Cannot refresh token that has not been issued", () async {
@@ -493,10 +479,7 @@ void main() {
       } on AuthServerException {}
 
       // Can no longer use issued token
-      try {
-        await auth.verify(issuedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(issuedToken.accessToken), isNull);
     });
 
     test(
@@ -514,15 +497,8 @@ void main() {
       } on AuthServerException {}
 
       // Can no longer use issued token
-      try {
-        await auth.verify(issuedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
-
-      try {
-        await auth.verify(refreshedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(issuedToken.accessToken), null);
+      expect(await auth.verify(refreshedToken.accessToken), null);
     });
 
     test("Null client ID fails", () async {

--- a/test/auth/authorizer_test.dart
+++ b/test/auth/authorizer_test.dart
@@ -264,13 +264,7 @@ Future<RequestControllerEvent> respond(Request req) async {
 }
 
 
-class CrashingStorage implements AuthStorage {
-  @override
-  Future revokeAuthenticatableWithIdentifier(
-      AuthServer server, dynamic identifier) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
+class CrashingStorage extends InMemoryAuthStorage {
   @override
   Future<AuthToken> fetchTokenByAccessToken(
       AuthServer server, String accessToken) async {
@@ -278,59 +272,7 @@ class CrashingStorage implements AuthStorage {
   }
 
   @override
-  Future<AuthToken> fetchTokenByRefreshToken(
-      AuthServer server, String refreshToken) async {
-    throw new HTTPResponseException(504, "ok");  }
-
-  @override
-  Future<TestUser> fetchAuthenticatableByUsername(
-      AuthServer server, String username) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
-  @override
-  Future revokeTokenIssuedFromCode(AuthServer server, AuthCode code) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
-  @override
-  Future storeToken(AuthServer server, AuthToken t,
-      {AuthCode issuedFrom}) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
-  @override
-  Future refreshTokenWithAccessToken(
-      AuthServer server,
-      String accessToken,
-      String newAccessToken,
-      DateTime newIssueDate,
-      DateTime newExpirationDate) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
-  @override
-  Future storeAuthCode(AuthServer server, AuthCode code) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
-  @override
-  Future<AuthCode> fetchAuthCodeByCode(AuthServer server, String code) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
-  @override
-  Future revokeAuthCodeWithCode(AuthServer server, String code) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
-  @override
   Future<AuthClient> fetchClientByID(AuthServer server, String id) async {
-    throw new HTTPResponseException(504, "ok");
-  }
-
-  @override
-  Future revokeClientWithID(AuthServer server, String id) async {
     throw new HTTPResponseException(504, "ok");
   }
 }

--- a/test/managed_auth/managed_auth_storage_test.dart
+++ b/test/managed_auth/managed_auth_storage_test.dart
@@ -208,13 +208,7 @@ void main() {
     });
 
     test("Cannot verify token that doesn't exist", () async {
-      try {
-        await auth.verify("nonsense");
-        expect(true, false);
-      } on AuthServerException catch (e) {
-        expect(e.client, isNull);
-        expect(e.reason, AuthRequestError.invalidToken);
-      }
+      expect(await auth.verify("nonsense"), isNull);
     });
 
     test("Expired token cannot be verified", () async {
@@ -224,12 +218,7 @@ void main() {
 
       sleep(new Duration(seconds: 1));
 
-      try {
-        await auth.verify(token.accessToken);
-        expect(true, false);
-      } on AuthServerException catch (e) {
-        expect(e.reason, AuthRequestError.invalidToken);
-      }
+      expect(await auth.verify(token.accessToken), isNull);
     });
 
     test("Cannot verify token if owner authentcatable is 'revoked'", () async {
@@ -237,10 +226,7 @@ void main() {
           User.DefaultPassword, "com.stablekernel.app1", "kilimanjaro");
       await auth.revokeAuthenticatableAccessForIdentifier(createdUser.id);
 
-      try {
-        await auth.verify(token.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(token.accessToken), isNull);
     });
   });
 
@@ -295,10 +281,7 @@ void main() {
     test("After refresh, the previous token cannot be used", () async {
       await auth.refresh(
           initialToken.refreshToken, "com.stablekernel.app1", "kilimanjaro");
-      try {
-        await auth.verify(initialToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(initialToken.accessToken), isNull);
 
       // Make sure we don't have duplicates in the db
       var q = new Query<ManagedToken>();
@@ -540,10 +523,7 @@ void main() {
       } on AuthServerException {}
 
       // Can no longer use issued token
-      try {
-        await auth.verify(issuedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(issuedToken.accessToken), isNull);
 
       // Ensure that the associated auth code is also destroyed
       var authCodeQuery = new Query<ManagedToken>();
@@ -565,16 +545,10 @@ void main() {
       } on AuthServerException {}
 
       // Can no longer use issued token
-      try {
-        await auth.verify(issuedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(issuedToken.accessToken), isNull);
 
       // Can no longer use refreshed token
-      try {
-        await auth.verify(refreshedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(refreshedToken.accessToken), isNull);
 
       // Ensure that the associated auth code is also destroyed
       var authCodeQuery = new Query<ManagedToken>();
@@ -657,14 +631,9 @@ void main() {
             unusedCode.code, "com.stablekernel.redirect", "mckinley");
         expect(true, false);
       } on AuthServerException {}
-      try {
-        await auth.verify(exchangedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
-      try {
-        await auth.verify(issuedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+
+      expect(await auth.verify(exchangedToken.accessToken), isNull);
+      expect(await auth.verify(issuedToken.accessToken), isNull);
 
       var tokenQuery = new Query<ManagedToken>();
       expect(await tokenQuery.fetch(), isEmpty);
@@ -772,14 +741,9 @@ void main() {
             unusedCode.code, "com.stablekernel.redirect", "mckinley");
         expect(true, false);
       } on AuthServerException {}
-      try {
-        await auth.verify(exchangedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
-      try {
-        await auth.verify(issuedToken.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+
+      expect(await auth.verify(exchangedToken.accessToken), isNull);
+      expect(await auth.verify(issuedToken.accessToken), isNull);
 
       var tokenQuery = new Query<ManagedToken>();
       expect(await tokenQuery.fetch(), isEmpty);
@@ -980,10 +944,7 @@ void main() {
       await auth.revokeAuthenticatableAccessForIdentifier(createdUsers[0].id);
       expect(await auth.verify(t2.accessToken), isNotNull);
 
-      try {
-        await auth.verify(t1.accessToken);
-        expect(true, false);
-      } on AuthServerException {}
+      expect(await auth.verify(t1.accessToken), isNull);
     });
   });
 }


### PR DESCRIPTION
Fixes issue where an unknown exception in Authorizer would always return a 401 instead of the appropriate status code for the exception