### PR TITLE
Add delay options to MockServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,12 @@
 # aqueduct changelog
 
-## 2.5.1
-
-- Adds `defaultDelay` to `MockHTTPServer`. Defaults to null for no delay.
-- Adds `defaultResponse` to `MockHTTPServer`. Defaults to a 503 response instead of a 200.
-- Adds option to set a custom delay for a specific response in `MockHTTPServer`'s `queueResponse` function.
-
 ## 2.5.0
 
 - Adds `aqueduct db schema` to print an application's data model.
 - Adds `--machine` flag to `aqueduct` tool to only emit machine-readable output.
+- Adds `defaultDelay` to `MockHTTPServer`. Defaults to null for no delay.
+- Adds `defaultResponse` to `MockHTTPServer`. Defaults to a 503 response instead of a 200.
+- Adds option to set a custom delay for a specific response in `MockHTTPServer`'s `queueResponse` function.
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # aqueduct changelog
 
+## 2.5.1
+
+- Adds `defaultDelay` to `MockHTTPServer`. Defaults to null for no delay.
+- Adds `defaultResponse` to `MockHTTPServer`. Defaults to a 503 response instead of a 200.
+- Adds option to set a custom delay for a specific response in `MockHTTPServer`'s `queueResponse` function.
+
 ## 2.5.0
 
 - Adds `aqueduct db schema` to print an application's data model.

--- a/lib/src/testing/mock_server.dart
+++ b/lib/src/testing/mock_server.dart
@@ -142,7 +142,7 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
   Duration defaultDelay;
 
   /// The number of currently queued responses
-  int get queueCount => _responseQueue.length;
+  int get queuedResponseCount => _responseQueue.length;
 
   /// The queue of responses that will be returned when HTTP requests are made against this instance.
   ///
@@ -154,7 +154,7 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
   /// A queued response will be returned for the next HTTP request made to this instance and will then be removed.
   /// You may queue up as many responses as you like and they will be returned in order.
   void queueResponse(Response resp, {Duration delay: null}) {
-    _responseQueue.add(new _MockServerResponse(resp, delay ?? defaultDelay));
+    _responseQueue.add(new _MockServerResponse(resp, delay));
   }
 
   /// Begins listening for HTTP requests on [port].
@@ -179,6 +179,7 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
       add(mockReq);
 
       Response response;
+      Duration delay = defaultDelay;
 
       if (_responseQueue.length > 0) {
         final mockResp = _responseQueue.removeAt(0);
@@ -189,12 +190,16 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
         }
 
         if (mockResp.delay != null) {
-          await new Future.delayed(mockResp.delay);
+          delay = mockResp.delay;
         }
 
         response = mockResp.response;
       } else {
         response = defaultResponse;
+      }
+
+      if (delay != null) {
+        await new Future.delayed(delay);
       }
 
       final wrappedReq = new Request(req);

--- a/lib/src/testing/mock_server.dart
+++ b/lib/src/testing/mock_server.dart
@@ -136,9 +136,13 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
   HttpServer server;
 
   /// The response to be returned if there are no queued responses
+  ///
+  /// The default response is a 503 with a JSON Error body
   Response defaultResponse = new Response(503, {}, {"error": "No queued requests"});
 
   /// The delay to be used for responses where a delay is not set
+  ///
+  /// The default delay is null which is no delay
   Duration defaultDelay;
 
   /// The number of currently queued responses
@@ -153,6 +157,7 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
   ///
   /// A queued response will be returned for the next HTTP request made to this instance and will then be removed.
   /// You may queue up as many responses as you like and they will be returned in order.
+  /// If a delay is set in this method it will take precedence over [defaultDelay]. If delay isn't set or is explicitly set to null, [defaultDelay] will be used.
   void queueResponse(Response resp, {Duration delay: null}) {
     _responseQueue.add(new _MockServerResponse(resp, delay));
   }

--- a/lib/src/testing/mock_server.dart
+++ b/lib/src/testing/mock_server.dart
@@ -135,17 +135,26 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
   /// The underlying [HttpServer] listening for requests.
   HttpServer server;
 
+  /// The response to be returned if there are no queued responses
+  Response defaultResponse = new Response(503, {}, {"error": "No queued requests"});
+
+  /// The delay to be used for responses where a delay is not set
+  Duration defaultDelay;
+
+  /// The number of currently queued responses
+  int get queueCount => _responseQueue.length;
+
   /// The queue of responses that will be returned when HTTP requests are made against this instance.
   ///
   /// See [queueResponse].
-  List<Response> responseQueue = [];
+  List<_MockServerResponse> _responseQueue = [];
 
   /// Adds an HTTP response to the list of responses to be returned.
   ///
   /// A queued response will be returned for the next HTTP request made to this instance and will then be removed.
   /// You may queue up as many responses as you like and they will be returned in order.
-  void queueResponse(Response resp) {
-    responseQueue.add(resp);
+  void queueResponse(Response resp, {Duration delay: null}) {
+    _responseQueue.add(new _MockServerResponse(resp, delay ?? defaultDelay));
   }
 
   /// Begins listening for HTTP requests on [port].
@@ -153,7 +162,7 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
   Future open() async {
     server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, port);
     server.listen((HttpRequest req) async {
-      var mockReq = new MockHTTPRequest()
+      final mockReq = new MockHTTPRequest()
         ..method = req.method
         ..path = req.uri.path
         ..queryParameters = req.uri.queryParameters;
@@ -169,21 +178,27 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
 
       add(mockReq);
 
-      if (responseQueue.length > 0) {
-        var respObj = responseQueue.first;
-        responseQueue.removeAt(0);
+      Response response;
 
-        if (respObj.statusCode == _mockConnectionFailureStatusCode) {
+      if (_responseQueue.length > 0) {
+        final mockResp = _responseQueue.removeAt(0);
+
+        if (mockResp.response.statusCode == _mockConnectionFailureStatusCode) {
           // We let this one die by not responding.
           return null;
         }
 
-        var wrappedReq = new Request(req);
-        wrappedReq.respond(respObj);
+        if (mockResp.delay != null) {
+          await new Future.delayed(mockResp.delay);
+        }
+
+        response = mockResp.response;
       } else {
-        req.response.statusCode = 200;
-        req.response.close();
+        response = defaultResponse;
       }
+
+      final wrappedReq = new Request(req);
+      wrappedReq.respond(response);
     });
   }
 
@@ -192,4 +207,11 @@ class MockHTTPServer extends MockServer<MockHTTPRequest> {
   Future close() {
     return server?.close();
   }
+}
+
+class _MockServerResponse {
+  _MockServerResponse(this.response, this.delay);
+
+  final Response response;
+  final Duration delay;
 }

--- a/test/testing/mock_server_test.dart
+++ b/test/testing/mock_server_test.dart
@@ -86,53 +86,53 @@ void main() {
     });
 
     test("Mock Server respects delays for queued requests", () async {
-      server.queueResponse(new Response.ok(null), delay: new Duration(milliseconds: 500));
+      server.queueResponse(new Response.ok(null), delay: new Duration(milliseconds: 1000));
 
       var responseReturned = false;
       var responseFuture = testClient.request("/hello").get();
       responseFuture.whenComplete(() => responseReturned = true);
 
-      await new Future.delayed(new Duration(milliseconds: 400));
+      await new Future.delayed(new Duration(milliseconds: 100));
       expect(responseReturned, false);
-      await new Future.delayed(new Duration(milliseconds: 200));
+      await new Future.delayed(new Duration(milliseconds: 1500));
       expect(responseReturned, true);
     });
 
     test("Mock server uses default delay for requests without an explicit delay", () async {
       server.queueResponse(new Response.ok(null));
-      server.defaultDelay = new Duration(milliseconds: 300);
+      server.defaultDelay = new Duration(milliseconds: 1000);
 
       var responseReturned = false;
       var responseFuture = testClient.request("/hello").get();
       responseFuture.whenComplete(() => responseReturned = true);
 
-      await new Future.delayed(new Duration(milliseconds: 200));
+      await new Future.delayed(new Duration(milliseconds: 100));
       expect(responseReturned, false);
-      await new Future.delayed(new Duration(milliseconds: 200));
+      await new Future.delayed(new Duration(milliseconds: 1500));
       expect(responseReturned, true);
 
-      server.queueResponse(new Response.ok(null), delay: new Duration(milliseconds: 600));
+      server.queueResponse(new Response.ok(null), delay: new Duration(milliseconds: 1000));
 
       responseReturned = false;
       responseFuture = testClient.request("/hello").get();
       responseFuture.whenComplete(() => responseReturned = true);
 
-      await new Future.delayed(new Duration(milliseconds: 500));
+      await new Future.delayed(new Duration(milliseconds: 100));
       expect(responseReturned, false);
-      await new Future.delayed(new Duration(milliseconds: 200));
+      await new Future.delayed(new Duration(milliseconds: 1500));
       expect(responseReturned, true);
     });
 
     test("Default response respects default delay", () async {
-      server.defaultDelay = new Duration(milliseconds: 300);
+      server.defaultDelay = new Duration(milliseconds: 1000);
 
       var responseReturned = false;
       var responseFuture = testClient.request("/hello").get();
       responseFuture.whenComplete(() => responseReturned = true);
 
-      await new Future.delayed(new Duration(milliseconds: 200));
+      await new Future.delayed(new Duration(milliseconds: 100));
       expect(responseReturned, false);
-      await new Future.delayed(new Duration(milliseconds: 200));
+      await new Future.delayed(new Duration(milliseconds: 1500));
       expect(responseReturned, true);
     });
   });

--- a/test/testing/mock_server_test.dart
+++ b/test/testing/mock_server_test.dart
@@ -4,6 +4,7 @@ import 'dart:isolate';
 
 import 'package:test/test.dart';
 import 'package:aqueduct/test.dart';
+import 'package:aqueduct/aqueduct.dart';
 
 void main() {
   group("Mock HTTP Tests", () {
@@ -11,7 +12,7 @@ void main() {
     var testClient = new TestClient.onPort(4000);
 
     test("Server opens", () async {
-      var openFuture = server.open();
+      final openFuture = server.open();
       expect(openFuture, completes);
     });
 
@@ -20,11 +21,11 @@ void main() {
     });
 
     test("Request is enqueued and immediately available", () async {
-      var response =
+      final response =
           (testClient.request("/hello?foo=bar")..headers = {"X": "Y"}).get();
       expect(response, completes);
 
-      var serverRequest = await server.next();
+      final serverRequest = await server.next();
       expect(serverRequest.method, "GET");
       expect(serverRequest.path, "/hello");
       expect(serverRequest.queryParameters["foo"], "bar");
@@ -32,10 +33,10 @@ void main() {
     });
 
     test("Request body is captured", () async {
-      var req = testClient.request("/foo")..json = {"a": "b"};
+      final req = testClient.request("/foo")..json = {"a": "b"};
       await req.put();
 
-      var serverRequest = await server.next();
+      final serverRequest = await server.next();
       expect(serverRequest.method, "PUT");
       expect(serverRequest.body, '{"a":"b"}');
       expect(serverRequest.jsonBody["a"], "b");
@@ -57,13 +58,90 @@ void main() {
       server.clear();
       expect(server.isEmpty, true);
     });
+
+    test("Mock server returns an error by default if there are no enqueued requests", () async {
+      final response = await testClient.request("/hello").get();
+      expect(response.statusCode, 503);
+    });
+
+    test("Mock server default response can be changed", () async {
+      server.defaultResponse = new Response.ok({"key": "This is the default response"});
+
+      final response = await testClient.request("/hello").get();
+      expect(response, hasResponse(200, {"key": "This is the default response"}));
+    });
+
+    test("Queued response count returns correct number of queued requests", () async {
+      expect(server.queuedResponseCount, 0);
+      server.queueResponse(new Response.ok(null));
+      expect(server.queuedResponseCount, 1);
+      server.queueResponse(new Response.unauthorized());
+      expect(server.queuedResponseCount, 2);
+      await testClient.request("/hello").get();
+      expect(server.queuedResponseCount, 1);
+      await testClient.request("/hello").post();
+      expect(server.queuedResponseCount, 0);
+      await testClient.request("/hello").get(); // Returns default response
+      expect(server.queuedResponseCount, 0);
+    });
+
+    test("Mock Server respects delays for queued requests", () async {
+      server.queueResponse(new Response.ok(null), delay: new Duration(milliseconds: 500));
+
+      var responseReturned = false;
+      var responseFuture = testClient.request("/hello").get();
+      responseFuture.whenComplete(() => responseReturned = true);
+
+      await new Future.delayed(new Duration(milliseconds: 400));
+      expect(responseReturned, false);
+      await new Future.delayed(new Duration(milliseconds: 200));
+      expect(responseReturned, true);
+    });
+
+    test("Mock server uses default delay for requests without an explicit delay", () async {
+      server.queueResponse(new Response.ok(null));
+      server.defaultDelay = new Duration(milliseconds: 300);
+
+      var responseReturned = false;
+      var responseFuture = testClient.request("/hello").get();
+      responseFuture.whenComplete(() => responseReturned = true);
+
+      await new Future.delayed(new Duration(milliseconds: 200));
+      expect(responseReturned, false);
+      await new Future.delayed(new Duration(milliseconds: 200));
+      expect(responseReturned, true);
+
+      server.queueResponse(new Response.ok(null), delay: new Duration(milliseconds: 600));
+
+      responseReturned = false;
+      responseFuture = testClient.request("/hello").get();
+      responseFuture.whenComplete(() => responseReturned = true);
+
+      await new Future.delayed(new Duration(milliseconds: 500));
+      expect(responseReturned, false);
+      await new Future.delayed(new Duration(milliseconds: 200));
+      expect(responseReturned, true);
+    });
+
+    test("Default response respects default delay", () async {
+      server.defaultDelay = new Duration(milliseconds: 300);
+
+      var responseReturned = false;
+      var responseFuture = testClient.request("/hello").get();
+      responseFuture.whenComplete(() => responseReturned = true);
+
+      await new Future.delayed(new Duration(milliseconds: 200));
+      expect(responseReturned, false);
+      await new Future.delayed(new Duration(milliseconds: 200));
+      expect(responseReturned, true);
+    });
   });
 }
 
 Future spawnFunc(List pair) async {
-  var path = pair.first;
-  var delay = pair.last;
-  var testClient = new TestClient.onPort(4000);
+  final path = pair.first;
+  final delay = pair.last;
+  final testClient = new TestClient.onPort(4000);
   sleep(new Duration(seconds: delay));
   await testClient.request(path).get();
 }

--- a/test/testing/test_matcher_test.dart
+++ b/test/testing/test_matcher_test.dart
@@ -9,6 +9,7 @@ void main() {
     MockHTTPServer server = new MockHTTPServer(4000);
     setUpAll(() async {
       await server.open();
+      server.defaultResponse = new Response.ok(null);
     });
 
     tearDownAll(() async {


### PR DESCRIPTION
Oh, also a default response that is an error so that it's easier to tell when you don't have the server configured properly.  `defaultResponse` can be set back to an empty 200 if you're into that sort of thing.