### PR TITLE
Adds metadata for configuring underlying database table 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.4.0
 
 - Adds `HTTPRequestBody.maxSize` to limit HTTP request body sizes. Defaults to 10MB.
+- Adds `ManagedTableAttributes` to configure underlying database table to use multiple columns to test for uniqueness.
 
 ## 2.3.2
 

--- a/lib/src/db/managed/attributes.dart
+++ b/lib/src/db/managed/attributes.dart
@@ -1,13 +1,39 @@
 import 'managed.dart';
 import '../query/query.dart';
 
-
+/// Metadata to configure underlying table of [ManagedObject] persistent type.
+///
+/// Adding this metadata to a persistent type (`T` in `ManagedObject<T>`) configures the behavior of the underlying table.
+/// For example:
+///
+///         class User extends ManagedObject<_User> implements _User {}
+///
+///         @ManagedTableAttributes(unique: const [#name, #email]);
+///         class _User {
+///           @managedPrimaryKey
+///           int id;
+///
+///           String name;
+///           String email;
+///         }
 class ManagedTableAttributes {
+  /// Metadata for persistent type.
+  ///
+  /// See also [ManagedTableAttributes.unique].
   const ManagedTableAttributes({List<Symbol> unique})
     : uniqueProperties = unique;
 
+  /// Configures each instance of associated persistent type to be unique for [unique].
+  ///
+  /// Adding this metadata to a persistent type requires that all instances of this type
+  /// must be unique for the properties in [unique]. [unique] must contain symbolic names of
+  /// properties declared in the persistent type, and those properties must be either attributes
+  /// or belongs-to relationship properties.
   const ManagedTableAttributes.unique(List<Symbol> unique) : this(unique: unique);
 
+  /// Each instance of the associated persistent type is unique for these properties.
+  ///
+  /// Null if not set.
   final List<Symbol> uniqueProperties;
 }
 
@@ -26,7 +52,7 @@ enum ManagedRelationshipDeleteRule {
   setDefault
 }
 
-/// Metadata for a [ManagedObject] property that requests the property be backed by a foreign key column in a database.
+/// Metadata to configure property of [ManagedObject] as a foreign key column.
 ///
 /// A property in a [ManagedObject]'s persistent type with this metadata will map to a database column
 /// that has a foreign key reference to the related [ManagedObject]. Relationships are made up of two [ManagedObject]s, where each
@@ -82,8 +108,10 @@ enum ManagedRelationshipType {
   belongsTo
 }
 
-/// Marks a property as a primary key, database type big integer, and autoincrementing. The corresponding property
-/// type must be [int]. It is assumed that the underlying database indexes and uniques the backing column.
+/// Metadata to mark a property as a primary key.
+///
+/// This is a convenience for primary key, database type big integer, and autoincrementing. The corresponding property
+/// type must be [int]. The underlying database indexes and uniques the backing column.
 const ManagedColumnAttributes managedPrimaryKey = const ManagedColumnAttributes(
     primaryKey: true,
     databaseType: ManagedPropertyType.bigInteger,

--- a/lib/src/db/managed/attributes.dart
+++ b/lib/src/db/managed/attributes.dart
@@ -23,17 +23,17 @@ class ManagedTableAttributes {
   const ManagedTableAttributes({List<Symbol> unique})
     : uniqueProperties = unique;
 
-  /// Configures each instance of associated persistent type to be unique for [unique].
+  /// Configures each instance of persistent type to be unique for the combination of [unique].
   ///
   /// Adding this metadata to a persistent type requires that all instances of this type
-  /// must be unique for the properties in [unique]. [unique] must contain symbolic names of
+  /// must be unique for the combined properties in [unique]. [unique] must contain symbolic names of
   /// properties declared in the persistent type, and those properties must be either attributes
-  /// or belongs-to relationship properties.
+  /// or belongs-to relationship properties. See [ManagedTableAttributes] for example.
   const ManagedTableAttributes.unique(List<Symbol> unique) : this(unique: unique);
 
   /// Each instance of the associated persistent type is unique for these properties.
   ///
-  /// Null if not set.
+  /// null if not set.
   final List<Symbol> uniqueProperties;
 }
 

--- a/lib/src/db/managed/attributes.dart
+++ b/lib/src/db/managed/attributes.dart
@@ -1,6 +1,16 @@
 import 'managed.dart';
 import '../query/query.dart';
 
+
+class ManagedTableAttributes {
+  const ManagedTableAttributes({List<Symbol> unique})
+    : uniqueProperties = unique;
+
+  const ManagedTableAttributes.unique(List<Symbol> unique) : this(unique: unique);
+
+  final List<Symbol> uniqueProperties;
+}
+
 /// Possible values for a delete rule in a [ManagedRelationship].
 enum ManagedRelationshipDeleteRule {
   /// Prevents a delete operation if the would-be deleted [ManagedObject] still has references to this relationship.

--- a/lib/src/db/managed/attributes.dart
+++ b/lib/src/db/managed/attributes.dart
@@ -20,21 +20,21 @@ class ManagedTableAttributes {
   /// Metadata for persistent type.
   ///
   /// See also [ManagedTableAttributes.unique].
-  const ManagedTableAttributes({List<Symbol> unique})
-    : uniqueProperties = unique;
+  const ManagedTableAttributes({List<Symbol> uniquePropertySet})
+    : this.uniquePropertySet = uniquePropertySet;
 
-  /// Configures each instance of persistent type to be unique for the combination of [unique].
+  /// Configures each instance of persistent type to be unique for the combination of [properties].
   ///
   /// Adding this metadata to a persistent type requires that all instances of this type
-  /// must be unique for the combined properties in [unique]. [unique] must contain symbolic names of
+  /// must be unique for the combined properties in [properties]. [properties] must contain symbolic names of
   /// properties declared in the persistent type, and those properties must be either attributes
   /// or belongs-to relationship properties. See [ManagedTableAttributes] for example.
-  const ManagedTableAttributes.unique(List<Symbol> unique) : this(unique: unique);
+  const ManagedTableAttributes.unique(List<Symbol> properties) : this(uniquePropertySet: properties);
 
   /// Each instance of the associated persistent type is unique for these properties.
   ///
   /// null if not set.
-  final List<Symbol> uniqueProperties;
+  final List<Symbol> uniquePropertySet;
 }
 
 /// Possible values for a delete rule in a [ManagedRelationship].

--- a/lib/src/db/managed/data_model.dart
+++ b/lib/src/db/managed/data_model.dart
@@ -241,6 +241,36 @@ class ManagedDataModelException implements Exception {
         "has invalid validator for property '$property'. Reason: $reason");
   }
 
+  factory ManagedDataModelException.emptyEntityUniqueProperties(
+      ManagedEntity entity) {
+    return new ManagedDataModelException("Type '${_getPersistentClassName(entity)}' "
+        "has empty set for unique 'ManagedTableAttributes'. Must contain two or "
+        "more attributes (or belongs-to relationship properties).");
+  }
+
+  factory ManagedDataModelException.singleEntityUniqueProperty(
+      ManagedEntity entity, Symbol property) {
+    return new ManagedDataModelException("Type '${_getPersistentClassName(entity)}' "
+        "has only one attribute for unique 'ManagedTableAttributes'. Must contain two or "
+        "more attributes (or belongs-to relationship properties). To make this property unique, "
+        "add 'ManagedColumnAttributes(unique: true)' to declaration of '${_getName(property)}'.");
+  }
+
+  factory ManagedDataModelException.invalidEntityUniqueProperty(
+      ManagedEntity entity, Symbol property) {
+    return new ManagedDataModelException("Type '${_getPersistentClassName(entity)}' "
+        "declares '${MirrorSystem.getName(property)}' as unique in 'ManagedTableAttributes', "
+        "but '${MirrorSystem.getName(property)}' is not a property of this type.");
+  }
+
+  factory ManagedDataModelException.relationshipEntityUniqueProperty(
+      ManagedEntity entity, Symbol property) {
+    return new ManagedDataModelException("Type '${_getPersistentClassName(entity)}' "
+        "declares '${_getName(property)}' as unique in 'ManagedTableAttributes'. This property cannot "
+        "be used to make an instance unique; only attributes or belongs-to relationships may used "
+        "in this way.");
+  }
+
   static String _getPersistentClassName(ManagedEntity entity) =>
       _getName(entity?.persistentType?.simpleName);
 

--- a/lib/src/db/managed/data_model_builder.dart
+++ b/lib/src/db/managed/data_model_builder.dart
@@ -49,7 +49,7 @@ class DataModelBuilder {
         }
       });
 
-      entity.unique = instanceUniquePropertiesForEntity(entity);
+      entity.uniquePropertySet = instanceUniquePropertiesForEntity(entity);
     });
   }
 
@@ -426,16 +426,16 @@ class DataModelBuilder {
         .firstWhere((im) => im.type.isSubtypeOf(reflectType(ManagedTableAttributes)),
           orElse: () => null)?.reflectee;
 
-    if (tableAttributes?.uniqueProperties != null) {
-      if (tableAttributes.uniqueProperties.length == 0) {
+    if (tableAttributes?.uniquePropertySet != null) {
+      if (tableAttributes.uniquePropertySet.length == 0) {
         throw new ManagedDataModelException.emptyEntityUniqueProperties(entity);
-      } else if (tableAttributes.uniqueProperties.length == 1) {
+      } else if (tableAttributes.uniquePropertySet.length == 1) {
         throw new ManagedDataModelException.singleEntityUniqueProperty(
-            entity, tableAttributes.uniqueProperties.first);
+            entity, tableAttributes.uniquePropertySet.first);
       }
 
       return tableAttributes
-          .uniqueProperties
+          .uniquePropertySet
           .map((sym) {
             var prop = entity.properties[MirrorSystem.getName(sym)];
             if (prop == null) {

--- a/lib/src/db/managed/entity.dart
+++ b/lib/src/db/managed/entity.dart
@@ -98,13 +98,13 @@ class ManagedEntity {
   /// Set of properties that, together, are unique for each instance of this entity.
   ///
   /// If non-null, each instance of this entity is unique for the combination of values
-  /// for these properties. Instances may have the same values for each property in [unique],
-  /// but cannot have the same value for all properties in [unique]. This differs from setting
+  /// for these properties. Instances may have the same values for each property in [uniquePropertySet],
+  /// but cannot have the same value for all properties in [uniquePropertySet]. This differs from setting
   /// a single property as unique with [ManagedColumnAttributes], where each instance has
   /// a unique value for that property.
   ///
   /// This value is set by adding [ManagedTableAttributes] to the persistent type of a [ManagedObject].
-  List<ManagedPropertyDescription> unique;
+  List<ManagedPropertyDescription> uniquePropertySet;
 
   /// List of [ManagedValidator]s for attributes of this entity.
   ///

--- a/lib/src/db/managed/entity.dart
+++ b/lib/src/db/managed/entity.dart
@@ -95,6 +95,8 @@ class ManagedEntity {
     return all;
   }
 
+  List<ManagedPropertyDescription> unique;
+
   /// List of [ManagedValidator]s for attributes of this entity.
   ///
   /// All validators for all [attributes] in one, flat list. Order is undefined.

--- a/lib/src/db/managed/entity.dart
+++ b/lib/src/db/managed/entity.dart
@@ -95,6 +95,15 @@ class ManagedEntity {
     return all;
   }
 
+  /// Set of properties that, together, are unique for each instance of this entity.
+  ///
+  /// If non-null, each instance of this entity is unique for the combination of values
+  /// for these properties. Instances may have the same values for each property in [unique],
+  /// but cannot have the same value for all properties in [unique]. This differs from setting
+  /// a single property as unique with [ManagedColumnAttributes], where each instance has
+  /// a unique value for that property.
+  ///
+  /// This value is set by adding [ManagedTableAttributes] to the persistent type of a [ManagedObject].
   List<ManagedPropertyDescription> unique;
 
   /// List of [ManagedValidator]s for attributes of this entity.

--- a/lib/src/db/managed/entity_mirrors.dart
+++ b/lib/src/db/managed/entity_mirrors.dart
@@ -125,6 +125,10 @@ bool doesVariableMirrorRepresentRelationship(VariableMirror mirror) {
   return false;
 }
 
+ManagedTableAttributes tableAttributesFromPersistentType(ClassMirror typeMirror) =>
+    firstMetadataOfType(
+        typeMirror.reflectedType, reflectType(ManagedTableAttributes));
+
 List<Validate> validatorsFromDeclaration(DeclarationMirror dm) =>
   allMetadataOfType(Validate, dm);
 ManagedTransientAttribute transientMetadataFromDeclaration(

--- a/test/db/data_model_test.dart
+++ b/test/db/data_model_test.dart
@@ -508,17 +508,17 @@ void main() {
     test("Add ManagedTableAttributes to persistent type with unique list makes instances unique for those columns", () {
       var dm = new ManagedDataModel([MultiUnique]);
       var e = dm.entityForType(MultiUnique);
-      expect(e.unique.length, 2);
-      expect(e.unique.contains(e.properties["a"]), true);
-      expect(e.unique.contains(e.properties["b"]), true);
+      expect(e.uniquePropertySet.length, 2);
+      expect(e.uniquePropertySet.contains(e.properties["a"]), true);
+      expect(e.uniquePropertySet.contains(e.properties["b"]), true);
     });
 
     test("Add ManagedTableAttributes to persistent type with unique list makes instances unique for those columns, where column is foreign key relationship", () {
       var dm = new ManagedDataModel([MultiUniqueBelongsTo, MultiUniqueHasA]);
       var e = dm.entityForType(MultiUniqueBelongsTo);
-      expect(e.unique.length, 2);
-      expect(e.unique.contains(e.properties["rel"]), true);
-      expect(e.unique.contains(e.properties["b"]), true);
+      expect(e.uniquePropertySet.length, 2);
+      expect(e.uniquePropertySet.contains(e.properties["rel"]), true);
+      expect(e.uniquePropertySet.contains(e.properties["b"]), true);
     });
 
     test("Add ManagedTableAttributes to persistent type with only single element in unique list throws exception, warns to use ManagedColumnAttributes", () {

--- a/test/db/data_model_test.dart
+++ b/test/db/data_model_test.dart
@@ -513,6 +513,14 @@ void main() {
       expect(e.unique.contains(e.properties["b"]), true);
     });
 
+    test("Add ManagedTableAttributes to persistent type with unique list makes instances unique for those columns, where column is foreign key relationship", () {
+      var dm = new ManagedDataModel([MultiUniqueBelongsTo, MultiUniqueHasA]);
+      var e = dm.entityForType(MultiUniqueBelongsTo);
+      expect(e.unique.length, 2);
+      expect(e.unique.contains(e.properties["rel"]), true);
+      expect(e.unique.contains(e.properties["b"]), true);
+    });
+
     test("Add ManagedTableAttributes to persistent type with only single element in unique list throws exception, warns to use ManagedColumnAttributes", () {
       try {
         new ManagedDataModel([MultiUniqueFailureSingleElement]);
@@ -527,7 +535,7 @@ void main() {
         new ManagedDataModel([MultiUniqueFailureNoElement]);
         expect(true, false);
       } on ManagedDataModelException catch (e) {
-        expect(e.message, contains("must have two or more properties"));
+        expect(e.message, contains("Must contain two or more attributes"));
       }
     });
 
@@ -536,7 +544,7 @@ void main() {
         new ManagedDataModel([MultiUniqueFailureUnknown]);
         expect(true, false);
       } on ManagedDataModelException catch (e) {
-        expect(e.message, contains("property 'a' does not exist"));
+        expect(e.message, contains("'a' is not a property of this type"));
       }
     });
 
@@ -545,7 +553,7 @@ void main() {
         new ManagedDataModel([MultiUniqueFailureRelationship, MultiUniqueFailureRelationshipInverse]);
         expect(true, false);
       } on ManagedDataModelException catch (e) {
-        expect(e.message, contains("property 'a' must not be has-many or has-one"));
+        expect(e.message, contains("declares 'a' as unique"));
       }
     });
   });
@@ -1019,4 +1027,24 @@ class _MultiUniqueFailureRelationshipInverse {
 
   @ManagedRelationship(#a)
   MultiUniqueFailureRelationship rel;
+}
+
+class MultiUniqueBelongsTo extends ManagedObject<_MultiUniqueBelongsTo> {}
+@ManagedTableAttributes.unique(const [#rel, #b])
+class _MultiUniqueBelongsTo {
+  @managedPrimaryKey
+  int id;
+
+  @ManagedRelationship(#a)
+  MultiUniqueHasA rel;
+
+  String b;
+}
+
+class MultiUniqueHasA extends ManagedObject<_MultiUniqueHasA> {}
+class _MultiUniqueHasA {
+  @managedPrimaryKey
+  int id;
+
+  MultiUniqueBelongsTo a;
 }


### PR DESCRIPTION
- Currently only has one option, to set a unique set of properties for an entity.
- Only impacts data model so far, a later PR will address actually getting this into PostgreSQL.