### PR TITLE
Remove slowdown from capturing stack traces

### DIFF
--- a/lib/src/application/application.dart
+++ b/lib/src/application/application.dart
@@ -102,7 +102,7 @@ class Application<RequestSinkType extends RequestSink> {
       try {
         var sink = requestSinkType
             .newInstance(new Symbol(""), [configuration]).reflectee;
-        server = new ApplicationServer(configuration, 1);
+        server = new ApplicationServer(configuration, 1, captureStack: true);
 
         await server.start(sink);
       } catch (e) {

--- a/lib/src/application/application_server.dart
+++ b/lib/src/application/application_server.dart
@@ -17,7 +17,7 @@ class ApplicationServer {
   /// Creates an instance of this type.
   ///
   /// You should not need to invoke this method directly.
-  ApplicationServer(this.configuration, this.identifier, {this.captureStack});
+  ApplicationServer(this.configuration, this.identifier, {this.captureStack: false});
 
   /// The configuration this instance used to start its [sink].
   ApplicationConfiguration configuration;
@@ -31,7 +31,7 @@ class ApplicationServer {
   /// Used during debugging to capture the stacktrace better for asynchronous calls.
   ///
   /// Defaults to false.
-  bool captureStack = false;
+  bool captureStack;
 
   /// Target for sending messages to other [RequestSink] isolates.
   ///

--- a/lib/src/application/application_server.dart
+++ b/lib/src/application/application_server.dart
@@ -17,7 +17,7 @@ class ApplicationServer {
   /// Creates an instance of this type.
   ///
   /// You should not need to invoke this method directly.
-  ApplicationServer(this.configuration, this.identifier);
+  ApplicationServer(this.configuration, this.identifier, {this.captureStack});
 
   /// The configuration this instance used to start its [sink].
   ApplicationConfiguration configuration;
@@ -27,6 +27,11 @@ class ApplicationServer {
 
   /// The instance of [RequestSink] serving requests.
   RequestSink sink;
+
+  /// Used during debugging to capture the stacktrace better for asynchronous calls.
+  ///
+  /// Defaults to false.
+  bool captureStack = false;
 
   /// Target for sending messages to other [RequestSink] isolates.
   ///
@@ -104,18 +109,21 @@ class ApplicationServer {
     await sink.willOpen();
 
     logger.fine("ApplicationServer($identifier).didOpen start listening");
-    server.map((baseReq) => new Request(baseReq)).listen(_dispatchRequest);
+    if (captureStack) {
+      server.map((baseReq) => new Request(baseReq)).listen((req) {
+        Chain.capture(() {
+          sink.receive(req);
+        });
+      });
+    } else {
+      server.map((baseReq) => new Request(baseReq)).listen(sink.receive);
+    }
+
     sink.didOpen();
     logger.info("Server aqueduct/$identifier started.");
   }
 
   void sendApplicationEvent(dynamic event) {
     // By default, do nothing
-  }
-
-  void _dispatchRequest(Request request) {
-    Chain.capture(() {
-      sink.receive(request);
-    });
   }
 }


### PR DESCRIPTION
Only capture async stack traces during debugging (runOnMainIsolate).