### PR TITLE
Adds multi-column unique to Schema and schema diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - STAGE=tests
   - STAGE=coverage COVERAGE_SLICE='auth base'
   - STAGE=coverage COVERAGE_SLICE='command'
-  - STAGE=coverage COVERAGE_SLICE='db managed_auth utilities'
+  - STAGE=coverage COVERAGE_SLICE='db managed_auth utilities testing'
 branches:
   only:
     - master

--- a/lib/src/db/schema/schema.dart
+++ b/lib/src/db/schema/schema.dart
@@ -241,16 +241,16 @@ class SchemaTableDifference {
   bool get _hasUniqueColumnDifferences => _uniqueColumnDifference != null;
 
   String get _uniqueColumnDifference {
-    if (expectedTable.uniqueForColumns == null && actualTable.uniqueForColumns != null) {
+    if (expectedTable.uniqueColumnSet == null && actualTable.uniqueColumnSet != null) {
       return "Multi-column unique constraint on table '${expectedTable.name}' "
           "should NOT exist, but is created by migration files.";
-    } else if (expectedTable.uniqueForColumns != null && actualTable.uniqueForColumns == null) {
+    } else if (expectedTable.uniqueColumnSet != null && actualTable.uniqueColumnSet == null) {
       return "Multi-column unique constraint on table '${expectedTable.name}' "
           "should exist, but it is NOT created by migration files.";
-    } else if (expectedTable.uniqueForColumns != null && actualTable.uniqueForColumns != null) {
-      if (!_equalListElements(expectedTable.uniqueForColumns, actualTable.uniqueForColumns)) {
-        var expectedColumns = expectedTable.uniqueForColumns.map((c) => "'$c'").join(", ");
-        var actualColumns = actualTable.uniqueForColumns.map((c) => "'$c'").join(", ");
+    } else if (expectedTable.uniqueColumnSet != null && actualTable.uniqueColumnSet != null) {
+      if (!_equalListElements(expectedTable.uniqueColumnSet, actualTable.uniqueColumnSet)) {
+        var expectedColumns = expectedTable.uniqueColumnSet.map((c) => "'$c'").join(", ");
+        var actualColumns = actualTable.uniqueColumnSet.map((c) => "'$c'").join(", ");
         return "Multi-column unique constraint on table '${expectedTable.name}' "
             "is expected to be for properties $expectedColumns, but is actually $actualColumns";
       }

--- a/lib/src/db/schema/schema.dart
+++ b/lib/src/db/schema/schema.dart
@@ -195,7 +195,8 @@ class SchemaTableDifference {
       differingColumns.length > 0 ||
       expectedTable?.name?.toLowerCase() != actualTable?.name?.toLowerCase() ||
       (expectedTable == null && actualTable != null) ||
-      (actualTable == null && expectedTable != null);
+      (actualTable == null && expectedTable != null) ||
+      _hasUniqueColumnDifferences;
 
   List<String> get errorMessages {
     if (expectedTable == null && actualTable != null) {
@@ -208,7 +209,14 @@ class SchemaTableDifference {
       ];
     }
 
-    return differingColumns.expand((diff) => diff.errorMessages(this)).toList();
+    var diffs = differingColumns.expand((diff) => diff.errorMessages(this)).toList();
+
+    var uniqueDiff = _uniqueColumnDifference;
+    if (uniqueDiff != null) {
+      diffs.add(uniqueDiff);
+    }
+
+    return diffs;
   }
 
   SchemaTable expectedTable;
@@ -227,6 +235,43 @@ class SchemaTableDifference {
           .where((diff) => diff.expectedColumn != null && diff.actualColumn == null)
           .map((diff) => diff.expectedColumn.name)
           .toList();
+
+  // Note: this is only table-wide, multi-column unique constraint, not per
+  // column uniqueness
+  bool get _hasUniqueColumnDifferences => _uniqueColumnDifference != null;
+
+  String get _uniqueColumnDifference {
+    if (expectedTable.uniqueForColumns == null && actualTable.uniqueForColumns != null) {
+      return "Multi-column unique constraint on table '${expectedTable.name}' "
+          "should NOT exist, but is created by migration files.";
+    } else if (expectedTable.uniqueForColumns != null && actualTable.uniqueForColumns == null) {
+      return "Multi-column unique constraint on table '${expectedTable.name}' "
+          "should exist, but it is NOT created by migration files.";
+    } else if (expectedTable.uniqueForColumns != null && actualTable.uniqueForColumns != null) {
+      if (!_equalListElements(expectedTable.uniqueForColumns, actualTable.uniqueForColumns)) {
+        var expectedColumns = expectedTable.uniqueForColumns.map((c) => "'$c'").join(", ");
+        var actualColumns = actualTable.uniqueForColumns.map((c) => "'$c'").join(", ");
+        return "Multi-column unique constraint on table '${expectedTable.name}' "
+            "is expected to be for properties $expectedColumns, but is actually $actualColumns";
+      }
+    }
+
+    return null;
+  }
+
+  bool _equalListElements(List<String> a, List<String> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }
 
 class SchemaColumnDifference {

--- a/lib/src/db/schema/schema_table.dart
+++ b/lib/src/db/schema/schema_table.dart
@@ -21,14 +21,14 @@ class SchemaTable {
         .map((p) => new SchemaColumn.fromEntity(entity, p))
         .toList();
 
-    uniqueForColumns = entity.uniquePropertySet?.map((p) => p.name)?.toList();
+    uniqueColumnSet = entity.uniquePropertySet?.map((p) => p.name)?.toList();
   }
 
   SchemaTable.from(SchemaTable otherTable) {
     name = otherTable.name;
     columns =
         otherTable.columns.map((col) => new SchemaColumn.from(col)).toList();
-    _uniqueForColumns = otherTable._uniqueForColumns;
+    _uniqueColumnSet = otherTable._uniqueColumnSet;
   }
 
   SchemaTable.empty();
@@ -38,16 +38,16 @@ class SchemaTable {
     columns = (map["columns"] as List<Map<String, dynamic>>)
         .map((c) => new SchemaColumn.fromMap(c))
         .toList();
-    uniqueForColumns = map["unique"];
+    uniqueColumnSet = map["unique"];
   }
 
   String name;
 
-  List<String> _uniqueForColumns;
-  List<String> get uniqueForColumns => _uniqueForColumns;
-  set uniqueForColumns(List<String> columns) {
-    _uniqueForColumns = columns;
-    _uniqueForColumns?.sort((String a, String b) => a.compareTo(b));
+  List<String> _uniqueColumnSet;
+  List<String> get uniqueColumnSet => _uniqueColumnSet;
+  set uniqueColumnSet(List<String> columns) {
+    _uniqueColumnSet = columns;
+    _uniqueColumnSet?.sort((String a, String b) => a.compareTo(b));
   }
   List<SchemaColumn> columns;
 
@@ -145,7 +145,7 @@ class SchemaTable {
     return {
       "name": name,
       "columns": columns.map((c) => c.asMap()).toList(),
-      "unique": uniqueForColumns
+      "unique": uniqueColumnSet
     };
   }
 

--- a/lib/src/db/schema/schema_table.dart
+++ b/lib/src/db/schema/schema_table.dart
@@ -21,7 +21,7 @@ class SchemaTable {
         .map((p) => new SchemaColumn.fromEntity(entity, p))
         .toList();
 
-    uniqueForColumns = entity.unique?.map((p) => p.name)?.toList();
+    uniqueForColumns = entity.uniquePropertySet?.map((p) => p.name)?.toList();
   }
 
   SchemaTable.from(SchemaTable otherTable) {

--- a/lib/src/db/schema/schema_table.dart
+++ b/lib/src/db/schema/schema_table.dart
@@ -20,12 +20,15 @@ class SchemaTable {
     columns = validProperties
         .map((p) => new SchemaColumn.fromEntity(entity, p))
         .toList();
+
+    uniqueForColumns = entity.unique?.map((p) => p.name)?.toList();
   }
 
   SchemaTable.from(SchemaTable otherTable) {
     name = otherTable.name;
     columns =
         otherTable.columns.map((col) => new SchemaColumn.from(col)).toList();
+    _uniqueForColumns = otherTable._uniqueForColumns;
   }
 
   SchemaTable.empty();
@@ -35,9 +38,17 @@ class SchemaTable {
     columns = (map["columns"] as List<Map<String, dynamic>>)
         .map((c) => new SchemaColumn.fromMap(c))
         .toList();
+    uniqueForColumns = map["unique"];
   }
 
   String name;
+
+  List<String> _uniqueForColumns;
+  List<String> get uniqueForColumns => _uniqueForColumns;
+  set uniqueForColumns(List<String> columns) {
+    _uniqueForColumns = columns;
+    _uniqueForColumns?.sort((String a, String b) => a.compareTo(b));
+  }
   List<SchemaColumn> columns;
 
   SchemaColumn operator [](String columnName) => columnForName(columnName);
@@ -131,7 +142,11 @@ class SchemaTable {
   }
 
   Map<String, dynamic> asMap() {
-    return {"name": name, "columns": columns.map((c) => c.asMap()).toList()};
+    return {
+      "name": name,
+      "columns": columns.map((c) => c.asMap()).toList(),
+      "unique": uniqueForColumns
+    };
   }
 
   @override

--- a/test/base/body_encoder_streaming_test.dart
+++ b/test/base/body_encoder_streaming_test.dart
@@ -330,7 +330,7 @@ void main() {
         } else {
           expect(response.statusCode, 413);
         }
-      } on SocketException catch (e) {
+      } on SocketException catch (_) {
         if (!Platform.isMacOS) {
           rethrow;
         }
@@ -372,7 +372,7 @@ void main() {
         } else {
           expect(response.statusCode, 413);
         }
-      } on SocketException catch (e) {
+      } on SocketException catch (_) {
         if (!Platform.isMacOS) {
           rethrow;
         }

--- a/test/db/data_model_test.dart
+++ b/test/db/data_model_test.dart
@@ -508,6 +508,7 @@ void main() {
     test("Add ManagedTableAttributes to persistent type with unique list makes instances unique for those columns", () {
       var dm = new ManagedDataModel([MultiUnique]);
       var e = dm.entityForType(MultiUnique);
+
       expect(e.uniquePropertySet.length, 2);
       expect(e.uniquePropertySet.contains(e.properties["a"]), true);
       expect(e.uniquePropertySet.contains(e.properties["b"]), true);
@@ -1028,6 +1029,7 @@ class _MultiUniqueFailureRelationshipInverse {
   @ManagedRelationship(#a)
   MultiUniqueFailureRelationship rel;
 }
+<<<<<<< HEAD
 
 class MultiUniqueBelongsTo extends ManagedObject<_MultiUniqueBelongsTo> {}
 @ManagedTableAttributes.unique(const [#rel, #b])
@@ -1048,3 +1050,5 @@ class _MultiUniqueHasA {
 
   MultiUniqueBelongsTo a;
 }
+=======
+>>>>>>> Adding some tests

--- a/test/db/data_model_test.dart
+++ b/test/db/data_model_test.dart
@@ -522,6 +522,14 @@ void main() {
       expect(e.uniquePropertySet.contains(e.properties["b"]), true);
     });
 
+    test("Add ManagedTableAttributes to persistent type with unique list makes instances unique for those columns, where column is foreign key relationship", () {
+      var dm = new ManagedDataModel([MultiUniqueBelongsTo, MultiUniqueHasA]);
+      var e = dm.entityForType(MultiUniqueBelongsTo);
+      expect(e.unique.length, 2);
+      expect(e.unique.contains(e.properties["rel"]), true);
+      expect(e.unique.contains(e.properties["b"]), true);
+    });
+
     test("Add ManagedTableAttributes to persistent type with only single element in unique list throws exception, warns to use ManagedColumnAttributes", () {
       try {
         new ManagedDataModel([MultiUniqueFailureSingleElement]);
@@ -1029,7 +1037,6 @@ class _MultiUniqueFailureRelationshipInverse {
   @ManagedRelationship(#a)
   MultiUniqueFailureRelationship rel;
 }
-<<<<<<< HEAD
 
 class MultiUniqueBelongsTo extends ManagedObject<_MultiUniqueBelongsTo> {}
 @ManagedTableAttributes.unique(const [#rel, #b])
@@ -1050,5 +1057,3 @@ class _MultiUniqueHasA {
 
   MultiUniqueBelongsTo a;
 }
-=======
->>>>>>> Adding some tests

--- a/test/db/data_model_test.dart
+++ b/test/db/data_model_test.dart
@@ -525,9 +525,9 @@ void main() {
     test("Add ManagedTableAttributes to persistent type with unique list makes instances unique for those columns, where column is foreign key relationship", () {
       var dm = new ManagedDataModel([MultiUniqueBelongsTo, MultiUniqueHasA]);
       var e = dm.entityForType(MultiUniqueBelongsTo);
-      expect(e.unique.length, 2);
-      expect(e.unique.contains(e.properties["rel"]), true);
-      expect(e.unique.contains(e.properties["b"]), true);
+      expect(e.uniquePropertySet.length, 2);
+      expect(e.uniquePropertySet.contains(e.properties["rel"]), true);
+      expect(e.uniquePropertySet.contains(e.properties["b"]), true);
     });
 
     test("Add ManagedTableAttributes to persistent type with only single element in unique list throws exception, warns to use ManagedColumnAttributes", () {

--- a/test/db/schema_test.dart
+++ b/test/db/schema_test.dart
@@ -10,7 +10,7 @@ void main() {
       var t = schema.tables.first;
 
       expect(t.name, "_SimpleModel");
-      expect(t.uniqueForColumns, isNull);
+      expect(t.uniqueColumnSet, isNull);
       var tableColumns = t.columns;
       expect(tableColumns.length, 1);
       expect(tableColumns.first.asMap(), {
@@ -38,7 +38,7 @@ void main() {
 
       var table = schema.tables.first;
       expect(table.name, "_ExtensiveModel");
-      expect(table.uniqueForColumns, isNull);
+      expect(table.uniqueColumnSet, isNull);
 
       var columns = table.columns;
       expect(columns.length, 8);
@@ -177,7 +177,7 @@ void main() {
       var containerTable =
           schema.tables.firstWhere((t) => t.name == "_Container");
       expect(containerTable.name, "_Container");
-      expect(containerTable.uniqueForColumns, isNull);
+      expect(containerTable.uniqueColumnSet, isNull);
       var containerColumns = containerTable.columns;
       expect(containerColumns.length, 1);
       expect(containerColumns.first.asMap(), {
@@ -197,7 +197,7 @@ void main() {
       var defaultItemTable =
           schema.tables.firstWhere((t) => t.name == "_DefaultItem");
       expect(defaultItemTable.name, "_DefaultItem");
-      expect(defaultItemTable.uniqueForColumns, isNull);
+      expect(defaultItemTable.uniqueColumnSet, isNull);
       var defaultItemColumns = defaultItemTable.columns;
       expect(defaultItemColumns.length, 2);
       expect(defaultItemColumns.first.asMap(), {
@@ -229,7 +229,7 @@ void main() {
 
       var loadedItemTable =
           schema.tables.firstWhere((t) => t.name == "_LoadedItem");
-      expect(loadedItemTable.uniqueForColumns, isNull);
+      expect(loadedItemTable.uniqueColumnSet, isNull);
       expect(loadedItemTable.name, "_LoadedItem");
       var loadedColumns = loadedItemTable.columns;
       expect(loadedColumns.length, 3);
@@ -275,7 +275,7 @@ void main() {
 
       var loadedSingleItemTable =
           schema.tables.firstWhere((t) => t.name == "_LoadedSingleItem");
-      expect(loadedSingleItemTable.uniqueForColumns, isNull);
+      expect(loadedSingleItemTable.uniqueColumnSet, isNull);
       expect(loadedSingleItemTable.name, "_LoadedSingleItem");
       var loadedSingleColumns = loadedSingleItemTable.columns;
       expect(loadedSingleColumns.length, 2);
@@ -315,7 +315,7 @@ void main() {
       var schema = new Schema.fromDataModel(dataModel);
       expect(schema.tables.length, 1);
       expect(schema.tables.first.name, "_Unique");
-      expect(schema.tables.first.uniqueForColumns, ["a", "b"]);
+      expect(schema.tables.first.uniqueColumnSet, ["a", "b"]);
 
       var tableMap = schema.asMap()["tables"].first;
       expect(tableMap["name"], "_Unique");
@@ -390,7 +390,7 @@ void main() {
 
     test("Table with different unique shows up as error", () {
       var newSchema = new Schema.from(baseSchema);
-      newSchema.tableForName("_Unique").uniqueForColumns = ["a", "b", "c"];
+      newSchema.tableForName("_Unique").uniqueColumnSet = ["a", "b", "c"];
       var diff = baseSchema.differenceFrom(newSchema);
       expect(diff.hasDifferences, true);
       expect(diff.errorMessages.length, 1);
@@ -400,7 +400,7 @@ void main() {
           contains(contains("'a', 'b', 'c'")));
 
       newSchema = new Schema.from(baseSchema);
-      newSchema.tableForName("_Unique").uniqueForColumns = ["a", "c"];
+      newSchema.tableForName("_Unique").uniqueColumnSet = ["a", "c"];
       diff = baseSchema.differenceFrom(newSchema);
       expect(diff.hasDifferences, true);
       expect(diff.errorMessages.length, 1);
@@ -411,24 +411,24 @@ void main() {
     });
 
     test("Table with same unique, but unordered, shows as equal", () {
-      expect(baseSchema.tableForName("_Unique").uniqueForColumns, ["a", "b"]);
+      expect(baseSchema.tableForName("_Unique").uniqueColumnSet, ["a", "b"]);
 
       var newSchema = new Schema.from(baseSchema);
-      newSchema.tableForName("_Unique").uniqueForColumns = ["b", "a"];
+      newSchema.tableForName("_Unique").uniqueColumnSet = ["b", "a"];
       var diff = baseSchema.differenceFrom(newSchema);
       expect(diff.hasDifferences, false);
     });
 
     test("Table with no unique/unique show up as error", () {
       var newSchema = new Schema.from(baseSchema);
-      newSchema.tableForName("_Unique").uniqueForColumns = null;
+      newSchema.tableForName("_Unique").uniqueColumnSet = null;
       var diff = baseSchema.differenceFrom(newSchema);
       expect(diff.hasDifferences, true);
       expect(diff.errorMessages, contains(contains("NOT created by migration files")));
       expect(diff.errorMessages, contains(contains("Multi-column unique constraint on table '_Unique'")));
 
       var nextSchema = new Schema.from(newSchema);
-      nextSchema.tableForName("_Unique").uniqueForColumns = ["a", "b"];
+      nextSchema.tableForName("_Unique").uniqueColumnSet = ["a", "b"];
       diff = newSchema.differenceFrom(nextSchema);
       expect(diff.hasDifferences, true);
       expect(diff.errorMessages, contains(contains("is created by migration files")));

--- a/test/db/schema_test.dart
+++ b/test/db/schema_test.dart
@@ -10,6 +10,7 @@ void main() {
       var t = schema.tables.first;
 
       expect(t.name, "_SimpleModel");
+      expect(t.uniqueForColumns, isNull);
       var tableColumns = t.columns;
       expect(tableColumns.length, 1);
       expect(tableColumns.first.asMap(), {
@@ -25,6 +26,9 @@ void main() {
         "deleteRule": null,
         "indexed": false
       });
+
+      expect(new Schema.fromMap(schema.asMap()).differenceFrom(schema).hasDifferences,
+          false);
     });
 
     test("An extensive model", () {
@@ -34,6 +38,7 @@ void main() {
 
       var table = schema.tables.first;
       expect(table.name, "_ExtensiveModel");
+      expect(table.uniqueForColumns, isNull);
 
       var columns = table.columns;
       expect(columns.length, 8);
@@ -150,6 +155,9 @@ void main() {
         "deleteRule": null,
         "indexed": true
       });
+
+      expect(new Schema.fromMap(schema.asMap()).differenceFrom(schema).hasDifferences,
+          false);
     });
 
     test("A model graph", () {
@@ -169,6 +177,7 @@ void main() {
       var containerTable =
           schema.tables.firstWhere((t) => t.name == "_Container");
       expect(containerTable.name, "_Container");
+      expect(containerTable.uniqueForColumns, isNull);
       var containerColumns = containerTable.columns;
       expect(containerColumns.length, 1);
       expect(containerColumns.first.asMap(), {
@@ -188,6 +197,7 @@ void main() {
       var defaultItemTable =
           schema.tables.firstWhere((t) => t.name == "_DefaultItem");
       expect(defaultItemTable.name, "_DefaultItem");
+      expect(defaultItemTable.uniqueForColumns, isNull);
       var defaultItemColumns = defaultItemTable.columns;
       expect(defaultItemColumns.length, 2);
       expect(defaultItemColumns.first.asMap(), {
@@ -219,6 +229,7 @@ void main() {
 
       var loadedItemTable =
           schema.tables.firstWhere((t) => t.name == "_LoadedItem");
+      expect(loadedItemTable.uniqueForColumns, isNull);
       expect(loadedItemTable.name, "_LoadedItem");
       var loadedColumns = loadedItemTable.columns;
       expect(loadedColumns.length, 3);
@@ -264,6 +275,7 @@ void main() {
 
       var loadedSingleItemTable =
           schema.tables.firstWhere((t) => t.name == "_LoadedSingleItem");
+      expect(loadedSingleItemTable.uniqueForColumns, isNull);
       expect(loadedSingleItemTable.name, "_LoadedSingleItem");
       var loadedSingleColumns = loadedSingleItemTable.columns;
       expect(loadedSingleColumns.length, 2);
@@ -293,6 +305,24 @@ void main() {
         "deleteRule": "cascade",
         "indexed": true
       });
+
+      expect(new Schema.fromMap(schema.asMap()).differenceFrom(schema).hasDifferences,
+          false);
+    });
+
+    test("Can specify unique across multiple columns", () {
+      var dataModel = new ManagedDataModel([Unique]);
+      var schema = new Schema.fromDataModel(dataModel);
+      expect(schema.tables.length, 1);
+      expect(schema.tables.first.name, "_Unique");
+      expect(schema.tables.first.uniqueForColumns, ["a", "b"]);
+
+      var tableMap = schema.asMap()["tables"].first;
+      expect(tableMap["name"], "_Unique");
+      expect(tableMap["unique"], ["a", "b"]);
+
+      var tableFromMap = new SchemaTable.fromMap(tableMap);
+      expect(tableFromMap.differenceFrom(schema.tables.first).hasDifferences, false);
     });
   });
 
@@ -320,7 +350,7 @@ void main() {
     Schema baseSchema;
     setUp(() {
       var dataModel = new ManagedDataModel(
-          [LoadedSingleItem, DefaultItem, LoadedItem, Container]);
+          [LoadedSingleItem, DefaultItem, LoadedItem, Container, Unique]);
       baseSchema = new Schema.fromDataModel(dataModel);
     });
 
@@ -356,6 +386,53 @@ void main() {
           contains(contains("'_DefaultItem' should exist")));
       expect(diff.errorMessages,
           contains(contains("'DefaultItem' should NOT exist")));
+    });
+
+    test("Table with different unique shows up as error", () {
+      var newSchema = new Schema.from(baseSchema);
+      newSchema.tableForName("_Unique").uniqueForColumns = ["a", "b", "c"];
+      var diff = baseSchema.differenceFrom(newSchema);
+      expect(diff.hasDifferences, true);
+      expect(diff.errorMessages.length, 1);
+      expect(diff.errorMessages,
+          contains(contains("'_Unique' is expected")));
+      expect(diff.errorMessages,
+          contains(contains("'a', 'b', 'c'")));
+
+      newSchema = new Schema.from(baseSchema);
+      newSchema.tableForName("_Unique").uniqueForColumns = ["a", "c"];
+      diff = baseSchema.differenceFrom(newSchema);
+      expect(diff.hasDifferences, true);
+      expect(diff.errorMessages.length, 1);
+      expect(diff.errorMessages,
+          contains(contains("'_Unique' is expected")));
+      expect(diff.errorMessages,
+          contains(contains("'a', 'c'")));
+    });
+
+    test("Table with same unique, but unordered, shows as equal", () {
+      expect(baseSchema.tableForName("_Unique").uniqueForColumns, ["a", "b"]);
+
+      var newSchema = new Schema.from(baseSchema);
+      newSchema.tableForName("_Unique").uniqueForColumns = ["b", "a"];
+      var diff = baseSchema.differenceFrom(newSchema);
+      expect(diff.hasDifferences, false);
+    });
+
+    test("Table with no unique/unique show up as error", () {
+      var newSchema = new Schema.from(baseSchema);
+      newSchema.tableForName("_Unique").uniqueForColumns = null;
+      var diff = baseSchema.differenceFrom(newSchema);
+      expect(diff.hasDifferences, true);
+      expect(diff.errorMessages, contains(contains("NOT created by migration files")));
+      expect(diff.errorMessages, contains(contains("Multi-column unique constraint on table '_Unique'")));
+
+      var nextSchema = new Schema.from(newSchema);
+      nextSchema.tableForName("_Unique").uniqueForColumns = ["a", "b"];
+      diff = newSchema.differenceFrom(nextSchema);
+      expect(diff.hasDifferences, true);
+      expect(diff.errorMessages, contains(contains("is created by migration files")));
+      expect(diff.errorMessages, contains(contains("Multi-column unique constraint on table '_Unique'")));
     });
 
     test("Missing column shows up as error", () {
@@ -684,4 +761,15 @@ class PartialModel {
 
   @ManagedColumnAttributes(indexed: true)
   String field;
+}
+
+class Unique extends ManagedObject<_Unique> implements _Unique {}
+@ManagedTableAttributes.unique(const [#a, #b])
+class _Unique {
+  @managedPrimaryKey
+  int id;
+
+  String a;
+  String b;
+  String c;
 }


### PR DESCRIPTION
PR 2/3 (rebase off #314) for multi-column unique. Really need a better name for this.

This adds multi-column unique to SchemaTable; two SchemaTables are not equivalent if they have different values for this property.