### PR TITLE
Change default port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # aqueduct changelog
 
+## 2.0.2
+
+- Allow binding to system-assigned port so tests can be run in parallel
+- Change `aqueduct serve` default port to 8081 so can develop in parallel to Angular2 apps that default to 8080
+
 ## 2.0.1
 
 - Fixes issue where some types of join queries would access the wrong properties

--- a/README.md
+++ b/README.md
@@ -114,17 +114,17 @@ And now you can make requests:
 
 ```sh
 # Create a new note: POST /notes
-curl -X POST http://localhost:8080/notes -H "Content-Type: application/json" -d '{"contents" : "a note"}'
+curl -X POST http://localhost:8081/notes -H "Content-Type: application/json" -d '{"contents" : "a note"}'
 
 # Get that note: GET /notes/1
-curl -X GET http://localhost:8080/notes/1
+curl -X GET http://localhost:8081/notes/1
 
 # Change that note: PUT /notes/1
-curl -X PUT http://localhost:8080/notes/1 -H "Content-Type: application/json" -d '{"contents" : "edit"}'
+curl -X PUT http://localhost:8081/notes/1 -H "Content-Type: application/json" -d '{"contents" : "edit"}'
 
 # Delete that note: 
-curl -X DELETE http://localhost:8080/notes/1
+curl -X DELETE http://localhost:8081/notes/1
 
 # Note there are no more notes:
-curl -X GET http://localhost:8080/notes
+curl -X GET http://localhost:8081/notes
 ```

--- a/example/templates/default/test/harness/app.dart
+++ b/example/templates/default/test/harness/app.dart
@@ -44,6 +44,7 @@ class TestApplication {
   Future start() async {
     RequestController.letUncaughtExceptionsEscape = true;
     application = new Application<WildfireSink>();
+    application.configuration.port = 0;
     application.configuration.configurationFilePath = "config.yaml.src";
 
     await application.start(runOnMainIsolate: true);
@@ -62,6 +63,7 @@ class TestApplication {
   ///
   /// This method must be called during test tearDown.
   Future stop() async {
+    application.logger.clearListeners();
     await application?.stop();
   }
 

--- a/lib/src/application/application_configuration.dart
+++ b/lib/src/application/application_configuration.dart
@@ -32,8 +32,8 @@ class ApplicationConfiguration {
 
   /// The port to listen for HTTP requests on.
   ///
-  /// Defaults to 8080.
-  int port = 8080;
+  /// Defaults to 8081.
+  int port = 8081;
 
   /// Whether or not the application should only receive connections over IPv6.
   ///

--- a/lib/src/commands/document.dart
+++ b/lib/src/commands/document.dart
@@ -35,7 +35,7 @@ class CLIDocument extends CLICommand with CLIProject {
   }
 
   List<Uri> get hosts {
-    List<String> hostValues = values["host"] ?? ["http://localhost:8080"];
+    List<String> hostValues = values["host"] ?? ["http://localhost:8081"];
     return hostValues.map((str) {
       var uri = Uri.parse(str);
       if (uri == null) {

--- a/lib/src/commands/serve.dart
+++ b/lib/src/commands/serve.dart
@@ -21,7 +21,7 @@ class CLIServer extends CLIServeBase {
       ..addOption("port",
           abbr: "p",
           help: "The port number to listen for HTTP requests on.",
-          defaultsTo: "8080")
+          defaultsTo: "8081")
       ..addOption("address",
           abbr: "a",
           help:

--- a/lib/src/utilities/test_client.dart
+++ b/lib/src/utilities/test_client.dart
@@ -12,7 +12,16 @@ import '../application/application_configuration.dart';
 /// test matchers.
 class TestClient {
   /// Creates an instance that targets the configured [app].
-  TestClient(Application app) : this.fromConfig(app.configuration);
+  TestClient(Application app) {
+    var scheme = app.configuration.securityContext != null ? "https" : "http";
+    var host = "localhost";
+    var port = app.configuration.port;
+
+    if (port == 0) {
+      port = app.mainIsolateSink.server.server.port;
+    }
+    baseURL = "$scheme://$host:$port";
+  }
 
   /// Creates an instance that targets http://localhost:[port].
   TestClient.onPort(int port) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: aqueduct
-version: 2.0.1
+version: 2.0.2
 description: A fully featured server-side framework built for productivity and testability.
 author: stable|kernel <http://stablekernel.com>
 homepage: https://github.com/stablekernel/aqueduct

--- a/test/auth/auth_code_controller_test.dart
+++ b/test/auth/auth_code_controller_test.dart
@@ -9,7 +9,7 @@ import 'dart:convert';
 
 void main() {
   Application<TestSink> application;
-  TestClient client = new TestClient.onPort(8080);
+  TestClient client = new TestClient.onPort(8081);
 
   var codeResponse = (Map<String, String> form) {
     var m = new Map<String, String>.from(form);

--- a/test/auth/auth_controller_test.dart
+++ b/test/auth/auth_controller_test.dart
@@ -8,7 +8,7 @@ import '../helpers.dart';
 
 void main() {
   HttpServer server;
-  TestClient client = new TestClient.onPort(8080)
+  TestClient client = new TestClient.onPort(8081)
     ..clientID = "com.stablekernel.app1"
     ..clientSecret = "kilimanjaro";
   AuthServer authenticationServer;
@@ -63,7 +63,7 @@ void main() {
     router.finalize();
 
     server =
-        await HttpServer.bind("localhost", 8080, v6Only: false, shared: false);
+        await HttpServer.bind("localhost", 8081, v6Only: false, shared: false);
     server.map((req) => new Request(req)).listen(router.receive);
   });
 

--- a/test/base/application_test.dart
+++ b/test/base/application_test.dart
@@ -23,13 +23,13 @@ main() {
     });
 
     test("Application responds to request", () async {
-      var response = await http.get("http://localhost:8080/t");
+      var response = await http.get("http://localhost:8081/t");
       expect(response.statusCode, 200);
     });
 
     test("Application properly routes request", () async {
-      var tResponse = await http.get("http://localhost:8080/t");
-      var rResponse = await http.get("http://localhost:8080/r");
+      var tResponse = await http.get("http://localhost:8081/t");
+      var rResponse = await http.get("http://localhost:8081/r");
 
       expect(tResponse.body, '"t_ok"');
       expect(rResponse.body, '"r_ok"');
@@ -37,7 +37,7 @@ main() {
 
     test("Application gzips content", () async {
       var resp = await http
-          .get("http://localhost:8080/t", headers: {"Accept-Encoding": "gzip"});
+          .get("http://localhost:8081/t", headers: {"Accept-Encoding": "gzip"});
       expect(resp.headers["content-encoding"], "gzip");
     });
 
@@ -46,7 +46,7 @@ main() {
 
       var successful = false;
       try {
-        var _ = await http.get("http://localhost:8080/t");
+        var _ = await http.get("http://localhost:8081/t");
         successful = true;
       } catch (e) {
         expect(e, isNotNull);
@@ -54,7 +54,7 @@ main() {
       expect(successful, false);
 
       await app.start(runOnMainIsolate: true);
-      var resp = await http.get("http://localhost:8080/t");
+      var resp = await http.get("http://localhost:8081/t");
       expect(resp.statusCode, 200);
     });
 
@@ -63,7 +63,7 @@ main() {
         () async {
       var sum = 0;
       for (var i = 0; i < 10; i++) {
-        var result = await http.get("http://localhost:8080/startup");
+        var result = await http.get("http://localhost:8081/startup");
         sum += int.parse(JSON.decode(result.body));
       }
       expect(sum, 10);
@@ -99,7 +99,7 @@ main() {
 
       crashingApp.configuration.options = {"crashIn": "dontCrash"};
       await crashingApp.start(runOnMainIsolate: true);
-      var response = await http.get("http://localhost:8080/t");
+      var response = await http.get("http://localhost:8081/t");
       expect(response.statusCode, 200);
       await crashingApp.stop();
     });
@@ -109,7 +109,7 @@ main() {
 
       await app.start(runOnMainIsolate: true);
 
-      var response = await http.get("http://localhost:8080/t");
+      var response = await http.get("http://localhost:8081/t");
       expect(response.statusCode, 200);
 
       await app.stop();

--- a/test/base/client_test_test.dart
+++ b/test/base/client_test_test.dart
@@ -6,9 +6,9 @@ import 'package:aqueduct/aqueduct.dart';
 
 main() {
   test("Client can expect array of JSON", () async {
-    TestClient client = new TestClient.onPort(8080);
+    TestClient client = new TestClient.onPort(8081);
     HttpServer server =
-        await HttpServer.bind("localhost", 8080, v6Only: false, shared: false);
+        await HttpServer.bind("localhost", 8081, v6Only: false, shared: false);
     var router = new Router();
     router.route("/na").generate(() => new TestController());
     router.finalize();

--- a/test/base/default_resource_controller_test.dart
+++ b/test/base/default_resource_controller_test.dart
@@ -11,7 +11,7 @@ void main() {
   group("Standard operations", () {
     var app = new Application<TestSink>();
     RequestController.letUncaughtExceptionsEscape = true;
-    app.configuration.port = 8080;
+    app.configuration.port = 8081;
     var client = new TestClient.onPort(app.configuration.port);
     List<TestModel> allObjects = [];
 
@@ -88,8 +88,8 @@ void main() {
 
   group("Standard operation failure cases", () {
     var app = new Application<TestSink>();
-    app.configuration.port = 8080;
-    var client = new TestClient.onPort(8080);
+    app.configuration.port = 8081;
+    var client = new TestClient.onPort(8081);
 
     setUpAll(() async {
       await app.start(runOnMainIsolate: true);
@@ -121,8 +121,8 @@ void main() {
 
   group("Objects that don't exist", () {
     var app = new Application<TestSink>();
-    app.configuration.port = 8080;
-    var client = new TestClient.onPort(8080);
+    app.configuration.port = 8081;
+    var client = new TestClient.onPort(8081);
 
     setUpAll(() async {
       await app.start(runOnMainIsolate: true);
@@ -150,15 +150,15 @@ void main() {
 
     test("Delete nonexistant object is 404", () async {
       expect(
-          await client.request("http://localhost:8080/controller/1").delete(),
+          await client.request("http://localhost:8081/controller/1").delete(),
           hasStatus(404));
     });
   });
 
   group("Extended GET requests", () {
     var app = new Application<TestSink>();
-    app.configuration.port = 8080;
-    var client = new TestClient.onPort(8080);
+    app.configuration.port = 8081;
+    var client = new TestClient.onPort(8081);
     List<TestModel> allObjects = [];
 
     setUpAll(() async {

--- a/test/base/isolate_application_test.dart
+++ b/test/base/isolate_application_test.dart
@@ -25,13 +25,13 @@ main() {
     ////////////////////////////////////////////
 
     test("Application responds to request", () async {
-      var response = await http.get("http://localhost:8080/t");
+      var response = await http.get("http://localhost:8081/t");
       expect(response.statusCode, 200);
     });
 
     test("Application properly routes request", () async {
-      var tRequest = http.get("http://localhost:8080/t");
-      var rRequest = http.get("http://localhost:8080/r");
+      var tRequest = http.get("http://localhost:8081/t");
+      var rRequest = http.get("http://localhost:8081/r");
 
       var tResponse = await tRequest;
       var rResponse = await rRequest;
@@ -44,7 +44,7 @@ main() {
       var reqs = <Future>[];
       var responses = [];
       for (int i = 0; i < 100; i++) {
-        var req = http.get("http://localhost:8080/t");
+        var req = http.get("http://localhost:8081/t");
         req.then((resp) {
           responses.add(resp);
         });
@@ -71,12 +71,12 @@ main() {
       await app.stop();
 
       try {
-        await http.get("http://localhost:8080/t");
+        await http.get("http://localhost:8081/t");
       } on SocketException {}
 
       await app.start(numberOfInstances: 3);
 
-      var resp = await http.get("http://localhost:8080/t");
+      var resp = await http.get("http://localhost:8081/t");
       expect(resp.statusCode, 200);
     });
 
@@ -85,7 +85,7 @@ main() {
         () async {
       var sum = 0;
       for (var i = 0; i < 10; i++) {
-        var result = await http.get("http://localhost:8080/startup");
+        var result = await http.get("http://localhost:8081/startup");
         sum += int.parse(JSON.decode(result.body));
       }
       expect(sum, 10);
@@ -124,7 +124,7 @@ main() {
 
       crashingApp.configuration.options = {"crashIn": "dontCrash"};
       await crashingApp.start();
-      var response = await http.get("http://localhost:8080/t");
+      var response = await http.get("http://localhost:8081/t");
       expect(response.statusCode, 200);
       await crashingApp.stop();
     });
@@ -132,11 +132,11 @@ main() {
     test(
         "Application that fails to open because port is bound fails gracefully",
         () async {
-      var server = await HttpServer.bind(InternetAddress.ANY_IP_V4, 8080);
+      var server = await HttpServer.bind(InternetAddress.ANY_IP_V4, 8081);
       server.listen((req) {});
 
       var conflictingApp = new Application<TestSink>();
-      conflictingApp.configuration.port = 8080;
+      conflictingApp.configuration.port = 8081;
 
       try {
         await conflictingApp.start();

--- a/test/base/recovery_test.dart
+++ b/test/base/recovery_test.dart
@@ -15,10 +15,10 @@ main() {
       await app.start(numberOfInstances: 1);
 
       // This request will generate an uncaught exception
-      var failFuture = http.get("http://localhost:8080/");
+      var failFuture = http.get("http://localhost:8081/");
 
       // This request will come in right after the failure but should succeed
-      var successFuture = http.get("http://localhost:8080/1");
+      var successFuture = http.get("http://localhost:8081/1");
 
       // Ensure both requests respond with 200, since the failure occurs asynchronously AFTER the response has been generated
       // for the failure case.
@@ -33,7 +33,7 @@ main() {
       expect(errorMessage.stackTrace, isNotNull);
 
       // And then we should make sure everything is working just fine.
-      expect((await http.get("http://localhost:8080/1")).statusCode, 200);
+      expect((await http.get("http://localhost:8081/1")).statusCode, 200);
     });
 
     test("Application with multiple isolates reports uncaught error, recovers",
@@ -42,8 +42,8 @@ main() {
 
       // Throw some deferred crashers then some success messages at the server
       var failFutures = new Iterable.generate(5)
-          .map((_) => http.get("http://localhost:8080"));
-      var successResponse = await http.get("http://localhost:8080/1");
+          .map((_) => http.get("http://localhost:8081"));
+      var successResponse = await http.get("http://localhost:8081/1");
       expect(successResponse.statusCode, 200);
 
       var logMessages = await app.logger.onRecord.take(5);

--- a/test/base/request_controller_test.dart
+++ b/test/base/request_controller_test.dart
@@ -133,7 +133,7 @@ void main() {
   test(
       "Request controller's can serialize and encode Serializable objects as JSON by default",
       () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -143,7 +143,7 @@ void main() {
       await next.receive(req);
     });
 
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.headers["content-type"], startsWith("application/json"));
     expect(JSON.decode(resp.body), {"name": "Bob"});
   });
@@ -151,7 +151,7 @@ void main() {
   test(
       "Responding to request with no content-type, but does have a body, defaults to application/json",
       () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -160,7 +160,7 @@ void main() {
       await next.receive(req);
     });
 
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.headers["content-type"], startsWith("application/json"));
     expect(JSON.decode(resp.body), {"a": "b"});
   });
@@ -168,7 +168,7 @@ void main() {
   test(
       "Responding to a request with no explicit content-type and has a body that cannot be encoded to JSON will throw 500",
       () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -177,7 +177,7 @@ void main() {
       await next.receive(req);
     });
 
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.statusCode, 500);
     expect(resp.headers["content-type"], "text/plain; charset=utf-8");
     expect(resp.body, "");
@@ -186,7 +186,7 @@ void main() {
   test(
       "Responding to request with no explicit content-type, but does not have a body, defaults to plaintext Content-Type header",
       () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -194,7 +194,7 @@ void main() {
       });
       await next.receive(req);
     });
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.statusCode, 200);
     expect(resp.headers["content-length"], "0");
     expect(resp.headers["content-type"], "text/plain; charset=utf-8");
@@ -202,7 +202,7 @@ void main() {
   });
 
   test("Using an encoder that doesn't exist returns a 500", () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -211,7 +211,7 @@ void main() {
       });
       await next.receive(req);
     });
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     var contentType = ContentType.parse(resp.headers["content-type"]);
     expect(resp.statusCode, 500);
     expect(contentType.primaryType, "application");
@@ -223,7 +223,7 @@ void main() {
   test(
       "Using an encoder other than the default correctly encodes and sets content-type",
       () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -232,7 +232,7 @@ void main() {
       });
       await next.receive(req);
     });
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.statusCode, 200);
     expect(resp.headers["content-type"], "text/plain");
     expect(resp.body, "1234");
@@ -241,7 +241,7 @@ void main() {
   test("A decoder with a match-all subtype will be used when matching",
       () async {
     Response.addEncoder(new ContentType("b", "*"), (s) => s);
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -250,7 +250,7 @@ void main() {
       });
       await next.receive(req);
     });
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.statusCode, 200);
     expect(resp.headers["content-type"], "b/bar; charset=utf-8");
     expect(resp.body, "hello");
@@ -263,7 +263,7 @@ void main() {
     Response.addEncoder(new ContentType("a", "html"), (s) {
       return "<html>$s</html>";
     });
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -272,7 +272,7 @@ void main() {
       });
       await next.receive(req);
     });
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.statusCode, 200);
     expect(resp.headers["content-type"], "a/html; charset=utf-8");
     expect(resp.body, "<html>hello</html>");
@@ -283,7 +283,7 @@ void main() {
     Response.addEncoder(new ContentType("foo", "bar"), (s) {
       throw new Exception("uhoh");
     });
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((req) async {
@@ -292,14 +292,14 @@ void main() {
       });
       await next.receive(req);
     });
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.statusCode, 500);
   });
 
   test(
       "willSendResponse is always called prior to Response being sent for preflight requests",
       () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.generate(() => new Always200Controller());
@@ -307,7 +307,7 @@ void main() {
     });
 
     // Invalid preflight
-    var req = await (new HttpClient().open("OPTIONS", "localhost", 8080, ""));
+    var req = await (new HttpClient().open("OPTIONS", "localhost", 8081, ""));
     req.headers.set("Origin", "http://foobar.com");
     req.headers.set("Access-Control-Request-Method", "POST");
     req.headers.set("Access-Control-Request-Headers", "accept, authorization");
@@ -318,7 +318,7 @@ void main() {
         {"statusCode": 403});
 
     // valid preflight
-    req = await (new HttpClient().open("OPTIONS", "localhost", 8080, ""));
+    req = await (new HttpClient().open("OPTIONS", "localhost", 8081, ""));
     req.headers.set("Origin", "http://somewhere.com");
     req.headers.set("Access-Control-Request-Method", "POST");
     req.headers.set("Access-Control-Request-Headers", "accept, authorization");
@@ -334,7 +334,7 @@ void main() {
   test(
       "willSendResponse is always called prior to Response being sent for normal requests",
       () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.generate(() => new Always200Controller());
@@ -342,28 +342,28 @@ void main() {
     });
 
     // normal response
-    var resp = await http.get("http://localhost:8080");
+    var resp = await http.get("http://localhost:8081");
     expect(resp.statusCode, 200);
     expect(JSON.decode(resp.body), {"statusCode": 100});
 
     // httpresponseexception
-    resp = await http.get("http://localhost:8080?q=http_response_exception");
+    resp = await http.get("http://localhost:8081?q=http_response_exception");
     expect(resp.statusCode, 200);
     expect(JSON.decode(resp.body), {"statusCode": 400});
 
     // query exception
-    resp = await http.get("http://localhost:8080?q=query_exception");
+    resp = await http.get("http://localhost:8081?q=query_exception");
     expect(resp.statusCode, 200);
     expect(JSON.decode(resp.body), {"statusCode": 503});
 
     // any other exception (500)
-    resp = await http.get("http://localhost:8080?q=server_error");
+    resp = await http.get("http://localhost:8081?q=server_error");
     expect(resp.statusCode, 200);
     expect(JSON.decode(resp.body), {"statusCode": 500});
   });
 
   test("Failure to decode request body as appropriate type is 400", () async {
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     server.map((req) => new Request(req)).listen((req) async {
       var next = new RequestController();
       next.listen((r) async {
@@ -373,7 +373,7 @@ void main() {
       await next.receive(req);
     });
 
-    var resp = await http.post("http://localhost:8080", headers: {
+    var resp = await http.post("http://localhost:8081", headers: {
       "content-type": "application/json"
     }, body: JSON.encode(["a"]));
 

--- a/test/command/serve_test.dart
+++ b/test/command/serve_test.dart
@@ -33,7 +33,7 @@ void main() {
         await runAqueductProcess(["serve", "--detached"], temporaryDirectory);
     expect(res, 0);
 
-    var result = await http.get("http://localhost:8080/endpoint");
+    var result = await http.get("http://localhost:8081/endpoint");
     expect(result.statusCode, 200);
   });
 

--- a/test/db/model_controller_test.dart
+++ b/test/db/model_controller_test.dart
@@ -16,7 +16,7 @@ main() {
     context = await contextWithModels([TestModel]);
     ManagedContext.defaultContext = context;
 
-    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8080);
+    server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8081);
     var router = new Router();
     router.route("/users/[:id]").generate(() => new TestModelController());
     router.finalize();
@@ -32,29 +32,29 @@ main() {
   });
 
   test("Request with no path parameters OK", () async {
-    var response = await http.get("http://localhost:8080/users");
+    var response = await http.get("http://localhost:8081/users");
     expect(response.statusCode, 200);
   });
 
   test("Request with path parameter of type needing parse OK", () async {
-    var response = await http.get("http://localhost:8080/users/1");
+    var response = await http.get("http://localhost:8081/users/1");
     expect(response.statusCode, 200);
   });
 
   test("Request with path parameter of wrong type returns 404", () async {
-    var response = await http.get("http://localhost:8080/users/foo");
+    var response = await http.get("http://localhost:8081/users/foo");
     expect(response.statusCode, 404);
   });
 
   test("Request with path parameter and body", () async {
-    var response = await http.put("http://localhost:8080/users/2",
+    var response = await http.put("http://localhost:8081/users/2",
         headers: {"Content-Type": "application/json;charset=utf-8"},
         body: JSON.encode({"name": "joe"}));
     expect(response.statusCode, 200);
   });
 
   test("Request without path parameter and body", () async {
-    var response = await http.post("http://localhost:8080/users",
+    var response = await http.post("http://localhost:8081/users",
         headers: {"Content-Type": "application/json;charset=utf-8"},
         body: JSON.encode({"name": "joe"}));
     expect(response.statusCode, 200);


### PR DESCRIPTION
Defaults to 8081 to avoid conflict with pub serve for development in parallel 
Allow system assigned ports to run tests in parallel 
Reset logger listeners during tests so they stop accruing newlines 