### PR TITLE
TestRequest.formData now correctly moves body to URI query

### DIFF
--- a/test/base/body_decoder_test.dart
+++ b/test/base/body_decoder_test.dart
@@ -110,14 +110,17 @@ void main() {
       http
           .post("http://localhost:8123",
               headers: {"Content-Type": "application/x-www-form-urlencoded"},
-              body: "a=b&c=2")
+              body: "a=b&c=2%2F4")
           .catchError((err) => null);
       var request = new Request(await server.first);
+      request.body.retainOriginalBytes = true;
       var body = await request.body.decodedData;
       expect(body, [{
         "a": ["b"],
-        "c": ["2"]
+        "c": ["2/4"]
       }]);
+
+      expect(UTF8.decode(request.body.asBytes()), "a=b&c=2%2F4");
     });
 
     test("Any text decoder works on text with charset", () async {

--- a/test/testing/test_client_test.dart
+++ b/test/testing/test_client_test.dart
@@ -220,6 +220,32 @@ void main() {
       expect(msg.path, "/foo");
       expect(msg.headers["x-content"], "1, 2");
     });
+
+    test("Form data is in query string if GET", () async {
+      var data = {"a": "b/b"};
+
+      var defaultTestClient = new TestClient.onPort(4040);
+
+      await (defaultTestClient.request("/foo")..formData = data).get();
+
+      var msg = await server.next();
+      expect(msg.path, "/foo");
+      expect(msg.queryParameters, {"a": "b/b"});
+      expect(msg.body, isNull);
+    });
+
+    test("Form data is in body if POST", () async {
+      var data = {"a": "b/b"};
+
+      var defaultTestClient = new TestClient.onPort(4040);
+
+      await (defaultTestClient.request("/foo")..formData = data).post();
+
+      var msg = await server.next();
+      expect(msg.path, "/foo");
+      expect(msg.queryParameters, {});
+      expect(msg.body, "a=b%2Fb");
+    });
   });
 
   group("Test Response", () {


### PR DESCRIPTION
 when method is GET, DELETE or HEAD