### PR TITLE
Cleans up Request.path behavior

### DIFF
--- a/lib/src/http/request.dart
+++ b/lib/src/http/request.dart
@@ -14,9 +14,8 @@ typedef void _ResponseModifier(Response resp);
 /// directly to the [HttpRequest], as [Controller]s take that responsibility.
 class Request implements RequestOrResponse {
   /// Creates an instance of [Request], no need to do so manually.
-  Request(this.raw) {
-    _body = new HTTPRequestBody(this.raw);
-  }
+  Request(this.raw) : path = new HTTPRequestPath(raw.uri.pathSegments),
+    body = new HTTPRequestBody(raw);
 
   /// The underlying [HttpRequest] of this instance.
   ///
@@ -36,6 +35,21 @@ class Request implements RequestOrResponse {
   ///         });
   final HttpRequest raw;
 
+  /// The path of the request URI.
+  ///
+  /// Provides convenient access to the request URI path. Also provides path variables and wildcard path values
+  /// after this instance is handled by a [Router].
+  final HTTPRequestPath path;
+
+  /// The request body object.
+  ///
+  /// This object contains the request body if one exists and behavior for decoding it according
+  /// to this instance's content-type. See [HTTPRequestBody] for details on decoding the body into
+  /// an object (or objects).
+  ///
+  /// This value is is always non-null. If there is no request body, [HTTPRequestBody.isEmpty] is true.
+  final HTTPRequestBody body;
+
   /// Information about the client connection.
   ///
   /// Note: accessing this property incurs a significant performance penalty.
@@ -47,13 +61,6 @@ class Request implements RequestOrResponse {
   /// using a [Response] instance to fill out this property.
   HttpResponse get response => raw.response;
 
-  /// The path and any extracted variable parameters from the URI of this request.
-  ///
-  /// Typically set by a [Router] instance when the request has been piped through one,
-  /// this property will contain a list of each path segment, a map of matched variables,
-  /// and any remaining wildcard path.
-  HTTPRequestPath path;
-
   /// Authorization information associated with this request.
   ///
   /// When this request goes through an [Authorizer], this value will be set with
@@ -61,16 +68,6 @@ class Request implements RequestOrResponse {
   /// or other properties of the authentication information in the request. This value will be
   /// null if no permission has been set.
   Authorization authorization;
-
-  /// The request body object.
-  ///
-  /// This object contains the request body if one exists and behavior for decoding it according
-  /// to this instance's content-type. See [HTTPRequestBody] for details on decoding the body into
-  /// an object (or objects).
-  ///
-  /// This value is is always non-null. If there is no request body, [HTTPRequestBody.isEmpty] is true.
-  HTTPRequestBody get body => _body;
-  HTTPRequestBody _body;
 
   List<_ResponseModifier> _responseModifiers;
 

--- a/lib/src/http/request.dart
+++ b/lib/src/http/request.dart
@@ -35,6 +35,11 @@ class Request implements RequestOrResponse {
   ///         });
   final HttpRequest raw;
 
+  /// HTTP method of this request.
+  ///
+  /// Always uppercase. e.g., GET, POST, PUT.
+  String get method => raw.method.toUpperCase();
+
   /// The path of the request URI.
   ///
   /// Provides convenient access to the request URI path. Also provides path variables and wildcard path values

--- a/lib/src/http/request_path.dart
+++ b/lib/src/http/request_path.dart
@@ -1,21 +1,21 @@
 import 'http.dart';
 import 'route_specification.dart';
 
-/// The HTTP request path decomposed into variables and segments based on a [RouteSpecification].
+/// Stores path info for a [Request].
 ///
-/// After passing through a [Router], a [Request] will have an instance of [HTTPRequestPath] in [Request.path].
-/// Any variable path parameters will be available in [variables].
+/// Contains the raw path string, the path as segments and values created by routing a request.
 ///
-/// For each request passes through a router, a new instance of this type is created specific to that request.
+/// Note: The properties [variables], [orderedVariableNames] and [remainingPath] are not set until
+/// after the owning request has passed through a [Router].
 class HTTPRequestPath {
   /// Default constructor for [HTTPRequestPath].
   ///
   /// There is no need to invoke this constructor manually.
-  HTTPRequestPath(this.segments, {int segmentOffset: 0}) : _basePathSegments = segmentOffset;
+  HTTPRequestPath(this.segments);
 
-  set specification(RouteSpecification spec) {
+  void setSpecification(RouteSpecification spec, {int segmentOffset: 0}) {
     var requestIterator = segments.iterator;
-    for (var i = 0; i < _basePathSegments; i ++) {
+    for (var i = 0; i < segmentOffset; i ++) {
       requestIterator.moveNext();
     }
 
@@ -57,7 +57,7 @@ class HTTPRequestPath {
   /// This property will contain every segment of the matched path, including
   /// constant segments. It will not contain any part of the path caught by
   /// the asterisk 'match all' token (*), however. Those are in [remainingPath].
-  List<String> segments = new List<String>();
+  final List<String> segments;
 
   /// If a match specification uses the 'match all' token (*),
   /// the part of the path matched by that token will be stored in this property.
@@ -74,5 +74,8 @@ class HTTPRequestPath {
   /// will appear in this property.
   List<String> orderedVariableNames = [];
 
-  int _basePathSegments = 0;
+  /// The path of the requested URI.
+  ///
+  /// Always contains a leading '/', but never a trailing '/'.
+  String get string => "/" + segments.join("/");
 }

--- a/lib/src/http/rest_controller_binding.dart
+++ b/lib/src/http/rest_controller_binding.dart
@@ -60,7 +60,7 @@ class Bind {
   /// has a query key that matches [name], the argument or property value is set to the query parameter's value. For example,
   /// the request /users?foo=bar would bind the value `bar` to the variable `foo`:
   ///
-  ///         @Bind.method("get")
+  ///         @Operation.get()
   ///         Future<Response> getUsers(@Bind.query("foo") String foo) async => ...;
   ///
   /// [name] is compared case-sensitively, i.e. `Foo` and `foo` are different.
@@ -87,7 +87,7 @@ class Bind {
   /// the argument or property is set to the headers's value. For example,
   /// a request with the header `Authorization: Basic abcdef` would bind the value `Basic abcdef` to the `authHeader`  argument:
   ///
-  ///         @Bind.method("get")
+  ///         @Operation.get()
   ///         Future<Response> getUsers(@Bind.header("Authorization") String authHeader) async => ...;
   ///
   /// [name] is compared case-insensitively; both `Authorization` and `authorization` will match the same header.
@@ -118,7 +118,7 @@ class Bind {
   ///
   ///
   ///       class UserController extends RESTController {
-  ///         @Bind.method("post")
+  ///         @Operation.post()
   ///         Future<Response> createUser(@Bind.body() User user) async {
   ///           var query = new Query<User>()..values = user;
   ///
@@ -150,9 +150,9 @@ class Bind {
   /// consider the above route and a controller with the following operation methods:
   ///
   ///         class UserController extends RESTController {
-  ///           @Bind.get()
+  ///           @Operation.get()
   ///           Future<Response> getUsers() async => new Response.ok(getAllUsers());
-  ///           @Bind.get()
+  ///           @Operation.get('id')
   ///           Future<Response> getOneUser(@Bind.path("id") int id) async => new Response.ok(getUser(id));
   ///         }
   ///
@@ -197,11 +197,11 @@ enum _BindType { query, header, body, path }
 ///           @Bind.header("x-request-id")
 ///           String requestID;
 ///
-///           @Bind.method("get")
+///           @Operation.get('id')
 ///           Future<Response> getUser(@Bind.path("id") int id) async
 ///              => return Response.ok(await getUserByID(id));
 ///
-///           @Bind.method("get")
+///           @Operation.get()
 ///           Future<Response> getAllUsers() async
 ///              => return Response.ok(await getUsers());
 ///         }

--- a/lib/src/http/router.dart
+++ b/lib/src/http/router.dart
@@ -136,14 +136,12 @@ class Router extends Controller {
         }
       }
 
-      req.path = new HTTPRequestPath(req.raw.uri.pathSegments, segmentOffset: _basePathSegments.length);
-
       var node = _rootRouteNode.nodeForPathSegments(requestURISegmentIterator, req.path);
       if (node?.specification == null) {
         await _unmatchedController(req);
         return null;
       }
-      req.path.specification = node.specification;
+      req.path.setSpecification(node.specification, segmentOffset: _basePathSegments.length);
 
       next = node.controller;
     } catch (any, stack) {


### PR DESCRIPTION
- Instantiates Request.path when Request is first created, instead of waiting for it to pass through Router.
- Fills in path variables/remaining path after passing thru Router. 
- Fixes some outdated API refs
- Adds a few more pass-thrus from Request -> Request.raw.