### PR TITLE
Remove @Bind for methods, replace with @Operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 3.0.0
 
 - Change default port for `aqueduct serve` to 8888.
-- Binding metadata - `HTTPMethod`, `HTTPPath`, `HTTPBody`, `HTTPQuery` and `HTTPHeader` - have been changed to `Bind.method`, `Bind.path`, `Bind.body`, `Bind.query` and `Bind.header`, respectively.
-- Deprecates `@httpGet` and similar constants for `Bind.get()` and similar constructors.
+- Binding metadata - `HTTPPath`, `HTTPBody`, `HTTPQuery` and `HTTPHeader` - have been changed to `Bind.path`, `Bind.body`, `Bind.query` and `Bind.header`, respectively.
+- Remove `@httpGet` (and other `HTTPMethod` annotations) constants. Behavior replaced by`@Operation`.
 - Renames `Request.innerRequest` to `Request.raw`.
 - Removes `runOnMainIsolate` from `Application.start()` and introduces `Application.test()` as replacement.
 - Renames `RequestSink` to `ApplicationChannel` and improves its structure.

--- a/lib/src/auth/auth_code_controller.dart
+++ b/lib/src/auth/auth_code_controller.dart
@@ -80,7 +80,7 @@ class AuthCodeController extends RESTController {
   ///
   /// The 'client_id' must be a registered, valid client of this server. The client must also provide
   /// a [state] to this request and verify that the redirect contains the same value in its query string.
-  @Bind.method("get")
+  @Operation.get()
   Future<Response> getAuthorizationPage({@Bind.query("scope") String scope}) async {
     if (delegate == null) {
       return new Response(405, {}, null);
@@ -101,7 +101,7 @@ class AuthCodeController extends RESTController {
   /// will contain an 'error' key instead of the authorization code.
   ///
   /// This method is typically invoked by the login form returned from the GET to this path.
-  @Bind.method("post")
+  @Operation.post()
   Future<Response> authorize(
       {@Bind.query("username") String username,
       @Bind.query("password") String password,

--- a/lib/src/auth/auth_controller.dart
+++ b/lib/src/auth/auth_controller.dart
@@ -54,7 +54,7 @@ class AuthController extends RESTController {
   ///
   /// This endpoint requires client authentication. The Authorization header must
   /// include a valid Client ID and Secret in the Basic authorization scheme format.
-  @Bind.method("post")
+  @Operation.post()
   Future<Response> create(
       {@Bind.query("username") String username,
       @Bind.query("password") String password,

--- a/lib/src/http/managed_object_controller.dart
+++ b/lib/src/http/managed_object_controller.dart
@@ -90,7 +90,7 @@ class ManagedObjectController<InstanceType extends ManagedObject>
     return new Response.notFound();
   }
 
-  @Bind.get()
+  @Operation.get("id")
   Future<Response> getObject(@Bind.path("id") String id) async {
     var primaryKey = _query.entity.primaryKey;
     _query.where[primaryKey] = whereEqualTo(
@@ -124,7 +124,7 @@ class ManagedObjectController<InstanceType extends ManagedObject>
     return new Response.ok(object);
   }
 
-  @Bind.post()
+  @Operation.post()
   Future<Response> createObject() async {
     InstanceType instance = _query.entity.instanceType
         .newInstance(new Symbol(""), []).reflectee as InstanceType;
@@ -161,7 +161,7 @@ class ManagedObjectController<InstanceType extends ManagedObject>
     return new Response.notFound();
   }
 
-  @Bind.delete()
+  @Operation.delete("id")
   Future<Response> deleteObject(@Bind.path("id") String id) async {
     var primaryKey = _query.entity.primaryKey;
     _query.where[primaryKey] = whereEqualTo(
@@ -202,7 +202,7 @@ class ManagedObjectController<InstanceType extends ManagedObject>
     return new Response.notFound();
   }
 
-  @Bind.put()
+  @Operation.put("id")
   Future<Response> updateObject(@Bind.path("id") String id) async {
     var primaryKey = _query.entity.primaryKey;
     _query.where[primaryKey] = whereEqualTo(
@@ -240,7 +240,7 @@ class ManagedObjectController<InstanceType extends ManagedObject>
     return new Response.ok(objects);
   }
 
-  @Bind.get()
+  @Operation.get()
   Future<Response> getObjects(
       {@Bind.query("count") int count: 0,
       @Bind.query("offset") int offset: 0,

--- a/lib/src/http/rest_controller_binding.dart
+++ b/lib/src/http/rest_controller_binding.dart
@@ -4,39 +4,56 @@ import 'request_path.dart';
 import 'serializable.dart';
 import '../db/managed/managed.dart';
 
+class Operation {
+  const Operation(this.method, [String pathVariable1, String pathVariable2, String pathVariable3, String pathVariable4])
+      : _pathVariable1 = pathVariable1,
+        _pathVariable2 = pathVariable2,
+        _pathVariable3 = pathVariable3,
+        _pathVariable4 = pathVariable4;
+
+  const Operation.get([String pathVariable1, String pathVariable2, String pathVariable3, String pathVariable4])
+      : this.method = "GET",
+        _pathVariable1 = pathVariable1,
+        _pathVariable2 = pathVariable2,
+        _pathVariable3 = pathVariable3,
+        _pathVariable4 = pathVariable4;
+
+  const Operation.put([String pathVariable1, String pathVariable2, String pathVariable3, String pathVariable4])
+      : this.method = "PUT",
+        _pathVariable1 = pathVariable1,
+        _pathVariable2 = pathVariable2,
+        _pathVariable3 = pathVariable3,
+        _pathVariable4 = pathVariable4;
+
+  const Operation.post([String pathVariable1, String pathVariable2, String pathVariable3, String pathVariable4])
+      : this.method = "POST",
+        _pathVariable1 = pathVariable1,
+        _pathVariable2 = pathVariable2,
+        _pathVariable3 = pathVariable3,
+        _pathVariable4 = pathVariable4;
+
+  const Operation.delete([String pathVariable1, String pathVariable2, String pathVariable3, String pathVariable4])
+      : this.method = "DELETE",
+        _pathVariable1 = pathVariable1,
+        _pathVariable2 = pathVariable2,
+        _pathVariable3 = pathVariable3,
+        _pathVariable4 = pathVariable4;
+
+  final String method;
+  final String _pathVariable1;
+  final String _pathVariable2;
+  final String _pathVariable3;
+  final String _pathVariable4;
+
+  List<String> get pathVariables {
+    return [_pathVariable1, _pathVariable2, _pathVariable3, _pathVariable4].where((s) => s != null).toList();
+  }
+}
 
 /// Binds elements of an HTTP request to a [RESTController]'s operation method arguments and properties.
 ///
 /// See individual constructors and [RESTController] for more details.
 class Bind {
-  /// Binds an [RESTController] operation method to GET requests.
-  ///
-  /// Equivalent to `Bind.method("get")`
-  ///
-  /// See [Bind.method].
-  const Bind.get() : name = "get", _type = _BindType.method;
-
-  /// Binds an [RESTController] operation method to PUT requests.
-  ///
-  /// Equivalent to `Bind.method("put")`
-  ///
-  /// See [Bind.method].
-  const Bind.put() : name = "put", _type = _BindType.method;
-
-  /// Binds an [RESTController] operation method to POST requests.
-  ///
-  /// Equivalent to `Bind.method("post")`
-  ///
-  /// See [Bind.method].
-  const Bind.post() : name = "post", _type = _BindType.method;
-
-  /// Binds an [RESTController] operation method to DELETE requests.
-  ///
-  /// Equivalent to `Bind.method("delete")`
-  ///
-  /// See [Bind.method].
-  const Bind.delete() : name = "delete", _type = _BindType.method;
-
   /// Binds an HTTP query parameter to an [RESTController] property or operation method argument.
   ///
   /// When the incoming request's [Uri]
@@ -64,27 +81,6 @@ class Bind {
   /// If a declaration with this metadata is a property with [requiredHTTPParameter], it is required for all methods in an [RESTController].
   const Bind.query(this.name) : _type = _BindType.query;
 
-  /// Binds an HTTP method to a [RESTController] operation method.
-  ///
-  /// See also [Bind.get], [Bind.put], [Bind.post], and [Bind.delete].
-  ///
-  /// [RESTController] methods with this metadata will be invoked when [name] matches the HTTP method
-  /// of the incoming request. [name] is case-insensitively compared; e.g. "GET" and "get" are identical.
-  ///
-  /// Note that multiple operation methods can have the same [Bind.method] metadata as long as each method
-  /// has different [Bind.path] arguments. A operation method is invoked if both [Bind.method] and its [Bind.path] arguments
-  /// match the incoming request.
-  ///
-  /// Example:
-  ///
-  ///         class UserController extends RESTController {
-  ///           @Bind.method("get")
-  ///           Future<Response> getThings() => return new Response.ok(null);
-  ///         }
-  ///
-  /// This is the generic form of [Bind.get], [Bind.put], [Bind.delete] and [Bind.post].
-  const Bind.method(this.name) : _type  = _BindType.method;
-
   /// Binds an HTTP request header to an [RESTController] property or operation method argument.
   ///
   /// When the incoming request has a header with the name [name],
@@ -106,7 +102,7 @@ class Bind {
   ///
   /// If a declaration with this metadata is a property without any additional metadata, it is optional for all methods in an [RESTController].
   /// If a declaration with this metadata is a property with [requiredHTTPParameter], it is required for all methods in an [RESTController].
-  const Bind.header(this.name) : _type  = _BindType.header;
+  const Bind.header(this.name) : _type = _BindType.header;
 
   /// Binds an HTTP request body to an [RESTController] property or operation method argument.
   ///
@@ -139,7 +135,9 @@ class Bind {
   /// No operation method will be called in this case.
   ///
   /// If not required and not present in a request, the bound arguments and properties will be null when the operation method is invoked.
-  const Bind.body() : name = null, _type  = _BindType.body;
+  const Bind.body()
+      : name = null,
+        _type = _BindType.body;
 
   /// Binds a route variable from [HTTPRequestPath.variables] to an [RESTController] operation method argument.
   ///
@@ -160,7 +158,7 @@ class Bind {
   ///
   /// If the request path is /users/1, /users/2, etc., `getOneUser` is invoked because the path variable `id` is present and matches
   /// the [Bind.path] argument. If no path variables are present, `getUsers` is invoked.
-  const Bind.path(this.name) : _type  = _BindType.path;
+  const Bind.path(this.name) : _type = _BindType.path;
 
   final String name;
   final _BindType _type;
@@ -168,43 +166,21 @@ class Bind {
   /// Used internally
   HTTPBinding get binding {
     switch (_type) {
-      case _BindType.query: return new HTTPQuery(name);
-      case _BindType.method: return new HTTPMethod(name);
-      case _BindType.header: return new HTTPHeader(name);
-      case _BindType.body: return new HTTPBody();
-      case _BindType.path: return new HTTPPath(name);
-      default: return null;
+      case _BindType.query:
+        return new HTTPQuery(name);
+      case _BindType.header:
+        return new HTTPHeader(name);
+      case _BindType.body:
+        return new HTTPBody();
+      case _BindType.path:
+        return new HTTPPath(name);
+      default:
+        return null;
     }
   }
 }
 
-enum _BindType {
-  query, method, header, body, path
-}
-
-/// Binds an [RESTController] operation method to HTTP GET requests.
-///
-/// Equivalent to [Bind.method] with "GET" argument.
-@Deprecated("4.0; use Bind.get() instead")
-const Bind httpGet = const Bind.method("get");
-
-/// Binds an [RESTController] operation method to HTTP PUT requests.
-///
-/// Equivalent to [Bind.method] with "PUT" argument.
-@Deprecated("4.0; use Bind.put() instead")
-const Bind httpPut = const Bind.method("put");
-
-/// Binds an [RESTController] operation method to HTTP POST requests.
-///
-/// Equivalent to [Bind.method] with "POST" argument.
-@Deprecated("4.0; use Bind.post() instead")
-const Bind httpPost = const Bind.method("post");
-
-/// Binds an [RESTController] operation method to HTTP DELETE requests.
-///
-/// Equivalent to [Bind.method] with "DELETE" argument requests.
-@Deprecated("4.0; use Bind.delete() instead")
-const Bind httpDelete = const Bind.method("delete");
+enum _BindType { query, header, body, path }
 
 /// Marks an [RESTController] property binding as required.
 ///
@@ -229,11 +205,9 @@ const Bind httpDelete = const Bind.method("delete");
 ///           Future<Response> getAllUsers() async
 ///              => return Response.ok(await getUsers());
 ///         }
-const HTTPRequiredParameter requiredHTTPParameter =
-    const HTTPRequiredParameter();
+const HTTPRequiredParameter requiredHTTPParameter = const HTTPRequiredParameter();
 
 /// See [requiredHTTPParameter].
 class HTTPRequiredParameter {
   const HTTPRequiredParameter();
 }
-

--- a/lib/src/http/rest_controller_internal/bindings.dart
+++ b/lib/src/http/rest_controller_internal/bindings.dart
@@ -78,18 +78,6 @@ class HTTPValueBinding {
   String errorMessage;
 }
 
-class HTTPMethod extends HTTPBinding {
-  HTTPMethod(String method) : super(method.toLowerCase());
-
-  @override
-  String get type => "Method";
-
-  @override
-  dynamic parse(ClassMirror intoType, Request request) {
-    return request.raw.method.toLowerCase();
-  }
-}
-
 class HTTPPath extends HTTPBinding {
   HTTPPath(String segment) : super(segment);
 

--- a/lib/src/http/rest_controller_internal/utility.dart
+++ b/lib/src/http/rest_controller_internal/utility.dart
@@ -46,10 +46,10 @@ Map<Symbol, dynamic> toSymbolMap(List<HTTPValueBinding> boundValues) {
 
 
 bool isOperation(DeclarationMirror m) {
-  return methodBindingFrom(m) != null;
+  return getMethodOperationMetadata(m) != null;
 }
 
-HTTPMethod methodBindingFrom(DeclarationMirror m) {
+Operation getMethodOperationMetadata(DeclarationMirror m) {
   if (m is! MethodMirror) {
     return null;
   }
@@ -59,15 +59,7 @@ HTTPMethod methodBindingFrom(DeclarationMirror m) {
     return null;
   }
 
-  Bind metadata = method.metadata.firstWhere((im) => im.reflectee is Bind, orElse: () => null)?.reflectee;
-  if (metadata == null) {
-    return null;
-  }
+  Operation metadata = method.metadata.firstWhere((im) => im.reflectee is Operation, orElse: () => null)?.reflectee;
 
-  var binding = metadata.binding;
-  if (binding is! HTTPMethod) {
-    return null;
-  }
-
-  return binding;
+  return metadata;
 }

--- a/templates/db_and_auth/lib/controller/identity_controller.dart
+++ b/templates/db_and_auth/lib/controller/identity_controller.dart
@@ -2,7 +2,7 @@ import '../wildfire.dart';
 import '../model/user.dart';
 
 class IdentityController extends RESTController {
-  @Bind.get()
+  @Operation.get()
   Future<Response> getIdentity() async {
     var q = new Query<User>()
       ..where.id = request.authorization.resourceOwnerIdentifier;

--- a/templates/db_and_auth/lib/controller/register_controller.dart
+++ b/templates/db_and_auth/lib/controller/register_controller.dart
@@ -6,7 +6,7 @@ class RegisterController extends QueryController<User> {
 
   AuthServer authServer;
 
-  @Bind.post()
+  @Operation.post()
   Future<Response> createUser() async {
     if (query.values.username == null || query.values.password == null) {
       return new Response.badRequest(

--- a/templates/db_and_auth/lib/controller/user_controller.dart
+++ b/templates/db_and_auth/lib/controller/user_controller.dart
@@ -6,7 +6,7 @@ class UserController extends QueryController<User> {
 
   AuthServer authServer;
 
-  @Bind.get()
+  @Operation.get("id")
   Future<Response> getUser(@Bind.path("id") int id) async {
     var u = await query.fetchOne();
     if (u == null) {
@@ -20,7 +20,7 @@ class UserController extends QueryController<User> {
     return new Response.ok(u);
   }
 
-  @Bind.put()
+  @Operation.put("id")
   Future<Response> updateUser(@Bind.path("id") int id) async {
     if (request.authorization.resourceOwnerIdentifier != id) {
       return new Response.unauthorized();
@@ -34,7 +34,7 @@ class UserController extends QueryController<User> {
     return new Response.ok(u);
   }
 
-  @Bind.delete()
+  @Operation.delete("id")
   Future<Response> deleteUser(@Bind.path("id") int id) async {
     if (request.authorization.resourceOwnerIdentifier != id) {
       return new Response.unauthorized();

--- a/test/db/model_controller_test.dart
+++ b/test/db/model_controller_test.dart
@@ -69,7 +69,7 @@ void main() {
 }
 
 class TestModelController extends QueryController<TestModel> {
-  @Bind.get()
+  @Operation.get()
   Future<Response> getAll() async {
     int statusCode = 200;
 
@@ -84,7 +84,7 @@ class TestModelController extends QueryController<TestModel> {
     return new Response(statusCode, {}, null);
   }
 
-  @Bind.get()
+  @Operation.get("id")
   Future<Response> getOne(@Bind.path("id") int id) async {
     int statusCode = 200;
 
@@ -105,7 +105,7 @@ class TestModelController extends QueryController<TestModel> {
     return new Response(statusCode, {}, null);
   }
 
-  @Bind.put()
+  @Operation.put("id")
   Future<Response> putOne(@Bind.path("id") int id) async {
     int statusCode = 200;
 
@@ -136,7 +136,7 @@ class TestModelController extends QueryController<TestModel> {
     return new Response(statusCode, {}, null);
   }
 
-  @Bind.post()
+  @Operation.post()
   Future<Response> create() async {
     int statusCode = 200;
     if (query.values == null) {
@@ -152,7 +152,7 @@ class TestModelController extends QueryController<TestModel> {
     return new Response(statusCode, {}, null);
   }
 
-  @Bind.post()
+  @Operation.post("id")
   Future<Response> crash(@Bind.path("id") int id) async {
     return new Response.ok("");
   }
@@ -169,7 +169,7 @@ class _TestModel {
 }
 
 class StringController extends QueryController<StringModel> {
-  @Bind.get()
+  @Operation.get("id")
   Future<Response> get(@Bind.path("id") String id) async {
     ComparisonMatcherExpression comparisonMatcher = query.where["foo"];
     return new Response.ok(comparisonMatcher.value);

--- a/test/http/application_test.dart
+++ b/test/http/application_test.dart
@@ -168,14 +168,14 @@ class TestChannel extends ApplicationChannel {
 }
 
 class TController extends RESTController {
-  @Bind.get()
+  @Operation.get()
   Future<Response> getAll() async {
     return new Response.ok("t_ok");
   }
 }
 
 class RController extends RESTController {
-  @Bind.get()
+  @Operation.get()
   Future<Response> getAll() async {
     return new Response.ok("r_ok");
   }

--- a/test/http/client_test_test.dart
+++ b/test/http/client_test_test.dart
@@ -23,7 +23,7 @@ void main() {
 }
 
 class TestController extends RESTController {
-  @Bind.get()
+  @Operation.get()
   Future<Response> get() async {
     return new Response.ok([
       {"id": 1},

--- a/test/http/cors_test.dart
+++ b/test/http/cors_test.dart
@@ -636,24 +636,24 @@ class NoPolicyController extends RESTController {
     policy = null;
   }
 
-  @Bind.get()
+  @Operation.get()
   Future<Response> getAll() async {
     return new Response.ok("getAll");
   }
 
-  @Bind.post()
+  @Operation.post()
   Future<Response> throwException() async {
     throw new HTTPResponseException(400, "Foobar");
   }
 }
 
 class DefaultPolicyController extends RESTController {
-  @Bind.get()
+  @Operation.get()
   Future<Response> getAll() async {
     return new Response.ok("getAll");
   }
 
-  @Bind.post()
+  @Operation.post()
   Future<Response> throwException() async {
     throw new HTTPResponseException(400, "Foobar");
   }
@@ -666,12 +666,12 @@ class RestrictiveNoCredsOriginController extends RESTController {
     policy.exposedResponseHeaders = ["foobar"];
   }
 
-  @Bind.get()
+  @Operation.get()
   Future<Response> getAll() async {
     return new Response.ok("getAll");
   }
 
-  @Bind.post()
+  @Operation.post()
   Future<Response> makeThing() async {
     return new Response.ok("makeThing");
   }
@@ -682,12 +682,13 @@ class RestrictiveOriginController extends RESTController {
     policy.allowedOrigins = ["http://exclusive.com"];
     policy.exposedResponseHeaders = ["foobar", "x-foo"];
   }
-  @Bind.get()
+
+  @Operation.get()
   Future<Response> getAll() async {
     return new Response.ok("getAll");
   }
 
-  @Bind.post()
+  @Operation.post()
   Future<Response> makeThing() async {
     return new Response.ok("makeThing");
   }
@@ -698,7 +699,7 @@ class OptionsController extends RESTController {
     policy = null;
   }
 
-  @Bind.method("options")
+  @Operation("OPTIONS")
   Future<Response> getThing() async {
     return new Response.ok("getThing");
   }
@@ -715,7 +716,7 @@ class AdditiveController extends RESTController {
     policy.exposedResponseHeaders.add("X-Header");
   }
 
-  @Bind.get()
+  @Operation.get()
   Future<Response> getThing() async {
     return new Response.ok(null);
   }

--- a/test/http/document_test.dart
+++ b/test/http/document_test.dart
@@ -460,19 +460,19 @@ class TController extends RESTController {
   /// ABCD
   /// EFGH
   /// IJKL
-  @Bind.get()
+  @Operation.get()
   Future<Response> getAll({@Bind.query("param") String param}) async {
     return new Response.ok("");
   }
 
   /// ABCD
-  @Bind.put()
+  @Operation.put("id")
   Future<Response> putOne(@Bind.path("id") int id,
       {@Bind.query("p1") int p1, @Bind.header("X-P2") int p2}) async {
     return new Response.ok("");
   }
 
-  @Bind.get()
+  @Operation.get("id")
   Future<Response> getOne(@Bind.path("id") int id) async {
     return new Response.ok("");
   }
@@ -480,14 +480,14 @@ class TController extends RESTController {
   /// MNOP
   /// QRST
 
-  @Bind.get()
+  @Operation.get("id", "notID")
   Future<Response> getTwo(@Bind.path("id") int id, @Bind.path("notID") int notID) async {
     return new Response.ok("");
   }
 
   /// EFGH
   /// IJKL
-  @Bind.post()
+  @Operation.post()
   Future<Response> createOne(
       @Bind.header("X-Date") DateTime date, @Bind.query("foo") String foo) async {
     return new Response.ok("");

--- a/test/http/isolate/recovery_test.dart
+++ b/test/http/isolate/recovery_test.dart
@@ -81,7 +81,7 @@ class TestChannel extends ApplicationChannel {
 }
 
 class UncaughtCrashController extends RESTController {
-  @Bind.get()
+  @Operation.get()
   Future<Response> crashUncaught() async {
     new Future(() {
       var x;
@@ -90,7 +90,7 @@ class UncaughtCrashController extends RESTController {
     return new Response.ok(null);
   }
 
-  @Bind.get()
+  @Operation.get("id")
   Future<Response> dontCrash(@Bind.path("id") int id) async {
     return new Response.ok(null);
   }

--- a/test/http/rest_controller_body_binding_test.dart
+++ b/test/http/rest_controller_body_binding_test.dart
@@ -211,21 +211,21 @@ class CrashModel implements HTTPSerializable {
 }
 
 class TestController extends RESTController {
-  @Bind.post()
+  @Operation.post()
   Future<Response> create(@Bind.body() TestModel tm) async {
     return new Response.ok(tm);
   }
 }
 
 class ListTestController extends RESTController {
-  @Bind.post()
+  @Operation.post()
   Future<Response> create(@Bind.body() List<TestModel> tms) async {
     return new Response.ok(tms);
   }
 }
 
 class OptionalTestController extends RESTController {
-  @Bind.post()
+  @Operation.post()
   Future<Response> create({@Bind.body() TestModel tm}) async {
     return new Response.ok(tm);
   }
@@ -235,28 +235,28 @@ class PropertyTestController extends RESTController {
   @Bind.body()
   TestModel tm;
 
-  @Bind.post()
+  @Operation.post()
   Future<Response> create() async {
     return new Response.ok(tm);
   }
 }
 
 class NotSerializableController extends RESTController {
-  @Bind.post()
+  @Operation.post()
   Future<Response> create(@Bind.body() Uri uri) async {
     return new Response.ok(null);
   }
 }
 
 class ListNotSerializableController extends RESTController {
-  @Bind.post()
+  @Operation.post()
   Future<Response> create(@Bind.body() List<Uri> uri) async {
     return new Response.ok(null);
   }
 }
 
 class CrashController extends RESTController {
-  @Bind.post()
+  @Operation.post()
   Future<Response> create(@Bind.body() CrashModel tm) async {
     return new Response.ok(null);
   }

--- a/test/http/sink_test.dart
+++ b/test/http/sink_test.dart
@@ -33,7 +33,7 @@ class TestChannel extends ApplicationChannel {
 }
 
 class FailingController extends RESTController {
-  @Bind.get()
+  @Operation.get()
   Future<Response> get() async {
     return new Response.ok(null);
   }


### PR DESCRIPTION
Makes operation methods more explicit and clarifies behavior of `Bind`. Operation methods now must declare the HTTP method and the path variables that select them.

Examples:

```dart
@Operation.get()
Future<Response> getAll() => ...;

@Operation.get("id")
Future<Response> getOne(@Bind.path("id") int id) => ...;
```