### PR TITLE
Cleanup on request body processing

### DIFF
--- a/lib/src/http/http_controller.dart
+++ b/lib/src/http/http_controller.dart
@@ -145,12 +145,12 @@ abstract class HTTPController extends RequestController {
     return req;
   }
 
-  /// Executed prior to a responder method being executed, but after the body has been processed.
+  /// Callback to indicate when a request body has been processed.
   ///
   /// This method is called after the body has been processed by the decoder, but prior to the request being
-  /// handled by the selected responder method. If there is no HTTP body in the request,
+  /// handled by the selected responder method. If there is no HTTP request body,
   /// this method is not called.
-  void didDecodeRequestBody(HTTPBody decodedObject) {}
+  void didDecodeRequestBody(HTTPRequestBody decodedObject) {}
 
   /// Returns a [Response] for missing [HTTPParameter]s.
   ///
@@ -212,15 +212,12 @@ abstract class HTTPController extends RequestController {
           null);
     }
 
-    if (request.innerRequest.contentLength > 0) {
-      if (_requestContentTypeIsSupported(request)) {
-        await request.body.decodedData;
-      } else {
+    if (!request.body.isEmpty) {
+      if (!_requestContentTypeIsSupported(request)) {
         return new Response(HttpStatus.UNSUPPORTED_MEDIA_TYPE, null, null);
       }
-    }
 
-    if (request.body.hasContent != null) {
+      await request.body.decodedData;
       didDecodeRequestBody(request.body);
     }
 

--- a/lib/src/http/query_controller.dart
+++ b/lib/src/http/query_controller.dart
@@ -61,10 +61,8 @@ abstract class QueryController<InstanceType extends ManagedObject>
   }
 
   @override
-  void didDecodeRequestBody(HTTPBody body) {
-    if (body.hasContent) {
-      query.values.readMap(body.asMap());
-      query.values.removePropertyFromBackingMap(query.values.entity.primaryKey);
-    }
+  void didDecodeRequestBody(HTTPRequestBody body) {
+    query.values.readMap(body.asMap());
+    query.values.removePropertyFromBackingMap(query.values.entity.primaryKey);
   }
 }

--- a/lib/src/http/request.dart
+++ b/lib/src/http/request.dart
@@ -13,7 +13,7 @@ class Request implements RequestOrResponse {
   /// Creates an instance of [Request], no need to do so manually.
   Request(this.innerRequest) {
     connectionInfo = innerRequest.connectionInfo;
-    _body = new HTTPBody(this.innerRequest);
+    _body = new HTTPRequestBody(this.innerRequest);
   }
 
   /// The internal [HttpRequest] of this [Request].
@@ -47,14 +47,15 @@ class Request implements RequestOrResponse {
   /// null if no permission has been set.
   Authorization authorization;
 
-  /// The request body object, as determined by how it was decoded.
+  /// The request body object.
   ///
-  /// This value will be null until [decodeBody] is executed or if there is no request body.
-  /// Once decoded, this value will be an object that is determined by the decoder passed to [decodeBody].
-  /// For example, if the request body was a JSON object and the decoder handled JSON, this value would be a [Map]
-  /// representing the JSON object.
-  HTTPBody get body => _body;
-  HTTPBody _body;
+  /// This object contains the request body if one exists and behavior for decoding it according
+  /// to this instance's content-type. See [HTTPRequestBody] for details on decoding the body into
+  /// an object (or objects).
+  ///
+  /// This value is is always non-null. If there is no request body, [HTTPRequestBody.isEmpty] is true.
+  HTTPRequestBody get body => _body;
+  HTTPRequestBody _body;
 
   /// Whether or not this request is a CORS request.
   ///
@@ -94,19 +95,11 @@ class Request implements RequestOrResponse {
     return buf.toString();
   }
 
-  String get _sanitizedBody {
-    if (body.hasBeenDecoded) {
-      return _truncatedString(body.asDynamic().toString(), charSize: 512);
-    }
-
-    return "-";
-  }
-
   String _truncatedString(String originalString, {int charSize: 128}) {
     if (originalString.length <= charSize) {
       return originalString;
     }
-    return originalString.substring(0, charSize);
+    return originalString.substring(0, charSize) + " ... (${originalString.length - charSize} truncated bytes)";
   }
 
   /// Sends a [Response] to this [Request]'s client.
@@ -203,8 +196,7 @@ class Request implements RequestOrResponse {
       bool includeResource: true,
       bool includeStatusCode: true,
       bool includeContentSize: false,
-      bool includeHeaders: false,
-      bool includeBody: false}) {
+      bool includeHeaders: false}) {
     var builder = new StringBuffer();
     if (includeRequestIP) {
       builder.write("${innerRequest.connectionInfo?.remoteAddress?.address} ");
@@ -227,9 +219,6 @@ class Request implements RequestOrResponse {
     }
     if (includeHeaders) {
       builder.write("${_sanitizedHeaders} ");
-    }
-    if (includeBody) {
-      builder.write("${_sanitizedBody} ");
     }
 
     return builder.toString();

--- a/lib/src/http/request_controller.dart
+++ b/lib/src/http/request_controller.dart
@@ -225,7 +225,7 @@ class RequestController extends Object with APIDocumentable {
       await _sendResponse(request, response, includeCORSHeaders: true);
 
       logger.info(
-          "${request.toDebugString(includeHeaders: true, includeBody: true)}");
+          "${request.toDebugString(includeHeaders: true)}");
     } else if (caughtValue is QueryException &&
         caughtValue.event != QueryExceptionEvent.internalFailure) {
       // Note that if the event is an internal failure, this code is skipped and the 500 handler is executed.
@@ -250,7 +250,7 @@ class RequestController extends Object with APIDocumentable {
       await _sendResponse(request, response, includeCORSHeaders: true);
 
       logger.info(
-          "${request.toDebugString(includeHeaders: true, includeBody: true)}");
+          "${request.toDebugString(includeHeaders: true)}");
     } else {
       var body = null;
       if (includeErrorDetailsInServerErrorResponses) {
@@ -266,7 +266,7 @@ class RequestController extends Object with APIDocumentable {
       await _sendResponse(request, response, includeCORSHeaders: true);
 
       logger.severe(
-          "${request.toDebugString(includeHeaders: true, includeBody: true)}",
+          "${request.toDebugString(includeHeaders: true)}",
           caughtValue,
           trace);
 

--- a/test/base/controller_test.dart
+++ b/test/base/controller_test.dart
@@ -288,6 +288,19 @@ void main() {
     expect(resp.body, "body");
   });
 
+  test("didDecodeRequestBody invoked when there is a request body", () async {
+    server = await enableController("/a", DecodeCallbackController);
+    var resp = await http.get("http://localhost:4040/a");
+    expect(JSON.decode(resp.body), {"didDecode": false});
+
+    resp = await http.post("http://localhost:4040/a", headers: {
+      HttpHeaders.CONTENT_TYPE: ContentType.JSON.toString()
+    }, body: JSON.encode({
+      "k":"v"
+    }));
+    expect(JSON.decode(resp.body), {"didDecode": true});
+  });
+
   group("Annotated HTTP parameters", () {
     test("are supplied correctly", () async {
       server = await enableController("/a", HTTPParameterController);
@@ -675,6 +688,25 @@ class DuplicateParamController extends HTTPController {
   Future<Response> getThing(@HTTPQuery("list") List<String> list,
       @HTTPQuery("single") String single) async {
     return new Response.ok({"list": list, "single": single});
+  }
+}
+
+class DecodeCallbackController extends HTTPController {
+  bool didDecode = false;
+
+  @httpGet
+  Future<Response> getThing() async {
+    return new Response.ok({"didDecode": didDecode});
+  }
+
+  @httpPost
+  Future<Response> postThing() async {
+    return new Response.ok({"didDecode": didDecode});
+  }
+
+  @override
+  void didDecodeRequestBody(HTTPRequestBody decodedObject) {
+    didDecode = true;
   }
 }
 

--- a/test/base/request_controller_test.dart
+++ b/test/base/request_controller_test.dart
@@ -305,7 +305,6 @@ class OutlierSink extends RequestSink {
 
         req.toDebugString(
             includeHeaders: true,
-            includeBody: true,
             includeContentSize: true,
             includeElapsedTime: true,
             includeMethod: true,


### PR DESCRIPTION
Rename HTTPBody -> HTTPRequestBody.

Checked for transfer-encoding or content-length when identifying if Request has body.

Fix issue with didDecodeRequestBody being invoked without body.

Remove body logging for certain errors.