### PR TITLE
Minor fixes to ManagedObject

### DIFF
--- a/lib/src/db/managed/object.dart
+++ b/lib/src/db/managed/object.dart
@@ -208,6 +208,10 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
     var mirror = reflect(this);
 
     keyValues.forEach((k, v) {
+      if (_isPropertyPrivate(k)) {
+        return;
+      }
+
       var property = entity.properties[k];
 
       if (property == null) {
@@ -257,7 +261,9 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
     var outputMap = <String, dynamic>{};
 
     backing.valueMap.forEach((k, v) {
-      outputMap[k] = entity.properties[k].convertToPrimitiveValue(v);
+      if (!_isPropertyPrivate(k)) {
+        outputMap[k] = entity.properties[k].convertToPrimitiveValue(v);
+      }
     });
 
     var reflectedThis = reflect(this);
@@ -272,4 +278,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
 
     return outputMap;
   }
+
+  static bool _isPropertyPrivate(String propertyName) =>
+      propertyName.startsWith("_");
 }

--- a/lib/src/db/managed/property_description.dart
+++ b/lib/src/db/managed/property_description.dart
@@ -368,9 +368,13 @@ class ManagedRelationshipDescription extends ManagedPropertyDescription {
           .map((ManagedObject innerValue) => innerValue.asMap())
           .toList();
     } else if (value is ManagedObject) {
-      if (relationshipType == ManagedRelationshipType.belongsTo) {
+      // If we're only fetching the foreign key, don't do a full asMap
+      if (relationshipType == ManagedRelationshipType.belongsTo
+      && value.backingMap.length == 1
+      && value.backingMap.containsKey(destinationEntity.primaryKey)) {
         return {destinationEntity.primaryKey: value[destinationEntity.primaryKey]};
       }
+
       return value.asMap();
     } else if (value == null) {
       return null;

--- a/lib/src/db/managed/property_description.dart
+++ b/lib/src/db/managed/property_description.dart
@@ -368,6 +368,9 @@ class ManagedRelationshipDescription extends ManagedPropertyDescription {
           .map((ManagedObject innerValue) => innerValue.asMap())
           .toList();
     } else if (value is ManagedObject) {
+      if (relationshipType == ManagedRelationshipType.belongsTo) {
+        return {destinationEntity.primaryKey: value[destinationEntity.primaryKey]};
+      }
       return value.asMap();
     } else if (value == null) {
       return null;

--- a/test/db/model_test.dart
+++ b/test/db/model_test.dart
@@ -490,6 +490,23 @@ void main() {
       expect(p.public, "x");
       expect(p._private, "x");
     });
+
+    test("Private fields are omitted from asMap()", () {
+      var p = new PrivateField()
+        ..public = "x";
+      expect(p.asMap(), {"public": "x"});
+
+      p = new PrivateField()
+        .._private = "x";
+      expect(p.asMap(), {"public": "x"});
+    });
+
+    test("Private fields cannot be set in readFromMap()", () {
+      var p = new PrivateField();
+      p.readFromMap({"_private": "x"});
+      expect(p.public, isNull);
+      expect(p._private, isNull);
+    });
   });
 }
 
@@ -694,10 +711,12 @@ class _TransientTypeTest {
 }
 
 class PrivateField extends ManagedObject<_PrivateField> implements _PrivateField {
+  @managedTransientInputAttribute
   set public(String p) {
     _private = p;
   }
 
+  @managedTransientOutputAttribute
   String get public => _private;
 }
 class _PrivateField {

--- a/test/db/model_test.dart
+++ b/test/db/model_test.dart
@@ -6,8 +6,16 @@ import '../helpers.dart';
 void main() {
   setUpAll(() {
     var ps = new DefaultPersistentStore();
-    ManagedDataModel dm =
-        new ManagedDataModel([TransientTest, TransientTypeTest, User, Post, PrivateField, EnumObject]);
+    ManagedDataModel dm = new ManagedDataModel([
+      TransientTest,
+      TransientTypeTest,
+      User,
+      Post,
+      PrivateField,
+      EnumObject,
+      TransientBelongsTo,
+      TransientOwner
+    ]);
     var _ = new ManagedContext(dm, ps);
   });
 
@@ -436,6 +444,13 @@ void main() {
     expect(t.asMap().containsKey("notAnAttribute"), false);
   });
 
+  test("Omit transient properties in asMap when object is a foreign key reference", () {
+    var b = new TransientBelongsTo()
+        ..id = 1
+        ..owner = (new TransientOwner()..id = 1);
+    expect(b.asMap(), {"id": 1, "owner": {"id": 1}});
+  });
+
   group("Persistent enum fields", () {
     test("Can assign/read enum value to persistent property", () {
       var e = new EnumObject();
@@ -736,4 +751,25 @@ class _EnumObject {
 
 enum EnumValues {
   abcd, efgh, other18
+}
+
+class TransientOwner extends ManagedObject<_TransientOwner> implements _TransientOwner {
+  @managedTransientOutputAttribute
+  int v = 2;
+}
+class _TransientOwner {
+  @managedPrimaryKey
+  int id;
+
+  TransientBelongsTo t;
+}
+
+class TransientBelongsTo extends ManagedObject<_TransientBelongsTo> implements _TransientBelongsTo {
+}
+class _TransientBelongsTo {
+  @managedPrimaryKey
+  int id;
+
+  @ManagedRelationship(#t)
+  TransientOwner owner;
 }


### PR DESCRIPTION
- Private persistent properties aren't accessible thru HTTPSerializable methods
- asMap that emits foreign keys as objects (e.g., `{'id': 1'}`) no longer emits transient values