### PR TITLE
Add arbitrary HTTP method for test client.

### DIFF
--- a/lib/src/utilities/test_client.dart
+++ b/lib/src/utilities/test_client.dart
@@ -267,6 +267,14 @@ class TestRequest {
     return _executeRequest("POST");
   }
 
+  /// Executes this request with the given HTTP verb.
+  ///
+  /// The returned [Future] will complete with an instance of [TestResponse] which can be used
+  /// in test expectations using [hasResponse] or [hasStatus].
+  Future<TestResponse> method(String verb) {
+    return _executeRequest(verb);
+  }
+
   /// Executes this request with HTTP PUT.
   ///
   /// The returned [Future] will complete with an instance of [TestResponse] which can be used

--- a/test/utilities/test_client_test.dart
+++ b/test/utilities/test_client_test.dart
@@ -125,6 +125,15 @@ void main() {
 
       expect(
           (await (defaultTestClient.request("/foo")..json = {"foo": "bar"})
+              .method("PATCH")) is TestResponse,
+          true);
+      msg = await server.next();
+      expect(msg.path, "/foo");
+      expect(msg.method, "PATCH");
+      expect(msg.body, '{"foo":"bar"}');
+
+      expect(
+          (await (defaultTestClient.request("/foo")..json = {"foo": "bar"})
               .put()) is TestResponse,
           true);
       msg = await server.next();


### PR DESCRIPTION
Adds an orthogonal method, `method(String verb)` to test client, to match HTTP Controllers such as `@HTTPMethod(String verb)`.  I was testing an endpoint with PATCH and found that only the main verbs were supported.  It would be nice to be able to test any verbs.