### PR TITLE
Rename joinOne and joinMany to join(object:) and join(set:)

### DIFF
--- a/lib/src/application/isolate_application_server.dart
+++ b/lib/src/application/isolate_application_server.dart
@@ -49,9 +49,12 @@ class ApplicationIsolateServer extends ApplicationServer {
 
   Future stop() async {
     supervisingReceivePort.close();
+    logger.fine("ApplicationIsolateServer($identifier) closing server");
     await close();
+    logger.fine("ApplicationIsolateServer($identifier) did close server");
     await ResourceRegistry.release();
     logger.clearListeners();
+    logger.fine("ApplicationIsolateServer($identifier) sending stop acknowledgement");
     supervisingApplicationPort
         .send(ApplicationIsolateSupervisor.MessageStop);
   }

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -65,7 +65,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     if (attr == null) {
       throw new QueryException(QueryExceptionEvent.internalFailure,
           message:
-          "Property '${matchingKey}' is not a relationship or does not exist for ${entity.tableName} in 'joinMany'.");
+          "Invalid join. Property '${matchingKey}' is not a relationship or does not exist for ${entity.tableName}.");
     }
 
     return _createSubquery(attr);
@@ -148,12 +148,12 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
       if (entity.relationships[propertyName] != null) {
         throw new QueryException(QueryExceptionEvent.internalFailure,
             message:
-                "Property '${propertyName}' cannot be paged on for ${entity.tableName}. "
-                "Reason: relationship properties cannot be paged on.");
+                "Property '${propertyName}' cannot be sorted by for ${entity.tableName}. "
+                "Reason: results cannot be sorted by relationship properties.");
       } else {
         throw new QueryException(QueryExceptionEvent.internalFailure,
             message:
-                "Property '${propertyName}' cannot be paged on for ${entity.tableName}. "
+                "Property '${propertyName}' cannot be sorted by for ${entity.tableName}. "
                 "Reason: property does not exist for entity.");
       }
     }

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -37,56 +37,58 @@ abstract class Query<InstanceType extends ManagedObject> {
     return null;
   }
 
-  /// Configures this instance to also include has-one relationship properties for returned objects.
+  /// Configures this instance to fetch a relationship property identified by [object] or [set].
   ///
-  /// This method configures this instance to also include values for the relationship property identified
-  /// by [propertyIdentifier]. [propertyIdentifier] must return a has-one relationship property of [InstanceType].
-  /// i.e., the returned value from this closure must be a [ManagedObject] subclass.
+  /// By default, objects returned by [Query.fetch] do not have their relationship properties populated. (In other words,
+  /// [ManagedObject] and [ManagedSet] properties are null.) This method configures this instance to conduct a SQL join,
+  /// allowing it to fetch relationship properties for the returned instances.
   ///
-  ///         var query = new Query<AccountHolder>()
-  ///           ..joinOne((accountHolder) => accountHolder.primaryAccount);
+  /// Consider a [ManagedObject] subclass with the following relationship properties as an example:
   ///
-  /// Instances returned from this query when executing [fetch] or [fetchOne]
-  /// will include values for that relationship property if a value exists. If the value does not exist,
-  /// i.e. the value is null, the returned object will contain the null value for its relationship property.
+  ///         class User extends ManagedObject<_User> implements _User {}
+  ///         class _User {
+  ///           Profile profile;
+  ///           ManagedSet<Note> notes;
+  ///         }
   ///
-  /// This method returns another instance of [Query] with a parametrized type of the related object. The
-  /// return query is a subquery of this instance. A subquery may be configured just like any other query,
-  /// e.g. configuring properties like [returningProperties] and [where].
+  /// To fetch an object and one of its has-one properties, use the [object] closure:
   ///
-  /// More than one [joinOne] (or [joinMany]) can be used on a single query and subqueries can also have [joinOne]
-  /// and [joinMany] nested configurations. Keep in mind, each additional join configuration does have an impact on
-  /// query performance.
+  ///         var query = new Query<User>()
+  ///           ..join(object: (u) => u.profile);
   ///
-  /// This configuration is only valid when executing [fetch] or [fetchOne].
+  /// To fetch an object and its has-many properties, use the [set] closure:
+  ///
+  ///         var query = new Query<User>()
+  ///           ..join(set: (u) => u.notes);
+  ///
+  /// Both [object] and [set] are passed an empty instance of the type being queried. [object] must return a has-one property (a [ManagedObject] subclass)
+  /// of the object it is pased. [set] must return a has-many property (a [ManagedSet]) of the object it is passed.
+  ///
+  /// Multiple relationship properties can be included by invoking this method multiple times with different properties, e.g.:
+  ///
+  ///         var query = new Query<User>()
+  ///           ..join(object: (u) => u.profile)
+  ///           ..join(set: (u) => u.notes);
+  ///
+  /// This method also returns a new instance of [Query], where [InstanceType] is is the type of the relationship property. This can be used
+  /// to configure which properties are returned for the related objects and to filter a [ManagedSet] relationship property. For example:
+  ///
+  ///         var query = new Query<User>();
+  ///         var subquery = query.join(set: (u) => u.notes)
+  ///           ..where.dateCreatedAt = whereGreaterThan(someDate);
+  ///
+  /// This mechanism only works on [fetch] and [fetchOne] execution methods. You *must not* execute a subquery created by this method.
+  Query<T> join<T extends ManagedObject>({T object(InstanceType x), ManagedSet<T> set(InstanceType x)});
+
+  /// Deprecated: see [join].
+  @Deprecated("3.0, use join(object:set:) instead")
   Query<T> joinOne<T extends ManagedObject>(
       T propertyIdentifier(InstanceType x));
 
-  /// Configures this instance to also include has-many relationship properties for returned objects.
-  ///
-  /// This method configures this instance to also include values for the relationship property identified
-  /// by [propertyIdentifier]. [propertyIdentifier] must return a has-many relationship property of [InstanceType].
-  /// i.e., the returned value from this closure must be a [ManagedSet].
-  ///
-  ///         var query = new Query<AccountHolder>()
-  ///           ..joinMany((accountHolder) => accountHolder.accounts);
-  ///
-  /// Instances returned from this query when executing [fetch] or [fetchOne]
-  /// will include values for that relationship property if a value exists. If the value does not exist,
-  /// i.e. the value is null, the returned object will contain the null value for its relationship property.
-  ///
-  /// This method returns another instance of [Query] with a parametrized type of the related object. The
-  /// return query is a subquery of this instance. A subquery may be configured just like any other query,
-  /// e.g. configuring properties like [returningProperties] and [where].
-  ///
-  /// More than one [joinOne] (or [joinMany]) can be used on a single query and subqueries can also have [joinOne]
-  /// and [joinMany] nested configurations. Keep in mind, each additional join configuration does have an impact on
-  /// query performance.
-  ///
-  /// This configuration is only valid when executing [fetch] or [fetchOne].
+  /// Deprecated: see [join].
+  @Deprecated("3.0, use join(object:set:) instead")
   Query<T> joinMany<T extends ManagedObject>(
       ManagedSet<T> propertyIdentifier(InstanceType x));
-
 
   /// Configures this instance to fetch a section of a larger result set.
   ///

--- a/test/base/isolate/isolate_application_test.dart
+++ b/test/base/isolate/isolate_application_test.dart
@@ -16,7 +16,7 @@ main() {
 
     setUp(() async {
       app = new Application<TestSink>();
-      await app.start(numberOfInstances: 2);
+      await app.start(numberOfInstances: 2, consoleLogging: true);
       print("started");
     });
 
@@ -76,7 +76,7 @@ main() {
         await http.get("http://localhost:8081/t");
       } on SocketException {}
 
-      await app.start(numberOfInstances: 2);
+      await app.start(numberOfInstances: 2, consoleLogging: true);
 
       var resp = await http.get("http://localhost:8081/t");
       expect(resp.statusCode, 200);

--- a/test/base/isolate/isolate_failure_test.dart
+++ b/test/base/isolate/isolate_failure_test.dart
@@ -22,7 +22,7 @@ main() {
 
           try {
             crashingApp.configuration.options = {"crashIn": "constructor"};
-            await crashingApp.start();
+            await crashingApp.start(consoleLogging: true);
             expect(true, false);
           } on ApplicationStartupException catch (e) {
             expect(e.toString(), contains("TestException: constructor"));
@@ -30,7 +30,7 @@ main() {
 
           try {
             crashingApp.configuration.options = {"crashIn": "addRoutes"};
-            await crashingApp.start();
+            await crashingApp.start(consoleLogging: true);
             expect(true, false);
           } on ApplicationStartupException catch (e) {
             expect(e.toString(), contains("TestException: addRoutes"));
@@ -38,14 +38,14 @@ main() {
 
           try {
             crashingApp.configuration.options = {"crashIn": "willOpen"};
-            await crashingApp.start();
+            await crashingApp.start(consoleLogging: true);
             expect(true, false);
           } on ApplicationStartupException catch (e) {
             expect(e.toString(), contains("TestException: willOpen"));
           }
 
           crashingApp.configuration.options = {"crashIn": "dontCrash"};
-          await crashingApp.start();
+          await crashingApp.start(consoleLogging: true);
           var response = await http.get("http://localhost:8081/t");
           expect(response.statusCode, 200);
           await crashingApp.stop();
@@ -61,7 +61,7 @@ main() {
           conflictingApp.configuration.port = 8081;
 
           try {
-            await conflictingApp.start();
+            await conflictingApp.start(consoleLogging: true);
             expect(true, false);
           } on ApplicationStartupException catch (e) {
             expect(e.toString(), contains("Failed to create server socket"));

--- a/test/db/postgresql/belongs_to_fetch_test.dart
+++ b/test/db/postgresql/belongs_to_fetch_test.dart
@@ -112,8 +112,8 @@ void main() {
   test("Multiple joins from same table", () async {
     var q = new Query<ChildObject>()
       ..sortBy((c) => c.cid, QuerySortOrder.ascending)
-      ..joinOne((c) => c.parent)
-      ..joinOne((c) => c.parents);
+      ..join(object: (c) => c.parent)
+      ..join(object: (c) => c.parents);
     var results = await q.fetch();
 
     expect(
@@ -133,7 +133,7 @@ void main() {
 
   group("Join on parent of hasMany relationship", () {
     test("Standard join", () async {
-      var q = new Query<ChildObject>()..joinOne((c) => c.parents);
+      var q = new Query<ChildObject>()..join(object: (c) => c.parents);
       var results = await q.fetch();
 
       expect(
@@ -167,7 +167,7 @@ void main() {
 
     test("Nested join", () async {
       var q = new Query<GrandChildObject>();
-      q.joinOne((c) => c.parents)..joinOne((c) => c.parents);
+      q.join(object: (c) => c.parents)..join(object: (c) => c.parents);
       var results = await q.fetch();
 
       expect(
@@ -220,9 +220,9 @@ void main() {
     test("Bidirectional join", () async {
       var q = new Query<ChildObject>()
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
-        ..joinMany((c) => c.grandChildren)
+        ..join(set: (c) => c.grandChildren)
             .sortBy((g) => g.gid, QuerySortOrder.descending)
-        ..joinOne((c) => c.parents);
+        ..join(object: (c) => c.parents);
 
       var results = await q.fetch();
 
@@ -305,7 +305,7 @@ void main() {
     test("Standard join", () async {
       var q = new Query<ChildObject>()
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
-        ..joinOne((c) => c.parent);
+        ..join(object: (c) => c.parent);
       var results = await q.fetch();
 
       expect(
@@ -348,7 +348,7 @@ void main() {
       var q = new Query<GrandChildObject>()
         ..sortBy((g) => g.gid, QuerySortOrder.ascending);
 
-      q.joinOne((c) => c.parent)..joinOne((c) => c.parent);
+      q.join(object: (c) => c.parent)..join(object: (c) => c.parent);
 
       var results = await q.fetch();
 

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -96,6 +96,28 @@ void main() {
     }
   });
 
+  test("Cannot sort by property that doesn't exist", () async {
+    context = await contextWithModels([TestModel]);
+    try {
+      new Query<GenUser>()
+        ..sortBy((u) => u["nonexisting"], QuerySortOrder.ascending);
+      expect(true, false);
+    } on QueryException catch (e) {
+      expect(e.toString(), contains("property does not exist"));
+    }
+  });
+
+  test("Cannot sort by relationship property", () async {
+    context = await contextWithModels([GenUser, GenPost]);
+    try {
+      new Query<GenUser>()
+          ..sortBy((u) => u.posts, QuerySortOrder.ascending);
+      expect(true, false);
+    } on QueryException catch (e) {
+      expect(e.toString(), contains("results cannot be sorted by relationship properties"));
+    }
+  });
+
   test("Order by multiple sort descriptors work", () async {
     context = await contextWithModels([TestModel]);
 

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -99,7 +99,7 @@ void main() {
   test("Cannot sort by property that doesn't exist", () async {
     context = await contextWithModels([TestModel]);
     try {
-      new Query<GenUser>()
+      new Query<TestModel>()
         ..sortBy((u) => u["nonexisting"], QuerySortOrder.ascending);
       expect(true, false);
     } on QueryException catch (e) {

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -254,7 +254,7 @@ void main() {
     }
 
     try {
-      var q = new Query<GenUser>()..joinMany((u) => u.posts);
+      var q = new Query<GenUser>()..join(set: (u) => u.posts);
       await q.fetchOne();
 
       expect(true, false);

--- a/test/db/postgresql/has_many_fetch_test.dart
+++ b/test/db/postgresql/has_many_fetch_test.dart
@@ -29,7 +29,7 @@ void main() {
     test("Fetch has-many relationship that has none returns empty OrderedSet",
         () async {
       var q = new Query<Parent>()
-        ..joinMany((p) => p.children)
+        ..join(set: (p) => p.children)
         ..where.name = "D";
 
       var verifier = (Parent p) {
@@ -46,9 +46,9 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.name = "D";
 
-      q.joinMany((p) => p.children)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations);
+      q.join(set: (p) => p.children)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations);
 
       var verifier = (Parent p) {
         expect(p.name, "D");
@@ -63,7 +63,7 @@ void main() {
         "Fetch has-many relationship that is non-empty returns values for scalar properties in subobjects only",
         () async {
       var q = new Query<Parent>()
-        ..joinMany((p) => p.children)
+        ..join(set: (p) => p.children)
         ..where.name = "C";
 
       var verifier = (Parent p) {
@@ -83,10 +83,10 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.name = "B";
 
-      q.joinMany((p) => p.children)
+      q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations);
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations);
 
       var verifier = (Parent p) {
         expect(p.name, "B");
@@ -115,10 +115,10 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.name = "A";
 
-      q.joinMany((p) => p.children)
+      q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations)
             .sortBy((v) => v.vid, QuerySortOrder.ascending);
 
       var verifier = (Parent p) {
@@ -150,7 +150,7 @@ void main() {
         () async {
       var q = new Query<Parent>()
         ..sortBy((p) => p.pid, QuerySortOrder.ascending)
-        ..joinMany((p) => p.children)
+        ..join(set: (p) => p.children)
         ..where.name = whereIn(["A", "C", "D"]);
       var results = await q.fetch();
       expect(results.length, 3);
@@ -183,9 +183,9 @@ void main() {
 
     test("Fetch entire graph", () async {
       var q = new Query<Parent>();
-      q.joinMany((p) => p.children)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations);
+      q.join(set: (p) => p.children)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations);
 
       var all = await q.fetch();
 
@@ -236,10 +236,10 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.name = "A";
 
-      q.joinMany((p) => p.children)
+      q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations)
             .sortBy((v) => v.vid, QuerySortOrder.ascending);
 
       var results = await q.fetch();
@@ -262,12 +262,12 @@ void main() {
         () async {
       var q = new Query<Parent>();
 
-      q.joinMany((p) => p.children)
+      q.join(set: (p) => p.children)
         ..where.name = "C1"
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
-        ..joinMany((c) => c.vaccinations)
+        ..join(set: (c) => c.vaccinations)
             .sortBy((v) => v.vid, QuerySortOrder.ascending)
-        ..joinOne((c) => c.toy);
+        ..join(object: (c) => c.toy);
 
       var results = await q.fetch();
 
@@ -289,8 +289,8 @@ void main() {
         () async {
       var q = new Query<Parent>();
 
-      var childJoin = q.joinMany((p) => p.children)..joinOne((c) => c.toy);
-      childJoin.joinMany((c) => c.vaccinations)..where.kind = "V1";
+      var childJoin = q.join(set: (p) => p.children)..join(object: (c) => c.toy);
+      childJoin.join(set: (c) => c.vaccinations)..where.kind = "V1";
 
       var results = await q.fetch();
 
@@ -327,8 +327,8 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.pid = 5;
 
-      var childJoin = q.joinMany((p) => p.children)..joinOne((c) => c.toy);
-      childJoin.joinMany((c) => c.vaccinations)..where.kind = "V1";
+      var childJoin = q.join(set: (p) => p.children)..join(object: (c) => c.toy);
+      childJoin.join(set: (c) => c.vaccinations)..where.kind = "V1";
 
       var results = await q.fetch();
       expect(results.length, 0);
@@ -354,9 +354,9 @@ void main() {
       var q = new Query<Parent>()
         ..sortBy((p) => p.name, QuerySortOrder.descending);
 
-      q.joinMany((p) => p.children)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations);
+      q.join(set: (p) => p.children)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations);
 
       var results = await q.fetch();
 
@@ -404,7 +404,7 @@ void main() {
     test("Objects returned in join are not the same instance", () async {
       var q = new Query<Parent>()
         ..where.pid = 1
-        ..joinMany((p) => p.children);
+        ..join(set: (p) => p.children);
 
       var o = await q.fetchOne();
       for (var c in o.children) {
@@ -454,7 +454,7 @@ void main() {
       }
 
       q = new Query<Parent>();
-      q.joinMany((p) => p.children)
+      q.join(set: (p) => p.children)
         ..returningProperties((p) => [p.cid, p.vaccinations]);
 
       try {

--- a/test/db/postgresql/has_one_fetch_test.dart
+++ b/test/db/postgresql/has_one_fetch_test.dart
@@ -29,7 +29,7 @@ void main() {
     test("Fetch has-one relationship that is null returns null for property",
         () async {
       var q = new Query<Parent>()
-        ..joinOne((p) => p.child)
+        ..join(object: (p) => p.child)
         ..where.name = "D";
 
       var verifier = (Parent p) {
@@ -47,9 +47,9 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.name = "D";
 
-      q.joinOne((p) => p.child)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations);
+      q.join(object: (p) => p.child)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations);
 
       var verifier = (Parent p) {
         expect(p.name, "D");
@@ -65,7 +65,7 @@ void main() {
         "Fetch has-one relationship that is non-null returns value for property with scalar values only",
         () async {
       var q = new Query<Parent>()
-        ..joinOne((p) => p.child)
+        ..join(object: (p) => p.child)
         ..where.name = "C";
 
       var verifier = (Parent p) {
@@ -85,9 +85,9 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.name = "B";
 
-      q.joinOne((p) => p.child)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations);
+      q.join(object: (p) => p.child)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations);
 
       var verifier = (Parent p) {
         expect(p.name, "B");
@@ -110,9 +110,9 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.name = "C";
 
-      q.joinOne((p) => p.child)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations);
+      q.join(object: (p) => p.child)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations);
 
       var verifier = (Parent p) {
         expect(p.name, "C");
@@ -132,7 +132,7 @@ void main() {
         "Fetching multiple top-level instances and including next-level hasOne",
         () async {
       var q = new Query<Parent>()
-        ..joinOne((p) => p.child)
+        ..join(object: (p) => p.child)
         ..where.name = whereIn(["C", "D"]);
 
       var results = await q.fetch();
@@ -148,9 +148,9 @@ void main() {
 
     test("Fetch entire graph", () async {
       var q = new Query<Parent>();
-      q.joinOne((p) => p.child)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations);
+      q.join(object: (p) => p.child)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations);
 
       var all = await q.fetch();
 
@@ -192,9 +192,9 @@ void main() {
     test("Predicate impacts top-level objects when fetching object graph",
         () async {
       var q = new Query<Parent>()..where.name = "A";
-      q.joinOne((p) => p.child)
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations)
+      q.join(object: (p) => p.child)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations)
             .sortBy((v) => v.vid, QuerySortOrder.ascending);
 
       var results = await q.fetch();
@@ -212,10 +212,10 @@ void main() {
     test("Predicate impacts 2nd level objects when fetching object graph",
         () async {
       var q = new Query<Parent>();
-      q.joinOne((p) => p.child)
+      q.join(object: (p) => p.child)
         ..where.name = "C1"
-        ..joinOne((c) => c.toy)
-        ..joinMany((c) => c.vaccinations)
+        ..join(object: (c) => c.toy)
+        ..join(set: (c) => c.vaccinations)
             .sortBy((v) => v.vid, QuerySortOrder.ascending);
 
       var results = await q.fetch();
@@ -238,8 +238,8 @@ void main() {
     test("Predicate impacts 3rd level objects when fetching object graph",
         () async {
       var q = new Query<Parent>();
-      var childJoin = q.joinOne((p) => p.child)..joinOne((c) => c.toy);
-      childJoin.joinMany((c) => c.vaccinations)..where.kind = "V1";
+      var childJoin = q.join(object: (p) => p.child)..join(object: (c) => c.toy);
+      childJoin.join(set: (c) => c.vaccinations)..where.kind = "V1";
 
       var results = await q.fetch();
 
@@ -262,8 +262,8 @@ void main() {
         () async {
       var q = new Query<Parent>()..where.pid = 5;
 
-      var childJoin = q.joinOne((p) => p.child)..joinOne((c) => c.toy);
-      childJoin.joinMany((c) => c.vaccinations)..where.kind = "V1";
+      var childJoin = q.join(object: (p) => p.child)..join(object: (c) => c.toy);
+      childJoin.join(set: (c) => c.vaccinations)..where.kind = "V1";
       var results = await q.fetch();
       expect(results.length, 0);
     });
@@ -285,9 +285,9 @@ void main() {
         () async {
       var q = new Query<Parent>()..returningProperties((p) => [p.name]);
 
-      var childQuery = q.joinOne((p) => p.child)
+      var childQuery = q.join(object: (p) => p.child)
         ..returningProperties((c) => [c.name]);
-      childQuery.joinMany((c) => c.vaccinations)
+      childQuery.join(set: (c) => c.vaccinations)
         ..returningProperties((v) => [v.kind]);
 
       var parents = await q.fetch();
@@ -312,10 +312,10 @@ void main() {
     test("Can specify result keys for all joined objects", () async {
       var q = new Query<Parent>()..returningProperties((p) => [p.pid]);
 
-      var childQuery = q.joinOne((p) => p.child)
+      var childQuery = q.join(object: (p) => p.child)
         ..returningProperties((c) => [c.cid]);
 
-      childQuery.joinMany((c) => c.vaccinations)
+      childQuery.join(set: (c) => c.vaccinations)
         ..returningProperties((v) => [v.vid]);
 
       var parents = await q.fetch();
@@ -351,7 +351,7 @@ void main() {
     test("Objects returned in join are not the same instance", () async {
       var q = new Query<Parent>()
         ..where.pid = 1
-        ..joinOne((p) => p.child);
+        ..join(object: (p) => p.child);
 
       var o = await q.fetchOne();
       expect(identical(o.child.parent, o), false);
@@ -384,7 +384,7 @@ void main() {
       }
 
       q = new Query<Parent>();
-      q.joinOne((p) => p.child)..returningProperties((c) => [c.cid, c.toy]);
+      q.join(object: (p) => p.child)..returningProperties((c) => [c.cid, c.toy]);
 
       try {
         await q.fetchOne();
@@ -399,7 +399,7 @@ void main() {
 
     test("Including paging on a join fails", () async {
       var q = new Query<Parent>()
-        ..joinOne((p) => p.child)
+        ..join(object: (p) => p.child)
         ..pageBy((p) => p.pid, QuerySortOrder.ascending);
 
       try {

--- a/test/db/postgresql/many_to_many_fetch_test.dart
+++ b/test/db/postgresql/many_to_many_fetch_test.dart
@@ -35,7 +35,7 @@ void main() {
       var q = new Query<RootObject>()
         ..sortBy((r) => r.rid, QuerySortOrder.ascending);
 
-      q.joinMany((r) => r.join)..joinOne((r) => r.other);
+      q.join(set: (r) => r.join)..join(object: (r) => r.other);
       var results = await q.fetch();
       expect(
           results.map((r) => r.asMap()).toList(),
@@ -74,7 +74,7 @@ void main() {
       var q = new Query<OtherRootObject>()
         ..sortBy((o) => o.id, QuerySortOrder.ascending);
 
-      q.joinMany((r) => r.join)..joinOne((r) => r.root);
+      q.join(set: (r) => r.join)..join(object: (r) => r.root);
       var results = await q.fetch();
       expect(
           results.map((r) => r.asMap()).toList(),
@@ -112,8 +112,8 @@ void main() {
     test("Can join from join table", () async {
       var q = new Query<RootJoinObject>()
         ..sortBy((r) => r.id, QuerySortOrder.ascending)
-        ..joinOne((r) => r.other)
-        ..joinOne((r) => r.root);
+        ..join(object: (r) => r.other)
+        ..join(object: (r) => r.root);
 
       var results = await q.fetch();
       expect(
@@ -202,7 +202,7 @@ void main() {
     test("Can join by one relationship", () async {
       var q = new Query<Team>()..sortBy((t) => t.id, QuerySortOrder.ascending);
 
-      q.joinMany((t) => t.awayGames)..joinOne((g) => g.homeTeam);
+      q.join(set: (t) => t.awayGames)..join(object: (g) => g.homeTeam);
 
       var results = await q.fetch();
       expect(
@@ -248,7 +248,7 @@ void main() {
     test("Can join by other relationship", () async {
       var q = new Query<Team>()..sortBy((t) => t.id, QuerySortOrder.ascending);
 
-      q.joinMany((t) => t.homeGames)..joinOne((g) => g.awayTeam);
+      q.join(set: (t) => t.homeGames)..join(object: (g) => g.awayTeam);
       var results = await q.fetch();
 
       expect(
@@ -293,8 +293,8 @@ void main() {
 
     test("Can join from join table", () async {
       var q = new Query<Game>()
-        ..joinOne((g) => g.awayTeam)
-        ..joinOne((g) => g.homeTeam)
+        ..join(object: (g) => g.awayTeam)
+        ..join(object: (g) => g.homeTeam)
         ..sortBy((g) => g.id, QuerySortOrder.ascending);
       var results = await q.fetch();
 
@@ -332,7 +332,7 @@ void main() {
       try {
         var q = new Query<Team>();
 
-        q.joinMany((t) => t.homeGames)..joinOne((g) => g.homeTeam);
+        q.join(set: (t) => t.homeGames)..join(object: (g) => g.homeTeam);
         expect(true, false);
       } on QueryException catch (e) {
         expect(e.toString(), contains("Invalid cyclic"));
@@ -411,7 +411,7 @@ void main() {
         () async {
       try {
         var q = new Query<Team>();
-        q.joinMany((t) => t.awayGames)
+        q.join(set: (t) => t.awayGames)
           ..where.awayTeam.name = whereContainsString("Minn");
         await q.fetch();
 
@@ -426,7 +426,7 @@ void main() {
     test("Can filter returned nested objects by their values", () async {
       // 'All teams and the games they've played at Minnesota'
       var q = new Query<Team>();
-      q.joinMany((t) => t.awayGames)
+      q.join(set: (t) => t.awayGames)
         ..where.homeTeam.name = whereContainsString("Minn");
       var results = await q.fetch();
 

--- a/test/db/postgresql/matcher_test.dart
+++ b/test/db/postgresql/matcher_test.dart
@@ -178,7 +178,7 @@ void main() {
   });
 
   test("whereAnyMatch matcher", () async {
-    var q = new Query<TestModel>()..joinOne((t) => t.inner);
+    var q = new Query<TestModel>()..join(object: (t) => t.inner);
     var results = await q.fetch();
     expect(results.length, 6);
 

--- a/test/db/postgresql/tiered_where_test.dart
+++ b/test/db/postgresql/tiered_where_test.dart
@@ -46,7 +46,7 @@ void main() {
     });
 
     test("Objects have default values when explicitly joined", () async {
-      var q = new Query<RootObject>()..joinOne((r) => r.child);
+      var q = new Query<RootObject>()..join(object: (r) => r.child);
       var results = await q.fetch();
 
       for (var r in results) {
@@ -75,7 +75,7 @@ void main() {
         () async {
       var q = new Query<RootObject>();
 
-      q.joinOne((r) => r.child)..where.grandChild.gid = whereGreaterThan(1);
+      q.join(object: (r) => r.child)..where.grandChild.gid = whereGreaterThan(1);
       var results = await q.fetch();
 
       for (var r in results) {
@@ -103,7 +103,7 @@ void main() {
     test("Nested explicit joins return values for all tables", () async {
       var q = new Query<RootObject>();
 
-      q.joinOne((r) => r.child)..joinOne((c) => c.grandChild);
+      q.join(object: (r) => r.child)..join(object: (c) => c.grandChild);
 
       var results = await q.fetch();
       for (var r in results) {
@@ -143,7 +143,7 @@ void main() {
         () async {
       var q = new Query<RootObject>()..returningProperties((r) => [r.rid]);
 
-      q.joinOne((r) => r.child)..returningProperties((c) => [c.cid]);
+      q.join(object: (r) => r.child)..returningProperties((c) => [c.cid]);
 
       var results = await q.fetch();
       for (var r in results) {
@@ -163,9 +163,9 @@ void main() {
         () async {
       var q = new Query<RootObject>()..returningProperties((r) => [r.rid]);
 
-      var cq = q.joinOne((r) => r.child)..returningProperties((c) => [c.cid]);
+      var cq = q.join(object: (r) => r.child)..returningProperties((c) => [c.cid]);
 
-      cq.joinOne((c) => c.grandChild)..returningProperties((g) => [g.gid]);
+      cq.join(object: (c) => c.grandChild)..returningProperties((g) => [g.gid]);
 
       var results = await q.fetch();
       for (var r in results) {
@@ -201,7 +201,7 @@ void main() {
     test("Explicitly joining related object", () async {
       var q = new Query<RootObject>()..where.rid = whereGreaterThan(1);
 
-      q.joinMany((r) => r.children)..where.cid = whereGreaterThan(5);
+      q.join(set: (r) => r.children)..where.cid = whereGreaterThan(5);
 
       var results = await q.fetch();
       expect(results.length, rootObjects.length - 1);
@@ -218,7 +218,7 @@ void main() {
 
     test("Explicitly joining related objects, nested implicit join", () async {
       var q = new Query<RootObject>()..where.rid = whereEqualTo(1);
-      q.joinMany((r) => r.children)
+      q.join(set: (r) => r.children)
         ..where.grandChildren.haveAtLeastOneWhere.gid = whereEqualTo(5);
 
       var results = await q.fetch();
@@ -232,9 +232,9 @@ void main() {
         () async {
       var q = new Query<RootObject>()..where.rid = whereEqualTo(1);
 
-      var cq = q.joinMany((r) => r.children);
+      var cq = q.join(set: (r) => r.children);
 
-      cq.joinMany((c) => c.grandChildren)..where.gid = whereLessThan(6);
+      cq.join(set: (c) => c.grandChildren)..where.gid = whereLessThan(6);
 
       var results = await q.fetch();
       expect(results.length, 1);
@@ -285,7 +285,7 @@ void main() {
   group("With where clauses on child object", () {
     test("Explicit joins do not impact returned root objects", () async {
       var q = new Query<RootObject>();
-      q.joinOne((r) => r.child)..where.cid = whereEqualTo(1);
+      q.join(object: (r) => r.child)..where.cid = whereEqualTo(1);
       var results = await q.fetch();
 
       expect(results.length, rootObjects.length);
@@ -300,7 +300,7 @@ void main() {
         "Implicit join on child affects child object returned, but not root objects",
         () async {
       var q = new Query<RootObject>();
-      q.joinMany((r) => r.children)..where.grandChild.gid = whereEqualTo(4);
+      q.join(set: (r) => r.children)..where.grandChild.gid = whereEqualTo(4);
       var results = await q.fetch();
 
       expect(results.length, rootObjects.length);
@@ -315,7 +315,7 @@ void main() {
         "Where clause on child + implicit join to granchild can find overly identified object",
         () async {
       var q = new Query<RootObject>();
-      q.joinMany((r) => r.children)
+      q.join(set: (r) => r.children)
         ..where.cid = whereEqualTo(2)
         ..where.grandChildren.haveAtLeastOneWhere.gid = whereEqualTo(6);
       var results = await q.fetch();
@@ -333,7 +333,7 @@ void main() {
         "Where clause on child + implicit join to grandchild returns empty if conditions conflict",
         () async {
       var q = new Query<RootObject>();
-      q.joinMany((r) => r.children)
+      q.join(set: (r) => r.children)
         ..where.cid = whereEqualTo(4)
         ..where.grandChildren.haveAtLeastOneWhere.gid = whereEqualTo(6);
       var results = await q.fetch();
@@ -346,7 +346,7 @@ void main() {
         "Where clause on child + implicit join to grandchild returns appropriate matches",
         () async {
       var q = new Query<RootObject>();
-      q.joinMany((r) => r.children)
+      q.join(set: (r) => r.children)
         ..where.cid = whereLessThanEqualTo(5)
         ..where.grandChildren.haveAtLeastOneWhere.gid = whereGreaterThan(5);
       var results = await q.fetch();
@@ -369,8 +369,8 @@ void main() {
         "Explicit join on child and grandchild, retains all root objects and child objects",
         () async {
       var q = new Query<RootObject>();
-      var cq = q.joinMany((r) => r.children);
-      cq.joinMany((c) => c.grandChildren)..where.gid = whereEqualTo(5);
+      var cq = q.join(set: (r) => r.children);
+      cq.join(set: (c) => c.grandChildren)..where.gid = whereEqualTo(5);
 
       var results = await q.fetch();
 
@@ -414,7 +414,7 @@ void main() {
         () async {
       var q = new Query<RootObject>()..where.child.value1 = whereGreaterThan(0);
 
-      q.joinOne((r) => r.child)..returningProperties((c) => [c.cid]);
+      q.join(object: (r) => r.child)..returningProperties((c) => [c.cid]);
 
       var results = await q.fetch();
       for (var r in results) {
@@ -434,7 +434,7 @@ void main() {
       var q = new Query<RootObject>()
         ..where.children.haveAtLeastOneWhere.cid = whereGreaterThan(5);
 
-      q.joinMany((r) => r.children)..where.cid = whereLessThan(10);
+      q.join(set: (r) => r.children)..where.cid = whereLessThan(10);
 
       var results = await q.fetch();
 
@@ -518,9 +518,9 @@ void main() {
     test("Join on on two properties with same entity type", () async {
       var q = new Query<RootObject>();
 
-      q.joinMany((r) => r.children)..where.cid = whereGreaterThan(3);
+      q.join(set: (r) => r.children)..where.cid = whereGreaterThan(3);
 
-      q.joinOne((r) => r.child)..where.cid = whereEqualTo(1);
+      q.join(object: (r) => r.child)..where.cid = whereEqualTo(1);
       var results = await q.fetch();
 
       expect(results.length, rootObjects.length);

--- a/tool/coverage.dart
+++ b/tool/coverage.dart
@@ -18,15 +18,16 @@ Future main(List<String> args) async {
     outputDir.createSync();
 
     var count = 0;
-    for (var file in testFiles) {
+    await Future.forEach(testFiles, (File file) async {
       print("Running ${file.uri.pathSegments.last} (${count + 1} of ${testFiles.length})...");
       var coverage = await runAndCollect(file.path, outputSink: stdout);
+      print("All coverage collected for ${file.uri.pathSegments.last}.");
 
       var coverageJSONFile = new File.fromUri(tempDir.uri.resolve("$count.coverage.json"));
       coverageJSONFile.writeAsStringSync(JSON.encode(coverage));
 
       count ++;
-    }
+    });
 
     print("Formatting coverage...");
     var hitmap = await parseCoverage(tempDir


### PR DESCRIPTION
This deprecates joinOne and joinMany. To update in existing projects, do a find and replace regex in IntelliJ:

Find: joinOne\\(\\(([a-zA-Z]*)
Replace: join(object: ($1

Find: joinMany\\(\\(([a-zA-Z]*)
Replace: join(set: ($1