### PR TITLE
Prevents values from directly being assigned to Query.where properties

### DIFF
--- a/lib/managed_auth.dart
+++ b/lib/managed_auth.dart
@@ -316,7 +316,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
   Future<AuthToken> fetchTokenByAccessToken(
       AuthServer server, String accessToken) async {
     var query = new Query<ManagedAuthToken>(context)
-      ..where.accessToken = accessToken;
+      ..where.accessToken = whereEqualTo(accessToken);
     var token = await query.fetchOne();
 
     return token?.asToken();
@@ -326,7 +326,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
   Future<AuthToken> fetchTokenByRefreshToken(
       AuthServer server, String refreshToken) async {
     var query = new Query<ManagedAuthToken>(context)
-      ..where.refreshToken = refreshToken;
+      ..where.refreshToken = whereEqualTo(refreshToken);
     var token = await query.fetchOne();
 
     return token?.asToken();
@@ -335,7 +335,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
   @override
   Future<T> fetchAuthenticatableByUsername(AuthServer server, String username) {
     var query = new Query<T>(context)
-      ..where.username = username
+      ..where.username = whereEqualTo(username)
       ..returningProperties((t) => [t.id, t.hashedPassword, t.salt, t.username]);
 
     return query.fetchOne();
@@ -343,7 +343,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
 
   @override
   Future revokeTokenIssuedFromCode(AuthServer server, AuthCode code) {
-    var query = new Query<ManagedAuthToken>(context)..where.code = code.code;
+    var query = new Query<ManagedAuthToken>(context)..where.code = whereEqualTo(code.code);
 
     return query.delete();
   }
@@ -377,7 +377,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
       DateTime newIssueDate,
       DateTime newExpirationDate) {
     var query = new Query<ManagedAuthToken>(context)
-      ..where.accessToken = oldAccessToken
+      ..where.accessToken = whereEqualTo(oldAccessToken)
       ..values.accessToken = newAccessToken
       ..values.issueDate = newIssueDate
       ..values.expirationDate = newExpirationDate;
@@ -396,7 +396,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
 
   @override
   Future<AuthCode> fetchAuthCodeByCode(AuthServer server, String code) async {
-    var query = new Query<ManagedAuthToken>(context)..where.code = code;
+    var query = new Query<ManagedAuthToken>(context)..where.code = whereEqualTo(code);
 
     var storage = await query.fetchOne();
     return storage?.asAuthCode();
@@ -404,14 +404,14 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
 
   @override
   Future revokeAuthCodeWithCode(AuthServer server, String code) {
-    var query = new Query<ManagedAuthToken>(context)..where.code = code;
+    var query = new Query<ManagedAuthToken>(context)..where.code = whereEqualTo(code);
 
     return query.delete();
   }
 
   @override
   Future<AuthClient> fetchClientByID(AuthServer server, String id) async {
-    var query = new Query<ManagedAuthClient>(context)..where.id = id;
+    var query = new Query<ManagedAuthClient>(context)..where.id = whereEqualTo(id);
 
     var storage = await query.fetchOne();
 
@@ -420,7 +420,7 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
 
   @override
   Future revokeClientWithID(AuthServer server, String id) {
-    var query = new Query<ManagedAuthClient>(context)..where.id = id;
+    var query = new Query<ManagedAuthClient>(context)..where.id = whereEqualTo(id);
 
     return query.delete();
   }

--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -84,17 +84,9 @@ class ManagedMatcherBacking extends ManagedBacking {
         valueMap[propertyName] = value;
       }
     } else {
-      // Setting simply a value, wrap it with an AssignmentMatcher if applicable.
-      if (entity.relationships.containsKey(propertyName)) {
-        throw new QueryException(QueryExceptionEvent.internalFailure,
-            message:
-                "Attempting to set a value for property '${entity.tableName}.$propertyName' "
-                "on, but that property is a relationship. Valid values for relationship "
-                "properties are whereRelatedByValue, whereNull, or whereNotNull.");
-      }
+      final typeName = MirrorSystem.getName(entity.instanceType.simpleName);
 
-      valueMap[propertyName] =
-          new ComparisonMatcherExpression(value, MatcherOperator.equalTo);
+      throw new ArgumentError("Tried assigning value to 'Query<$typeName>.where.$propertyName'. Wrap value in 'whereEqualTo()'.");
     }
   }
 }

--- a/lib/src/http/query_controller.dart
+++ b/lib/src/http/query_controller.dart
@@ -44,11 +44,11 @@ abstract class QueryController<InstanceType extends ManagedObject>
       if (idValue != null) {
         var primaryKeyDesc = query.entity.attributes[query.entity.primaryKey];
         if (primaryKeyDesc.isAssignableWith(idValue)) {
-          query.where[query.entity.primaryKey] = idValue;
+          query.where[query.entity.primaryKey] = whereEqualTo(idValue);
         } else if (primaryKeyDesc.type == ManagedPropertyType.bigInteger ||
             primaryKeyDesc.type == ManagedPropertyType.integer) {
           try {
-            query.where[query.entity.primaryKey] = int.parse(idValue);
+            query.where[query.entity.primaryKey] = whereEqualTo(int.parse(idValue));
           } on FormatException {            
             return new Response.notFound();
           }

--- a/templates/db_and_auth/lib/controller/identity_controller.dart
+++ b/templates/db_and_auth/lib/controller/identity_controller.dart
@@ -5,7 +5,7 @@ class IdentityController extends RESTController {
   @Bind.get()
   Future<Response> getIdentity() async {
     var q = new Query<User>()
-      ..where.id = request.authorization.resourceOwnerIdentifier;
+      ..where.id = whereEqualTo(request.authorization.resourceOwnerIdentifier);
 
     var u = await q.fetchOne();
     if (u == null) {

--- a/templates/db_and_auth/lib/controller/user_controller.dart
+++ b/templates/db_and_auth/lib/controller/user_controller.dart
@@ -41,7 +41,7 @@ class UserController extends QueryController<User> {
     }
 
     await authServer.revokeAuthenticatableAccessForIdentifier(id);
-    var q = new Query<User>()..where.id = id;
+    var q = new Query<User>()..where.id = whereEqualTo(id);
     await q.delete();
 
     return new Response.ok(null);

--- a/test/command/create_test.dart
+++ b/test/command/create_test.dart
@@ -121,8 +121,8 @@ void main() {
         var res = Process.runSync("pub", ["run", "test", "-j", "1"],
             runInShell: true, workingDirectory: temporaryDirectory.path);
 
-        expect(res.exitCode, 0);
         expect(res.stdout, contains("All tests passed"));
+        expect(res.exitCode, 0);
       });
     }
   });

--- a/test/db/model_controller_test.dart
+++ b/test/db/model_controller_test.dart
@@ -171,7 +171,7 @@ class _TestModel {
 class StringController extends QueryController<StringModel> {
   @Bind.get()
   Future<Response> get(@Bind.path("id") String id) async {
-    ComparisonMatcherExpression comparisonMatcher = query.where["foo"];
+    StringMatcherExpression comparisonMatcher = query.where["foo"];
     return new Response.ok(comparisonMatcher.value);
   }
 }

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -338,15 +338,9 @@ void main() {
     context = await contextWithModels([PrivateField]);
 
     await (new Query<PrivateField>()).insert();
-    var q = new Query<PrivateField>()
-      ..where.public = "x";
-    var result = await q.fetchOne();
-    expect(result.public, "x");
-
-    q = new Query<PrivateField>()
-      ..where.public = "y";
-    result = await q.fetchOne();
-    expect(result, isNull);
+    var q = new Query<PrivateField>();
+    var result = await q.fetch();
+    expect(result.first.public, "x");
   });
 
   test("When fetching valid enum value from db, is available as enum value and in where", () async {
@@ -363,12 +357,12 @@ void main() {
     expect(result.asMap()["enumValues"], "abcd");
 
     q = new Query<EnumObject>()
-      ..where.enumValues = EnumValues.abcd;
+      ..where.enumValues = whereEqualTo(EnumValues.abcd);
     result = await q.fetchOne();
     expect(result, isNotNull);
 
     q = new Query<EnumObject>()
-      ..where.enumValues = EnumValues.efgh;
+      ..where.enumValues = whereEqualTo(EnumValues.efgh);
     result = await q.fetchOne();
     expect(result, isNull);
   });

--- a/test/db/postgresql/has_many_fetch_test.dart
+++ b/test/db/postgresql/has_many_fetch_test.dart
@@ -30,7 +30,7 @@ void main() {
         () async {
       var q = new Query<Parent>()
         ..join(set: (p) => p.children)
-        ..where.name = "D";
+        ..where.name = whereEqualTo("D");
 
       var verifier = (Parent p) {
         expect(p.name, "D");
@@ -44,7 +44,7 @@ void main() {
     test(
         "Fetch has-many relationship that is empty returns empty, and deeper nested relationships are ignored even when included",
         () async {
-      var q = new Query<Parent>()..where.name = "D";
+      var q = new Query<Parent>()..where.name = whereEqualTo("D");
 
       q.join(set: (p) => p.children)
         ..join(object: (c) => c.toy)
@@ -64,7 +64,7 @@ void main() {
         () async {
       var q = new Query<Parent>()
         ..join(set: (p) => p.children)
-        ..where.name = "C";
+        ..where.name = whereEqualTo("C");
 
       var verifier = (Parent p) {
         expect(p.name, "C");
@@ -81,7 +81,7 @@ void main() {
     test(
         "Fetch has-many relationship, include has-one and has-many in that has-many, where bottom of graph has valid object for hasmany but not for hasone",
         () async {
-      var q = new Query<Parent>()..where.name = "B";
+      var q = new Query<Parent>()..where.name = whereEqualTo("B");
 
       q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
@@ -113,7 +113,7 @@ void main() {
     test(
         "Fetch has-many relationship, include has-one and has-many in that has-many, where bottom of graph has valid object for hasone but not for hasmany",
         () async {
-      var q = new Query<Parent>()..where.name = "A";
+      var q = new Query<Parent>()..where.name = whereEqualTo("A");
 
       q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
@@ -234,7 +234,7 @@ void main() {
 
     test("Predicate impacts top-level objects when fetching object graph",
         () async {
-      var q = new Query<Parent>()..where.name = "A";
+      var q = new Query<Parent>()..where.name = whereEqualTo("A");
 
       q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
@@ -263,7 +263,7 @@ void main() {
       var q = new Query<Parent>();
 
       q.join(set: (p) => p.children)
-        ..where.name = "C1"
+        ..where.name = whereEqualTo("C1")
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
         ..join(set: (c) => c.vaccinations)
             .sortBy((v) => v.vid, QuerySortOrder.ascending)
@@ -290,7 +290,7 @@ void main() {
       var q = new Query<Parent>();
 
       var childJoin = q.join(set: (p) => p.children)..join(object: (c) => c.toy);
-      childJoin.join(set: (c) => c.vaccinations)..where.kind = "V1";
+      childJoin.join(set: (c) => c.vaccinations)..where.kind = whereEqualTo("V1");
 
       var results = await q.fetch();
 
@@ -325,10 +325,10 @@ void main() {
     test(
         "Predicate that omits top-level objects but would include lower level object return no results",
         () async {
-      var q = new Query<Parent>()..where.pid = 5;
+      var q = new Query<Parent>()..where.pid = whereEqualTo(5);
 
       var childJoin = q.join(set: (p) => p.children)..join(object: (c) => c.toy);
-      childJoin.join(set: (c) => c.vaccinations)..where.kind = "V1";
+      childJoin.join(set: (c) => c.vaccinations)..where.kind = whereEqualTo("V1");
 
       var results = await q.fetch();
       expect(results.length, 0);
@@ -403,7 +403,7 @@ void main() {
 
     test("Objects returned in join are not the same instance", () async {
       var q = new Query<Parent>()
-        ..where.pid = 1
+        ..where.pid = whereEqualTo(1)
         ..join(set: (p) => p.children);
 
       var o = await q.fetchOne();

--- a/test/db/postgresql/has_one_fetch_test.dart
+++ b/test/db/postgresql/has_one_fetch_test.dart
@@ -30,7 +30,7 @@ void main() {
         () async {
       var q = new Query<Parent>()
         ..join(object: (p) => p.child)
-        ..where.name = "D";
+        ..where.name = whereEqualTo("D");
 
       var verifier = (Parent p) {
         expect(p.name, "D");
@@ -45,7 +45,7 @@ void main() {
     test(
         "Fetch has-one relationship that is null returns null for property, and more nested has relationships are ignored",
         () async {
-      var q = new Query<Parent>()..where.name = "D";
+      var q = new Query<Parent>()..where.name = whereEqualTo("D");
 
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
@@ -61,7 +61,7 @@ void main() {
       verifier((await q.fetch()).first);
 
       var dynQuery = new Query.forEntity(context.dataModel.entityForType(Parent))
-        ..where["name"] = "D";
+        ..where["name"] = whereEqualTo("D");
 
       dynQuery.join<ManagedObject>(object: (p) => p["child"])
         ..join<ManagedObject>(object: (c) => c["toy"])
@@ -75,7 +75,7 @@ void main() {
         () async {
       var q = new Query<Parent>()
         ..join(object: (p) => p.child)
-        ..where.name = "C";
+        ..where.name = whereEqualTo("C");
 
       var verifier = (Parent p) {
         expect(p.name, "C");
@@ -92,7 +92,7 @@ void main() {
     test(
         "Fetch has-one relationship, include has-one and has-many in that has-one, where bottom of graph has valid object for hasmany but not for hasone",
         () async {
-      var q = new Query<Parent>()..where.name = "B";
+      var q = new Query<Parent>()..where.name = whereEqualTo("B");
 
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
@@ -117,7 +117,7 @@ void main() {
     test(
         "Fetch has-one relationship, include has-one and has-many in that has-one, where bottom of graph is all null/empty",
         () async {
-      var q = new Query<Parent>()..where.name = "C";
+      var q = new Query<Parent>()..where.name = whereEqualTo("C");
 
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
@@ -200,7 +200,7 @@ void main() {
 
     test("Predicate impacts top-level objects when fetching object graph",
         () async {
-      var q = new Query<Parent>()..where.name = "A";
+      var q = new Query<Parent>()..where.name = whereEqualTo("A");
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
         ..join(set: (c) => c.vaccinations)
@@ -222,7 +222,7 @@ void main() {
         () async {
       var q = new Query<Parent>();
       q.join(object: (p) => p.child)
-        ..where.name = "C1"
+        ..where.name = whereEqualTo("C1")
         ..join(object: (c) => c.toy)
         ..join(set: (c) => c.vaccinations)
             .sortBy((v) => v.vid, QuerySortOrder.ascending);
@@ -248,7 +248,7 @@ void main() {
         () async {
       var q = new Query<Parent>();
       var childJoin = q.join(object: (p) => p.child)..join(object: (c) => c.toy);
-      childJoin.join(set: (c) => c.vaccinations)..where.kind = "V1";
+      childJoin.join(set: (c) => c.vaccinations)..where.kind = whereEqualTo("V1");
 
       var results = await q.fetch();
 
@@ -269,10 +269,10 @@ void main() {
     test(
         "Predicate that omits top-level objects but would include lower level object return no results",
         () async {
-      var q = new Query<Parent>()..where.pid = 5;
+      var q = new Query<Parent>()..where.pid = whereEqualTo(5);
 
       var childJoin = q.join(object: (p) => p.child)..join(object: (c) => c.toy);
-      childJoin.join(set: (c) => c.vaccinations)..where.kind = "V1";
+      childJoin.join(set: (c) => c.vaccinations)..where.kind = whereEqualTo("V1");
       var results = await q.fetch();
       expect(results.length, 0);
     });
@@ -359,7 +359,7 @@ void main() {
 
     test("Objects returned in join are not the same instance", () async {
       var q = new Query<Parent>()
-        ..where.pid = 1
+        ..where.pid = whereEqualTo(1)
         ..join(object: (p) => p.child);
 
       var o = await q.fetchOne();

--- a/test/db/postgresql/insert_test.dart
+++ b/test/db/postgresql/insert_test.dart
@@ -270,14 +270,13 @@ void main() {
     expect(result.id, greaterThan(0));
   });
 
-  test("Can use public accessor to set private property in values", () async {
+  test("Can use insert private properties", () async {
     context = await contextWithModels([PrivateField]);
 
-    await (new Query<PrivateField>()..values.public = "x").insert();
-    var q = new Query<PrivateField>()
-      ..where.public = "x";
-    var result = await q.fetchOne();
-    expect(result.public, "x");
+    await (new Query<PrivateField>()..values.public = "abc").insert();
+    var q = new Query<PrivateField>();
+    var result = await q.fetch();
+    expect(result.first.public, "abc");
   });
 
   test("Can use enum to set property to be stored in db", () async {

--- a/test/db/postgresql/matcher_test.dart
+++ b/test/db/postgresql/matcher_test.dart
@@ -78,7 +78,6 @@ void main() {
     });
   });
 
-
   test("Less than matcher", () async {
     var q = new Query<TestModel>()..where["id"] = whereLessThan(3);
     var results = await q.fetch();
@@ -178,7 +177,6 @@ void main() {
       expect(results.any((t) => t.id == 1), true);
     });
   });
-
 
   test("whereIn matcher", () async {
     var q = new Query<TestModel>()..where["id"] = whereIn([1, 2]);
@@ -432,6 +430,15 @@ void main() {
     });
   });
 
+  test("Assigning Query.where to non-matcher value throws desrictive exception", () async {
+    try {
+      final _ = new Query<TestModel>()..where.id = 6;
+      expect(true, false);
+    } on ArgumentError catch (e) {
+      expect(e.message,
+          contains("Tried assigning value to 'Query<TestModel>.where.id'. Wrap value"));
+    }
+  });
 }
 
 class TestModel extends ManagedObject<_TestModel> implements _TestModel {}

--- a/test/db/postgresql/matcher_test.dart
+++ b/test/db/postgresql/matcher_test.dart
@@ -439,6 +439,15 @@ void main() {
           contains("Tried assigning value to 'Query<TestModel>.where.id'. Wrap value"));
     }
   });
+
+  test("Re-assignment to null removes matcher", () async {
+    final query = new Query<TestModel>()
+        ..where.id = whereEqualTo(6);
+    query.where.id = null;
+
+    final results = await query.fetch();
+    expect(results.length, 6);
+  });
 }
 
 class TestModel extends ManagedObject<_TestModel> implements _TestModel {}

--- a/test/db/postgresql/update_test.dart
+++ b/test/db/postgresql/update_test.dart
@@ -124,7 +124,7 @@ void main() {
     await req.insert();
 
     var q = new Query<TestModel>()
-      ..where["name"] = "Bob"
+      ..where["name"] = whereEqualTo("Bob")
       ..values = (new TestModel()..emailAddress = "3@a.com");
 
     List<TestModel> results = await q.update();
@@ -149,7 +149,7 @@ void main() {
         .insert();
 
     var updateQuery = new Query<TestModel>()
-      ..where["emailAddress"] = "1@a.com"
+      ..where["emailAddress"] = whereEqualTo("1@a.com")
       ..values.emailAddress = "3@a.com";
     var updatedObject = (await updateQuery.update()).first;
 
@@ -284,7 +284,7 @@ void main() {
 
     try {
       var q = new Query<TestModel>()
-        ..where.emailAddress = "2@a.com"
+        ..where.emailAddress = whereEqualTo("2@a.com")
         ..values.emailAddress = "1@a.com";
       await q.updateOne();
       expect(true, false);

--- a/test/db/postgresql/validation_test.dart
+++ b/test/db/postgresql/validation_test.dart
@@ -121,7 +121,7 @@ void main() {
   test("willUpdate runs prior to update", () async {
     var q = new Query<U>();
     var o = await q.insert();
-    q = new Query<U>()..where.id = o.id;
+    q = new Query<U>()..where.id = whereEqualTo(o.id);
     o = (await q.update()).first;
     expect(o.q, "willUpdate");
   });
@@ -138,7 +138,7 @@ void main() {
     var q = new Query<V>();
     var o = await q.insert();
 
-    q = new Query<V>()..where.id = o.id;
+    q = new Query<V>()..where.id = whereEqualTo(o.id);
     try {
       await q.update();
       expect(true, false);

--- a/test/managed_auth/managed_auth_role_storage_test.dart
+++ b/test/managed_auth/managed_auth_role_storage_test.dart
@@ -299,7 +299,7 @@ class RoleBasedAuthStorage extends ManagedAuthStorage<User> {
   Future<User> fetchAuthenticatableByUsername(
       AuthServer server, String username) {
     var query = new Query<User>(context)
-      ..where.username = username
+      ..where.username = whereEqualTo(username)
       ..returningProperties((t) => [t.id, t.hashedPassword, t.salt, t.username, t.role]);
 
     return query.fetchOne();

--- a/test/managed_auth/managed_auth_storage_test.dart
+++ b/test/managed_auth/managed_auth_storage_test.dart
@@ -507,7 +507,7 @@ void main() {
         expect(true, false);
       } on AuthServerException {}
 
-      var q = new Query<ManagedAuthToken>()..where.code = code.code;
+      var q = new Query<ManagedAuthToken>()..where.code = whereEqualTo(code.code);
       expect(await q.fetch(), isEmpty);
     });
 
@@ -770,11 +770,11 @@ void main() {
           exchangedCode.code, "com.stablekernel.redirect", "mckinley");
 
       var codeQuery = new Query<ManagedAuthToken>()
-        ..where.code = exchangedCode.code;
+        ..where.code = whereEqualTo(exchangedCode.code);
       expect(await codeQuery.fetch(), hasLength(1));
 
       var tokenQuery = new Query<ManagedAuthToken>()
-        ..where.accessToken = exchangedToken.accessToken;
+        ..where.accessToken = whereEqualTo(exchangedToken.accessToken);
       await tokenQuery.delete();
 
       expect(await codeQuery.fetch(), isEmpty);


### PR DESCRIPTION
Forces use of matcher instead of implicitly wrapping in `whereEqualTo`.