### PR TITLE
Test library now uses HTTPBodyDecoder/HTTPCodecRepository

### DIFF
--- a/lib/src/http/body_decoder.dart
+++ b/lib/src/http/body_decoder.dart
@@ -6,16 +6,15 @@ import 'http.dart';
 ///
 /// See [HTTPRequestBody] for a concrete implementation.
 abstract class HTTPBodyDecoder {
+  HTTPBodyDecoder(this.bytes);
+
   /// The stream of bytes to decode.
-  ///
-  /// Concrete implementations provide the bytes to be decoded.
-  Stream<List<int>> get bytes;
+  final Stream<List<int>> bytes;
 
   /// Determines how [bytes] get decoded.
   ///
   /// A decoder is chosen from [HTTPCodecRepository] according to this value.
   ContentType get contentType;
-
 
   /// Whether or not [bytes] is empty.
   ///

--- a/lib/src/http/body_decoder.dart
+++ b/lib/src/http/body_decoder.dart
@@ -2,45 +2,44 @@ import 'dart:async';
 import 'dart:io';
 import 'http.dart';
 
-/// Instances of this class decode HTTP request bodies according to their content type.
+/// Decodes [bytes] according to [contentType].
 ///
-/// Every instance of [Request] has a [Request.body] property of this type. [HTTPController]s automatically decode
-/// [Request.body] prior to invoking a responder method. Other [RequestController]s should use [decodedData]
-/// or one of the typed methods ([asList], [asMap], [decodeAsMap], [decodeAsList]) to decode HTTP body data.
-///
-/// Default decoders are available for 'application/json', 'application/x-www-form-urlencoded' and 'text/*' content types.
-class HTTPRequestBody {
-  /// Creates a new instance of this type.
+/// See [HTTPRequestBody] for a concrete implementation.
+abstract class HTTPBodyDecoder {
+  /// The stream of bytes to decode.
   ///
-  /// Instances of this type decode [request]'s body based on its content-type.
-  ///
-  /// See [HTTPCodecRepository] for more information about how data is decoded.
-  ///
-  /// Decoded data is cached the after it is decoded.
-  HTTPRequestBody(HttpRequest request) : this._request = request {
-    _hasContent = (request.headers.contentLength ?? 0) > 0
-               || request.headers.chunkedTransferEncoding;
-  }
+  /// Concrete implementations provide the bytes to be decoded.
+  Stream<List<int>> get bytes;
 
-  final HttpRequest _request;
-  List<dynamic> _decodedData;
+  /// Determines how [bytes] get decoded.
+  ///
+  /// A decoder is chosen from [HTTPCodecRepository] according to this value.
+  ContentType get contentType;
 
-  /// Whether or not to keep the raw bytes of a request body.
+
+  /// Whether or not [bytes] is empty.
   ///
-  /// By default, this flag is false and once [decodedData] has been invoked, the raw bytes of the request body
-  /// are lost and only the decoded value remains.
+  /// No decoding will occur if this flag is true.
   ///
-  /// If this flag is set to true, the encoded request body bytes are stored and accessible with [asBytes] (or [decodeAsBytes]).
+  /// Concrete implementations provide an implementation for this method without inspecting
+  /// [bytes].
+  bool get isEmpty;
+
+  /// Whether or not [bytes] are available as a list after decoding has occurred.
+  ///
+  /// By default, invoking [decodedData] (or one of the methods that invokes it) will discard
+  /// the initial bytes and only keep the decoded value. Setting this flag to false
+  /// will keep a copy of the original bytes, accessible through [asBytes].
   bool retainOriginalBytes = false;
-  List<int> _bytes;
 
-  /// Whether or not the data has been decoded yet.
+  /// Whether or not [bytes] have been decoded yet.
   ///
-  /// True when data has already been decoded.
-  ///
-  /// If this body has no content, this value is true.
+  /// If [isEmpty] is true, this value is always true.
   bool get hasBeenDecoded => _decodedData != null || isEmpty;
 
+  /// The type of data [bytes] was decoded into.
+  ///
+  /// Will throw an exception if [bytes] have not been decoded yet.
   Type get decodedType {
     if (!hasBeenDecoded) {
       throw new HTTPBodyDecoderException("decodedType invoked prior to decoding data");
@@ -49,56 +48,46 @@ class HTTPRequestBody {
     return _decodedData.first.runtimeType;
   }
 
-  /// Whether or not this body is empty or not.
-  ///
-  /// If content-length header is greater than 0.
-  bool get isEmpty => !_hasContent;
-  bool _hasContent;
+  List<dynamic> _decodedData;
+  List<int> _bytes;
 
   /// Returns decoded data, decoding it if not already decoded.
   ///
-  /// This is the raw access method to a request body's decoded data. It is preferable
+  /// This is the raw access method to an HTTP body's decoded data. It is preferable
   /// to use methods such as [decodeAsMap], [decodeAsList], and [decodeAsString], all of which
   /// invoke this method.
   ///
-  /// The first time this method is invoked, this instance's contents are
-  /// read in full and decoded according to the content-type of its request. The decoded data
-  /// is stored in this instance so that subsequent access will
+  /// The first time this method is invoked, [bytes] is read in full and decoded according to [contentType].
+  /// The decoded data is stored in this instance so that subsequent access will
   /// return the cached decoded data instead of decoding it again.
   ///
-  /// If the body of the request is empty, this method will return null and no decoding is attempted.
+  /// If the body is empty, this method will return null and no decoding is attempted.
   ///
-  /// The return type of this method depends on the codec selected from [HTTPCodecRepository], determined
-  /// by the content-type of the request.
+  /// The elements of the return value depend on the codec selected from [HTTPCodecRepository], determined
+  /// by [contentType]. There are effectively three different scenarios:
   ///
   /// If there is no codec in [HTTPCodecRepository] for the content type of the
-  /// request body being decoded, this method returns the unaltered list of bytes directly
+  /// request body being decoded, this method returns the flattened list of bytes directly
   /// from the request body as [List<int>].
   ///
   /// If the selected codec produces [String] data (for example, any `text` content-type), the return value
-  /// of this method is a [List<String>]. The entire decoded request body is obtained by concatenating
-  /// each element of this list. It is preferable to use [decodeAsString] which automatically does this concatenation.
+  /// is a list of strings that, when concatenated, are the full [String] body. It is preferable to use
+  /// [decodeAsString] which automatically does this concatenation.
   ///
-  /// For `application/json` and `application/x-www-form-urlencoded` data, the return value is a [List<Map>] that contains
-  /// exactly one object - the decoded JSON or form object as a Map. Prefer to use [decodeAsMap], which returns
-  /// the single object from this list. Note that if the request body is a JSON list, the return value of this type
-  /// is [List<List<Map<String, dynamic>>>], where the outer list contains exactly one object: the decoded JSON list.
-  ///
-  /// For custom codecs, the return type of this method is determined by the output of that codec. Note that
-  /// the reason [String] data must be concatenated is that body data may be chunked and each chunk is decoded independently.
-  /// Whereas a JSON or form data must be read in full before the conversion is complete and so its codec only emits a single,
-  /// complete object.
+  /// For most [contentType]s, the return value is a single element [List] containing the decoded body object. For example,
+  /// this method return a [List] with a single [Map] when the body is a JSON object. If the body is a list of JSON objects,
+  /// this method returns a [List] with a single [List] element that contains the JSON objects. It is preferable to use
+  /// [decodeAsMap] or [decodeAsList] which unboxes the outer [List] returned by this method.
   Future<List<dynamic>> get decodedData async {
-    // Note that gzip decompression will automatically be applied by dart:io.
     if (!hasBeenDecoded) {
       if (_decodedData == null) {
-        if (_request.headers.contentType != null) {
+        if (contentType != null) {
           var codec = HTTPCodecRepository.defaultInstance
-              .codecForContentType(_request.headers.contentType);
+              .codecForContentType(contentType);
           if (codec != null) {
-            Stream<List<int>> stream = _request;
+            Stream<List<int>> stream = bytes;
             if (retainOriginalBytes) {
-              _bytes = await _readBytes(_request);
+              _bytes = await _readBytes(bytes);
               stream = new Stream.fromIterable([_bytes]);
             }
 
@@ -108,10 +97,10 @@ class HTTPRequestBody {
             });
             _decodedData = await bodyStream.toList();
           } else {
-            _decodedData = await _readBytes(_request);
+            _decodedData = await _readBytes(bytes);
           }
         } else {
-          _decodedData = await _readBytes(_request);
+          _decodedData = await _readBytes(bytes);
         }
       }
     }

--- a/lib/src/http/http.dart
+++ b/lib/src/http/http.dart
@@ -1,3 +1,4 @@
+export 'request_body.dart';
 export 'body_decoder.dart';
 export 'cache_policy.dart';
 export 'cors_policy.dart';

--- a/lib/src/http/request_body.dart
+++ b/lib/src/http/request_body.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'http.dart';
 import 'body_decoder.dart';
@@ -10,7 +9,7 @@ import 'body_decoder.dart';
 /// or one of the typed methods ([asList], [asMap], [decodeAsMap], [decodeAsList]) to decode HTTP body data.
 ///
 /// Default decoders are available for 'application/json', 'application/x-www-form-urlencoded' and 'text/*' content types.
-class HTTPRequestBody extends Object with HTTPBodyDecoder {
+class HTTPRequestBody extends HTTPBodyDecoder {
   /// Creates a new instance of this type.
   ///
   /// Instances of this type decode [request]'s body based on its content-type.
@@ -18,16 +17,15 @@ class HTTPRequestBody extends Object with HTTPBodyDecoder {
   /// See [HTTPCodecRepository] for more information about how data is decoded.
   ///
   /// Decoded data is cached the after it is decoded.
-  HTTPRequestBody(HttpRequest request) : this._request = request {
+  HTTPRequestBody(HttpRequest request)
+      : this._request = request,
+        super(request) {
     _hasContent = (request.headers.contentLength ?? 0) > 0
         || request.headers.chunkedTransferEncoding;
   }
 
   final HttpRequest _request;
   bool _hasContent;
-
-  @override
-  Stream<List<int>> get bytes => _request;
 
   @override
   ContentType get contentType => _request.headers.contentType;

--- a/lib/src/http/request_body.dart
+++ b/lib/src/http/request_body.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+import 'dart:io';
+import 'http.dart';
+import 'body_decoder.dart';
+
+/// Instances of this class decode HTTP request bodies according to their content type.
+///
+/// Every instance of [Request] has a [Request.body] property of this type. [HTTPController]s automatically decode
+/// [Request.body] prior to invoking a responder method. Other [RequestController]s should use [decodedData]
+/// or one of the typed methods ([asList], [asMap], [decodeAsMap], [decodeAsList]) to decode HTTP body data.
+///
+/// Default decoders are available for 'application/json', 'application/x-www-form-urlencoded' and 'text/*' content types.
+class HTTPRequestBody extends Object with HTTPBodyDecoder {
+  /// Creates a new instance of this type.
+  ///
+  /// Instances of this type decode [request]'s body based on its content-type.
+  ///
+  /// See [HTTPCodecRepository] for more information about how data is decoded.
+  ///
+  /// Decoded data is cached the after it is decoded.
+  HTTPRequestBody(HttpRequest request) : this._request = request {
+    _hasContent = (request.headers.contentLength ?? 0) > 0
+        || request.headers.chunkedTransferEncoding;
+  }
+
+  final HttpRequest _request;
+  bool _hasContent;
+
+  @override
+  Stream<List<int>> get bytes => _request;
+
+  @override
+  ContentType get contentType => _request.headers.contentType;
+
+  @override
+  bool get isEmpty => !_hasContent;
+}

--- a/lib/src/testing/body_matcher.dart
+++ b/lib/src/testing/body_matcher.dart
@@ -1,5 +1,4 @@
 import 'package:matcher/matcher.dart';
-import 'client.dart';
 import 'matchers.dart';
 
 /// A test matcher that matches an HTTP response body.

--- a/lib/src/testing/client.dart
+++ b/lib/src/testing/client.dart
@@ -2,6 +2,7 @@ library aqueduct.test.client;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:mirrors';
 import 'dart:io';
 import 'package:aqueduct/aqueduct.dart';
 import '../application/application.dart';

--- a/lib/src/testing/client.dart
+++ b/lib/src/testing/client.dart
@@ -3,6 +3,7 @@ library aqueduct.test.client;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'package:aqueduct/aqueduct.dart';
 import '../application/application.dart';
 import '../application/application_configuration.dart';
 import 'matchers.dart';

--- a/lib/src/testing/header_matcher.dart
+++ b/lib/src/testing/header_matcher.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
 import 'package:matcher/matcher.dart';
-import 'client.dart';
 import 'partial_matcher.dart';
-import 'matchers.dart';
 import 'http_value_wrapper.dart';
 
 class HTTPHeaderMatcher extends Matcher {

--- a/lib/src/testing/matchers.dart
+++ b/lib/src/testing/matchers.dart
@@ -219,9 +219,9 @@ Matcher hasResponse(int statusCode, dynamic bodyMatcher,
       (bodyMatcher != null ? new HTTPBodyMatcher(bodyMatcher) : null));
 }
 
-/// Short-hand for [hasResponse] that returns [response].
+/// Short-hand for [expect] and [hasResponse] that returns [response].
 ///
-/// This convenience method runs an expectation on [response] with [hasResponse], that is:
+/// This convenience method runs an expectation on [response] using [hasResponse] built from [statusCode], [body], and [headers], that is:
 ///
 ///         expect(response, hasResponse(statusCode, body, headers: headers));
 ///

--- a/lib/src/testing/request.dart
+++ b/lib/src/testing/request.dart
@@ -27,11 +27,23 @@ class TestRequest {
 
   /// The HTTP request body.
   ///
-  /// Sets the body directly. Must be encoded according to [contentType].
+  /// Sets the body of this instance directly.
   ///
-  /// Prefer to use [setBody], [json] or [formData]; these methods encode
-  /// a body object, set this value and set [contentType].
-  List<int> body;
+  /// Prior to execution, this property will be encoded according to its [contentType] and [HTTPCodecRepository].
+  /// If [encodeBody] is false, this must be a [List<int>].
+  ///
+  /// Prefer to use [setBody], [json] or [formData] which set this property and [contentType]
+  /// at the same time.
+  ///
+  /// Note: for backwards compatibility, if [body] is a [String] is encoded
+  /// as UTF8 bytes by default and no codec is used.
+  dynamic body;
+
+  /// Whether or not [body] should be encoded according to [contentType].
+  ///
+  /// Defaults to true. When true, [body] will automatically be encoded by selecting a codec from
+  /// [HTTPCodecRepository] by [contentType]. If false, [body] must be a [List<int>].
+  bool encodeBody = true;
 
   /// Query parameters to add to the request.
   ///
@@ -105,10 +117,13 @@ class TestRequest {
         HttpHeaders.ACCEPT, contentTypes.map((ct) => ct.toString()).join(","));
   }
 
-
+  /// Sets the [body] and [contentType].
+  ///
+  /// On execution, [body] will be encoded according to [contentType]. [contentType]
+  /// defaults to [ContentType.JSON].
   void setBody(dynamic body, {ContentType contentType}) {
     this.contentType = contentType ?? ContentType.JSON;
-
+    this.body = body;
   }
 
   /// JSON encodes a serialized value into [body] and sets [contentType].
@@ -126,10 +141,6 @@ class TestRequest {
   /// a [Map<String, String>] . The [contentType] will be set to "application/x-www-form-urlencoded".
   set formData(Map<String, String> args) {
     setBody(args, contentType: new ContentType("application", "x-www-form-urlencoded", charset: "utf-8"));
-//    body = args.keys
-//        .map((key) => "$key=${Uri.encodeQueryComponent(args[key])}")
-//        .join("&");
-//    contentType = new ContentType("application", "x-www-form-urlencoded");
   }
 
   /// Adds a header to this request.
@@ -185,14 +196,22 @@ class TestRequest {
 
     if (body != null) {
       request.headers.contentType = contentType;
-      request.headers.contentLength = body.length;
-      request.add(body);
+      var bytes;
+      if (body is String) {
+        bytes = UTF8.encode(body);
+      } else {
+        bytes = _bodyBytes(body);
+      }
+      request.headers.contentLength = bytes.length;
+      request.add(bytes);
     }
 
     var requestResponse = await request.close();
 
     var response = new TestResponse._(requestResponse);
-    await response._decodeBody();
+
+    // Trigger body to be decoded
+    await response.bodyDecoder.decodedData;
 
     return response;
   }

--- a/lib/src/testing/response.dart
+++ b/lib/src/testing/response.dart
@@ -94,7 +94,7 @@ class TestResponse {
 }
 
 /// Instances of these type represent the body of a [TestResponse].
-class TestResponseBody extends Object with HTTPBodyDecoder {
+class TestResponseBody extends HTTPBodyDecoder {
   /// Creates a new instance of this type.
   ///
   /// Instances of this type decode [response]'s body based on its content-type.
@@ -102,16 +102,15 @@ class TestResponseBody extends Object with HTTPBodyDecoder {
   /// See [HTTPCodecRepository] for more information about how data is decoded.
   ///
   /// Decoded data is cached the after it is decoded.
-  TestResponseBody(HttpClientResponse response) : this._response = response {
+  TestResponseBody(HttpClientResponse response)
+      : this._response = response,
+        super(response) {
     _hasContent = (response.headers.contentLength ?? 0) > 0
         || response.headers.chunkedTransferEncoding;
   }
 
   final HttpClientResponse _response;
   bool _hasContent;
-
-  @override
-  Stream<List<int>> get bytes => _response;
 
   @override
   ContentType get contentType => _response.headers.contentType;

--- a/lib/src/testing/response.dart
+++ b/lib/src/testing/response.dart
@@ -10,6 +10,11 @@ class TestResponse {
     : bodyDecoder = new TestResponseBody(_innerResponse);
 
   final HttpClientResponse _innerResponse;
+
+  /// HTTP Body of this instance,
+  ///
+  /// Use this property to retrieve the body of this request. This property behaves exactly like
+  /// [Request.body] and is automatically decoded before this instance becomes available.
   final TestResponseBody bodyDecoder;
 
   /// The HTTP response body decoded according to its Content-Type.

--- a/lib/src/testing/response.dart
+++ b/lib/src/testing/response.dart
@@ -1,9 +1,10 @@
 part of aqueduct.test.client;
 
-/// Instances of this type represent the response from executing a [TestRequest].
+/// Instances are HTTP responses returned from [TestClient].
 ///
-/// This class is used to create test expectations on responses from your application code. See also [hasStatus] and [hasResponse].
-/// Do not create instances of this class manually - see [TestRequest] for more details.
+/// Instances are created when invoking an execution method with a [TestClient].
+///
+/// See methods like [expectResponse], [hasResponse] and [hasStatus] for usage.
 class TestResponse {
   TestResponse._(this._innerResponse);
 

--- a/lib/src/utilities/resource_registry.dart
+++ b/lib/src/utilities/resource_registry.dart
@@ -10,7 +10,7 @@ import '../db/persistent_store/persistent_store.dart';
 /// When shutdown of an application occurs, the registered objects are closed, thus releasing the resource they consume
 /// that prevent the isolate from shutting down.
 ///
-/// There is one registry per isolate. The order in which registrations are shut down is undefined. [release] triggers shutdown
+/// There is one registry per isolate. The order in which registrations are shut down is undefined. [close] triggers shutdown
 /// and is automatically invoked by [Application.stop].
 ///
 /// Built-in Aqueduct types that open a stream, like [PersistentStore], automatically register themselves
@@ -21,7 +21,7 @@ class ServiceRegistry {
 
   static List<_ServiceRegistration> _registrations = [];
 
-  /// Adds an object to the registry, registered objects are closed when [release] is invoked.
+  /// Adds an object to the registry, registered objects are closed when [close] is invoked.
   ///
   /// When [close] is invoked on this instance, [onClose] will be invoked with [object] and [object] will be removed.
   /// This method returns [object]. This allows for concise registration and allocation:

--- a/test/auth/auth_controller_test.dart
+++ b/test/auth/auth_controller_test.dart
@@ -132,7 +132,7 @@ void main() {
             "cache-control": "no-store",
             "pragma": "no-cache",
             "content-encoding": "gzip",
-            "content-length": asNumber(greaterThan(0)),
+            "content-length": greaterThan(0),
             "x-frame-options": isString,
             "x-xss-protection": isString,
             "x-content-type-options": isString
@@ -161,7 +161,7 @@ void main() {
             "cache-control": "no-store",
             "pragma": "no-cache",
             "content-encoding": "gzip",
-            "content-length": asNumber(greaterThan(0)),
+            "content-length": greaterThan(0),
             "x-frame-options": isString,
             "x-xss-protection": isString,
             "x-content-type-options": isString
@@ -192,7 +192,7 @@ void main() {
             "cache-control": "no-store",
             "pragma": "no-cache",
             "content-encoding": "gzip",
-            "content-length": asNumber(greaterThan(0)),
+            "content-length": greaterThan(0),
             "x-frame-options": isString,
             "x-xss-protection": isString,
             "x-content-type-options": isString
@@ -780,5 +780,5 @@ dynamic hasAuthResponse(int statusCode, dynamic body) =>
       "x-frame-options": isString,
       "x-xss-protection": isString,
       "x-content-type-options": isString,
-      "content-length": asNumber(greaterThan(0))
+      "content-length": greaterThan(0)
     });

--- a/test/base/body_decoder_test.dart
+++ b/test/base/body_decoder_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:test/test.dart';
 import 'package:aqueduct/aqueduct.dart';
+
 import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'dart:convert';


### PR DESCRIPTION
- Unifies body encoding/decoding across test and http libraries, custom codecs for an application are now implicitly available during tests
- Abstracts body decoding behavior from HTTPRequestBody into HTTPBodyDecoder.
- Improves interface for TestRequest/TestResponse
- Adds and improves API references