### PR TITLE
Cleans up Authorization related types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@
 - Removes `runOnMainIsolate` from `Application.start()` and introduces `Application.test()` as replacement.
 - Renames `RequestSink` to `ApplicationChannel` and improves its structure.
 - Replaces `AuthCodeController.renderFunction` with `AuthCodeControllerDelegate`.
+- Removes `AuthStrategy` in place of `AuthorizationParser<T>`.
+    - Adds concrete implementations of `AuthorizationParser<T>`, `AuthorizationBearerParser` and `AuthorizationBasicParser`.
+- Removes `AuthValidator.fromBearerToken` and `AuthValidator.fromBasicCredentials` and replaces with `AuthValidator.validate<T>`.    
 - Renames the following:
+    - `AuthStorage` -> `AuthServerDelegate`
+    - `AuthServer.storage` -> `AuthServer.delegate`
     - `ApplicationConfiguration` -> `ApplicationOptions`
     - `Application.configuration` -> `Application.options`
     - `ServiceRegistry` -> `ApplicationServiceRegistry`

--- a/lib/managed_auth.dart
+++ b/lib/managed_auth.dart
@@ -1,7 +1,7 @@
 /// Library for implementing OAuth 2.0 storage using [ManagedObject]s.
 ///
 /// This library contains [ManagedObject] subclasses to represent OAuth 2.0 artifacts
-/// and implements [AuthStorage] for use by an [AuthServer]. Usage of this library involves two tasks.
+/// and implements [AuthServerDelegate] for use by an [AuthServer]. Usage of this library involves two tasks.
 /// First, an instance of [ManagedAuthStorage] is provided to an [AuthServer] at startup:
 ///
 ///         var context = new ManagedContext(dataModel, store);
@@ -273,7 +273,7 @@ class ManagedAuthenticatable implements Authenticatable {
 abstract class ManagedAuthResourceOwner
     implements ManagedAuthenticatable, ManagedObject {}
 
-/// [AuthStorage] implementation for an [AuthServer] using [ManagedObject]s.
+/// [AuthServerDelegate] implementation for an [AuthServer] using [ManagedObject]s.
 ///
 /// An instance of this class manages storage and retrieval of OAuth 2.0 tokens, clients and resource owners
 /// using the [ManagedObject]s declared in this library.
@@ -288,7 +288,7 @@ abstract class ManagedAuthResourceOwner
 ///         var authServer = new AuthServer(storage);
 ///
 class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
-    extends AuthStorage {
+    extends AuthServerDelegate {
 
   /// Creates an instance of this type.
   ///
@@ -296,12 +296,12 @@ class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
   ManagedAuthStorage(this.context, {this.tokenLimit: 40});
 
   /// The [ManagedContext] this instance uses to store and retrieve values.
-  ManagedContext context;
+  final ManagedContext context;
 
   /// The number of tokens and authorization codes a user can have at a time.
   ///
   /// Once this limit is passed, older tokens and authorization codes are revoked automatically.
-  int tokenLimit;
+  final int tokenLimit;
 
   @override
   Future revokeAuthenticatableWithIdentifier(

--- a/lib/managed_auth.dart
+++ b/lib/managed_auth.dart
@@ -2,7 +2,7 @@
 ///
 /// This library contains [ManagedObject] subclasses to represent OAuth 2.0 artifacts
 /// and implements [AuthServerDelegate] for use by an [AuthServer]. Usage of this library involves two tasks.
-/// First, an instance of [ManagedAuthStorage] is provided to an [AuthServer] at startup:
+/// First, an instance of [ManagedAuthDelegate] is provided to an [AuthServer] at startup:
 ///
 ///         var context = new ManagedContext(dataModel, store);
 ///         var storage = new ManagedAuthStorage<User>(context)
@@ -29,7 +29,7 @@ import 'package:aqueduct/aqueduct.dart';
 
 /// Represent an OAuth 2.0 authorization token and authorization code.
 ///
-/// Instances of this type are created by [ManagedAuthStorage] to store
+/// Instances of this type are created by [ManagedAuthDelegate] to store
 /// authorization tokens and codes on behalf of an [AuthServer]. There is no
 /// need to use this class directly.
 class ManagedAuthToken extends ManagedObject<_ManagedAuthToken>
@@ -287,13 +287,13 @@ abstract class ManagedAuthResourceOwner
 ///         var storage = new ManagedAuthStorage<User>(context)
 ///         var authServer = new AuthServer(storage);
 ///
-class ManagedAuthStorage<T extends ManagedAuthResourceOwner>
+class ManagedAuthDelegate<T extends ManagedAuthResourceOwner>
     extends AuthServerDelegate {
 
   /// Creates an instance of this type.
   ///
   /// [context]'s [ManagedDataModel] must contain [T], [ManagedAuthToken] and [ManagedAuthClient].
-  ManagedAuthStorage(this.context, {this.tokenLimit: 40});
+  ManagedAuthDelegate(this.context, {this.tokenLimit: 40});
 
   /// The [ManagedContext] this instance uses to store and retrieve values.
   final ManagedContext context;

--- a/lib/src/auth/auth.dart
+++ b/lib/src/auth/auth.dart
@@ -5,12 +5,13 @@ import 'objects.dart';
 
 export 'auth_code_controller.dart';
 export 'auth_controller.dart';
-export 'authorization_server.dart';
 export 'authorization_parser.dart';
+export 'authorization_server.dart';
 export 'authorizer.dart';
 export 'exceptions.dart';
 export 'objects.dart';
 export 'protocols.dart';
+export 'validator.dart';
 
 /// Exposes static utility methods for password, salt and API credential generation.
 ///

--- a/lib/src/auth/auth_code_controller.dart
+++ b/lib/src/auth/auth_code_controller.dart
@@ -4,53 +4,53 @@ import 'dart:io';
 import '../http/http.dart';
 import 'auth.dart';
 
-/// Interface for providing [AuthCodeController] with application-specific behavior.
+/// Provides [AuthCodeController] with application-specific behavior.
 abstract class AuthCodeControllerDelegate {
-  /// Returns an HTML string for a login page.
+  /// Returns an HTML representation of a login form.
   ///
   /// Invoked when [AuthCodeController.getAuthorizationPage] is called in response to a GET request.
-  /// Must provide HTML that will be returned to the browser for rendering. This page must execute
-  /// a POST request to the same endpoint, including the values of [responseType], [clientID], [state], [scope]
-  /// as well as user-entered username and password.
+  /// Must provide HTML that will be returned to the browser for rendering. This form submission of this page
+  /// should be a POST to [requestUri].
   ///
-  /// All four of [responseType], [clientID], [state] and [scope] are provided in the query parameters of the request
-  /// that triggered this method. Only [scope] may be null; the other three are non-null.
+  /// The form submission should include the values of [responseType], [clientID], [state], [scope]
+  /// as well as user-entered username and password in `x-www-form-urlencoded` data, e.g.
   ///
-  /// [requestUri] is the request [Uri] that triggered this page fetch.
+  ///         POST https://example.com/auth/code
+  ///         Content-Type: application/x-www-form-urlencoded
+  ///
+  ///         response_type=code&client_id=com.aqueduct.app&state=o9u3jla&username=bob&password=password
+  ///
+  ///
+  /// If not null, [scope] should also be included as an additional form parameter.
   Future<String> render(AuthCodeController forController, Uri requestUri, String responseType, String clientID,
       String state, String scope);
 }
 
-/// [RESTController] for issuing OAuth 2.0 authorization codes.
+/// [Controller] for issuing OAuth 2.0 authorization codes.
 ///
-/// This controller provides the necessary methods for issuing OAuth 2.0 authorization codes: returning
-/// a HTML login form and issuing a request for an authorization code. The login form's submit
-/// button should initiate the request for the authorization code.
+/// This controller provides an endpoint for the creating an OAuth 2.0 authorization code. This authorization code
+/// can be exchanged for an access token with an [AuthController]. This is known as the OAuth 2.0 'Authorization Code Grant' flow.
 ///
-/// This controller should be routed to by a pattern like `/auth/code`. It will respond to POST and GET HTTP methods.
-/// Do not put an [Authorizer] in front of instances of this type. Example:
+/// See operation methods [getAuthorizationPage] and [authorize] for more details.
 ///
-///       router.route("/auth/token").generate(() => new AuthCodeController(authServer));
+/// Usage:
 ///
+///       router
+///         .route("/auth/code")
+///         .generate(() => new AuthCodeController(authServer));
 ///
-/// See [getAuthorizationPage] (GET) and [authorize] (POST) for more details.
 class AuthCodeController extends RESTController {
   /// Creates a new instance of an [AuthCodeController].
   ///
-  /// An [AuthCodeController] requires an [AuthServer].
-  ///
-  /// By default, an [AuthCodeController] has only one [acceptedContentTypes]: 'application/x-www-form-urlencoded'.
-  ///
-  /// A GET request to this controller will return an HTML login page. This page is provided through [delegate]'s callback methods.
-  /// This page should allow a user to submit their username and password via POST request to the same endpoint.  See [AuthCodeControllerDelegate.render] for more details.
+  /// [authServer] is the required authorization server. If [delegate] is provided, this controller will return a login page for all GET requests.
   AuthCodeController(this.authServer, {this.delegate}) {
     acceptedContentTypes = [new ContentType("application", "x-www-form-urlencoded")];
   }
 
-  /// A reference to the [AuthServer] this controller uses to grant authorization codes.
-  AuthServer authServer;
+  /// A reference to the [AuthServer] used to grant authorization codes.
+  final AuthServer authServer;
 
-  /// The state parameter a client uses to verify the origin of a redirect when receiving an authorization redirect.
+  /// A randomly generated value the client can use to verify the origin of the redirect.
   ///
   /// Clients must include this query parameter and verify that any redirects from this
   /// server have the same value for 'state' as passed in. This value is usually a randomly generated
@@ -58,7 +58,7 @@ class AuthCodeController extends RESTController {
   @Bind.query("state")
   String state;
 
-  /// The desired response type; must be 'code'.
+  /// Must be 'code'.
   @Bind.query("response_type")
   String responseType;
 
@@ -68,15 +68,14 @@ class AuthCodeController extends RESTController {
   @Bind.query("client_id")
   String clientID;
 
-  AuthCodeControllerDelegate delegate;
+  /// Renders an HTML login form.
+  final AuthCodeControllerDelegate delegate;
 
   /// Returns an HTML login form.
   ///
   /// A client that wishes to authenticate with this server should direct the user
-  /// to this page. The user will enter their username and password, and upon successful
-  /// authentication, the returned page will redirect the user back to the initial application.
-  /// The redirect URL will contain a 'code' query parameter that the application can intercept
-  /// and send to the route that exchanges authorization codes for tokens.
+  /// to this page. The user will enter their username and password that is sent as a POST
+  /// request to this same controller.
   ///
   /// The 'client_id' must be a registered, valid client of this server. The client must also provide
   /// a [state] to this request and verify that the redirect contains the same value in its query string.
@@ -100,7 +99,7 @@ class AuthCodeController extends RESTController {
   /// and the passed in 'state'. If this request fails, the redirect URL
   /// will contain an 'error' key instead of the authorization code.
   ///
-  /// This method is typically invoked by the login form returned from the GET to this path.
+  /// This method is typically invoked by the login form returned from the GET to this controller.
   @Operation.post()
   Future<Response> authorize(
       {@Bind.query("username") String username,

--- a/lib/src/auth/auth_controller.dart
+++ b/lib/src/auth/auth_controller.dart
@@ -143,7 +143,7 @@ class AuthController extends RESTController {
   @override
   List<APIResponse> documentResponsesForOperation(APIOperation operation) {
     var responses = super.documentResponsesForOperation(operation);
-    if (operation.id == APIOperation.idForMethod(this, #create)) {
+    if (operation.id == APIOperation.idForMethod(this, #grant)) {
       responses.addAll([
         new APIResponse()
           ..statusCode = HttpStatus.OK

--- a/lib/src/auth/authorization_parser.dart
+++ b/lib/src/auth/authorization_parser.dart
@@ -1,14 +1,23 @@
 import 'dart:convert';
 
+abstract class AuthorizationParser<T> {
+  const AuthorizationParser();
+
+  T parse (String authorizationHeader);
+}
+
 /// Parses a Bearer token from an Authorization header.
-class AuthorizationBearerParser {
+class AuthorizationBearerParser extends AuthorizationParser<String> {
+  const AuthorizationBearerParser();
+
   /// Parses a Bearer token from [authorizationHeader]. If the header is malformed or doesn't exist,
   /// throws an [AuthorizationParserException]. Otherwise, returns the [String] representation of the bearer token.
   ///
   /// For example, if the input to this method is "Bearer token" it would return 'token'.
   ///
   /// If [authorizationHeader] is malformed or null, throws an [AuthorizationParserException].
-  static String parse(String authorizationHeader) {
+  @override
+  String parse(String authorizationHeader) {
     if (authorizationHeader == null) {
       throw new AuthorizationParserException(
           AuthorizationParserExceptionReason.missing);
@@ -39,14 +48,17 @@ class AuthBasicCredentials {
 }
 
 /// Parses a Basic Authorization header.
-class AuthorizationBasicParser {
+class AuthorizationBasicParser extends AuthorizationParser <AuthBasicCredentials> {
+  const AuthorizationBasicParser();
+
   /// Returns a [AuthBasicCredentials] containing the username and password
   /// base64 encoded in [authorizationHeader]. For example, if the input to this method
   /// was 'Basic base64String' it would decode the base64String
   /// and return the username and password by splitting that decoded string around the character ':'.
   ///
   /// If [authorizationHeader] is malformed or null, throws an [AuthorizationParserException].
-  static AuthBasicCredentials parse(String authorizationHeader) {
+  @override
+  AuthBasicCredentials parse(String authorizationHeader) {
     if (authorizationHeader == null) {
       throw new AuthorizationParserException(
           AuthorizationParserExceptionReason.missing);

--- a/lib/src/auth/authorizer.dart
+++ b/lib/src/auth/authorizer.dart
@@ -4,141 +4,119 @@ import 'dart:io';
 import '../http/http.dart';
 import 'auth.dart';
 
-/// The type of authorization strategy to use for an [Authorizer].
-enum AuthStrategy {
-  /// This strategy will parse the Authorization header using the Basic Authorization scheme.
-  ///
-  /// The resulting [AuthBasicCredentials] will be passed to [AuthValidator.fromBasicCredentials].
-  basic,
-
-  /// This strategy will parse the Authorization header using the Bearer Authorization scheme.
-  ///
-  /// The resulting bearer token will be passed to [AuthValidator.fromBearerToken].
-  bearer
-}
-
-/// A [Controller] that will authorize further passage in a [Controller] chain when a request has valid
-/// credentials.
+/// A [Controller] that verifies the Authorization header of a request.
 ///
-/// An instance of [Authorizer] will validate a [Request] given a [strategy] and a [validator]. [validator] is typically the instance
-/// of [AuthServer] in an application.
+/// An instance of this type will validate that the authorization information in an Authorization header is sufficient to access
+/// the next controller in the channel.
 ///
-/// If the [Request] is unauthorized (as determined by the [validator]), it will respond with the appropriate status code and prevent
-/// further request processing. If the [Request] is valid, an [Authorization] will be added
-/// to the [Request] and the request will be delivered to this instance's [nextController]. Usage:
+/// For each request, this controller parses the authorization header, validates it with an [AuthValidator] and then create an [Authorization] object
+/// if successful. The [Request] keeps a reference to this [Authorization] and is then sent to the next controller in the channel.
+///
+/// If either parsing or validation fails, a 401 Unauthorized response is sent and the [Request] is removed from the channel.
+///
+/// Parsing occurs according to [parser]. The resulting value (e.g., username and password) is sent to [validator].
+/// [validator] verifies this value (e.g., lookup a user in the database and verify their password matches).
+///
+/// Usage:
 ///
 ///         router
-///           .route("/protectedroute")
+///           .route("/protected-route")
 ///           .pipe(new Authorizer.bearer(authServer))
 ///           .generate(() => new ProtectedResourceController());
 class Authorizer extends Controller {
   /// Creates an instance of [Authorizer].
   ///
-  /// The default strategy is [AuthStrategy.bearer].
-  Authorizer(this.validator,
-      {this.strategy: AuthStrategy.bearer, List<String> scopes}) {
-    this.scopes = scopes;
+  /// Use this constructor to provide custom [AuthorizationParser]s.
+  ///
+  /// By default, this instance will parse bearer tokens from the authorization header, e.g.:
+  ///
+  ///         Authorization: Bearer ap9ijlarlkz8jIOa9laweo
+  ///
+  /// If [scopes] is provided, the authorization granted must have access to *all* scopes according to [validator].
+  Authorizer(this.validator, {this.parser: const AuthorizationBearerParser(), List<String> scopes})
+      : this.scopes = scopes?.map((s) => new AuthScope(s))?.toList() {
     policy = null;
   }
 
-  /// Creates an instance of [Authorizer] using [AuthStrategy.basic].
-  Authorizer.basic(AuthValidator validator)
-      : this(validator, strategy: AuthStrategy.basic);
-
-  /// Creates an instance of [Authorizer] using [AuthStrategy.bearer].
+  /// Creates an instance of [Authorizer] with Basic Authentication parsing.
   ///
-  /// Optionally allows the setting of [Authorizer.scopes].
+  /// Parses a username and password from the request's Basic Authentication data in the Authorization header, e.g.:
+  ///
+  ///         Authorization: Basic base64(username:password)
+  Authorizer.basic(AuthValidator validator) : this(validator, parser: const AuthorizationBasicParser());
+
+  /// Creates an instance of [Authorizer] with Bearer token parsing.
+  ///
+  /// Parses a bearer token from the request's Authorization header, e.g.
+  ///
+  ///         Authorization: Bearer ap9ijlarlkz8jIOa9laweo
+  ///
+  /// If [scopes] is provided, the bearer token must have access to *all* scopes according to [validator].
   Authorizer.bearer(AuthValidator validator, {List<String> scopes})
-      : this(validator, strategy: AuthStrategy.bearer, scopes: scopes);
+      : this(validator, parser: const AuthorizationBearerParser(), scopes: scopes);
 
   /// The validating authorization object.
   ///
   /// This object will check credentials parsed from the Authorization header and produce an
-  /// [Authorization] instance representing the authorization the credentials have. It may also
+  /// [Authorization] object representing the authorization the credentials have. It may also
   /// reject a request. This is typically an instance of [AuthServer].
-  AuthValidator validator;
+  final AuthValidator validator;
 
-  /// The list of scopes this instance requires.
+  /// The list of required scopes.
   ///
-  /// A bearer token must have access to all of the scopes in this list in order to pass
-  /// through to the [nextController].
-  List<String> get scopes => _scopes?.map((s) => s.scopeString)?.toList();
-  set scopes(List<String> scopes) {
-    _scopes = scopes?.map((s) => new AuthScope(s))?.toList();
-  }
-  List<AuthScope> _scopes;
+  /// If [validator] grants scope-limited authorizations (e.g., OAuth2 bearer tokens), the authorization
+  /// provided by the request's header must have access to all [scopes] in order to move on to the next controller.
+  ///
+  /// This property is set with a list of scope strings in a constructor. Each scope string is parsed into
+  /// an [AuthScope] and added to this list.
+  final List<AuthScope> scopes;
 
-  /// The [AuthStrategy] for authorizing a request.
+  /// Parses the Authorization header.
   ///
-  /// This property determines which [AuthValidator] method is invoked on [validator].
-  AuthStrategy strategy;
+  /// The parser determines how to interpret the data in the Authorization header. Concrete subclasses
+  /// are [AuthorizationBasicParser] and [AuthorizationBearerParser].
+  ///
+  /// Once parsed, the parsed value is validated by [validator].
+  final AuthorizationParser parser;
 
   @override
-  FutureOr<RequestOrResponse> handle(Request req) {
-    var header = req.raw.headers.value(HttpHeaders.AUTHORIZATION);
-    if (header == null) {
+  FutureOr<RequestOrResponse> handle(Request req) async {
+    var authData = req.raw.headers.value(HttpHeaders.AUTHORIZATION);
+    if (authData == null) {
       return new Response.unauthorized();
     }
 
-    switch (strategy) {
-      case AuthStrategy.bearer: return _processBearerHeader(req, header);
-      case AuthStrategy.basic: return _processBasicHeader(req, header);
-      default: return new Response.serverError();
-    }
-  }
-
-  Future<RequestOrResponse> _processBearerHeader(
-      Request request, String headerValue) async {
-    String bearerToken;
+    var value;
     try {
-      bearerToken = AuthorizationBearerParser.parse(headerValue);
+      value = parser.parse(authData);
     } on AuthorizationParserException catch (e) {
       return _responseFromParseException(e);
     }
 
-    var authorization = await validator.fromBearerToken(bearerToken, scopesRequired: _scopes);
-    if (authorization == null) {
+    req.authorization = await validator.validate(parser, value, requiredScope: scopes);
+
+    if (req.authorization == null) {
       return new Response.unauthorized();
     }
 
-    request.authorization = authorization;
-    return request;
-  }
-
-  Future<RequestOrResponse> _processBasicHeader(
-      Request request, String headerValue) async {
-    AuthBasicCredentials elements;
-    try {
-      elements = AuthorizationBasicParser.parse(headerValue);
-    } on AuthorizationParserException catch (e) {
-      return _responseFromParseException(e);
-    }
-
-    var authorization = await validator.fromBasicCredentials(elements);
-    if (authorization == null) {
-      return new Response.unauthorized();
-    }
-
-    request.authorization = authorization;
-    return request;
+    return req;
   }
 
   Response _responseFromParseException(AuthorizationParserException e) {
     switch (e.reason) {
       case AuthorizationParserExceptionReason.malformed:
-        return new Response.badRequest(
-            body: {"error": "invalid_authorization_header"});
+        return new Response.badRequest(body: {"error": "invalid_authorization_header"});
       case AuthorizationParserExceptionReason.missing:
         return new Response.unauthorized();
       default:
         return new Response.serverError();
-    }    
+    }
   }
 
   @override
   List<APIOperation> documentOperations(PackagePathResolver resolver) {
     List<APIOperation> operations = nextController.documentOperations(resolver);
-    var requirements = validator.requirementsForStrategy(strategy);
+    var requirements = validator.requirementsForStrategy(parser);
 
     operations.forEach((i) {
       i.security = requirements;
@@ -146,39 +124,4 @@ class Authorizer extends Controller {
 
     return operations;
   }
-}
-
-/// Instances that implement this type can be used by an [Authorizer] to determine authorization of a request.
-///
-/// When an [Authorizer] processes a [Request], it invokes methods from this type to determine the [Authorization] from the Authorization
-/// header of the [Request]. [AuthServer] implements this interface.
-abstract class AuthValidator {
-  /// Returns an [Authorization] from basic credentials.
-  ///
-  /// This method must either return a [Future] that yields an [Authorization] or return null.
-  /// If this method returns null, the invoking [Authorizer] will disallow further
-  /// request handling and immediately return a 401 status code. If this method returns an
-  /// [Authorization], it will be set as the [Request.authorization] and request handling
-  /// will continue to the [Authorizer.nextController].
-  FutureOr<Authorization> fromBasicCredentials(
-      AuthBasicCredentials usernameAndPassword);
-
-  /// Returns an [Authorization] from a bearer token.
-  ///
-  /// This method must either return a [Future] that yields an [Authorization] or return null.
-  /// If this method returns null, the invoking [Authorizer] will disallow further
-  /// request handling and immediately return a 401 status code. If this method returns an
-  /// [Authorization], it will be set as the [Request.authorization] and request handling
-  /// will continue to the [Authorizer.nextController].
-  ///
-  /// [scopesRequired] is the list of scopes established when the [Authorizer]
-  /// is created. Implementors of this method must verify the bearer token has access to [scopesRequired].
-  ///
-  /// If [scopesRequired] is null, an implementor may make its own determination about whether
-  /// the token results in an [Authorization]. By default, [AuthServer] - the primary implementor of this type -
-  /// will allow access, assuming that 'null scope' means 'any scope'.
-  FutureOr<Authorization> fromBearerToken(
-      String bearerToken, {List<AuthScope> scopesRequired});
-
-  List<APISecurityRequirement> requirementsForStrategy(AuthStrategy strategy) => [];
 }

--- a/lib/src/auth/objects.dart
+++ b/lib/src/auth/objects.dart
@@ -97,7 +97,7 @@ class AuthClient {
 
 /// Represents an OAuth 2.0 token.
 ///
-/// [AuthStorage] and [AuthServer] will exchange OAuth 2.0
+/// [AuthServerDelegate] and [AuthServer] will exchange OAuth 2.0
 /// tokens through instances of this type.
 ///
 /// See the `package:aqueduct/managed_auth` library for a concrete implementation of this type.
@@ -158,7 +158,7 @@ class AuthToken {
 
 /// Represents an OAuth 2.0 authorization code.
 ///
-/// [AuthStorage] and [AuthServer] will exchange OAuth 2.0
+/// [AuthServerDelegate] and [AuthServer] will exchange OAuth 2.0
 /// authorization codes through instances of this type.
 ///
 /// See the aqueduct/managed_auth library for a concrete implementation of this type.
@@ -298,9 +298,9 @@ class AuthScope {
 
   const AuthScope._(this.scopeString, this._segments, this._lastModifier);
 
-  /// Signifies 'any' scope in [AuthStorage.allowedScopesForAuthenticatable].
+  /// Signifies 'any' scope in [AuthServerDelegate.allowedScopesForAuthenticatable].
   ///
-  /// See [AuthStorage.allowedScopesForAuthenticatable] for more details.
+  /// See [AuthServerDelegate.allowedScopesForAuthenticatable] for more details.
   static const List<AuthScope> Any = const [
     const AuthScope._("_scope:_constant:_marker", const [], null)
   ];

--- a/lib/src/auth/protocols.dart
+++ b/lib/src/auth/protocols.dart
@@ -31,7 +31,7 @@ abstract class Authenticatable {
 ///
 /// An [AuthServer] does not dictate how information is stored and therefore can't dictate how information is disposed of.
 /// It is up to implementors of this class to discard of any information it no longer wants to keep.
-abstract class AuthStorage {
+abstract class AuthServerDelegate {
   /// This method must revoke all [AuthToken] and [AuthCode]s for an [Authenticatable].
   ///
   /// [server] is the requesting [AuthServer]. [identifier] is the [Authenticatable.id].

--- a/lib/src/auth/validator.dart
+++ b/lib/src/auth/validator.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:aqueduct/src/http/documentable.dart';
+import 'package:aqueduct/src/http/request.dart';
+import 'auth.dart';
+
+/// Instances that implement this type can be used by an [Authorizer] to determine authorization of a request.
+///
+/// When an [Authorizer] processes a [Request], it invokes methods from this type to determine the [Authorization] from the Authorization
+/// header of the [Request]. [AuthServer] implements this interface.
+abstract class AuthValidator {
+  /// Returns an [Authorization] if [authorizationData] is valid.
+  ///
+  /// [authorizationData] is usually the contents of an Authorization header. Instances of this type validate the data
+  /// and the [Authorization] that data represents. For example, if [authorizationData] were a username and password
+  /// and this instance verifies it is the correct password for the user, an [Authorization] for that user will be returned.
+  ///
+  /// This method must return null if [authorizationData] is invalid. This includes instances like an incorrect password, malformed data,
+  /// or any other kind of error.
+  ///
+  /// [parser] indicates the object that provided [authorizationData]. For example, a [AuthorizationBearerParser] will provide a [String] representation of the bearer token.
+  ///
+  /// If [requiredScope] is provided, this instance will verify that the [Authorization] for [authorizationData] has the appropriate scope to access to every element in [requiredScope].
+  /// This parameter is only valid for instances that support scoping (e.g., OAuth2).
+  FutureOr<Authorization> validate<T>(AuthorizationParser<T> parser, T authorizationData,
+      {List<AuthScope> requiredScope});
+
+  // todo (joeconwaystk): temporary until openapi integration
+  List<APISecurityRequirement> requirementsForStrategy(AuthorizationParser<dynamic> strategy) => [];
+}

--- a/templates/db_and_auth/lib/channel.dart
+++ b/templates/db_and_auth/lib/channel.dart
@@ -29,7 +29,7 @@ class WildfireChannel extends ApplicationChannel implements AuthCodeControllerDe
 
     ManagedContext.defaultContext = contextWithConnectionInfo(config.database);
 
-    var authStorage = new ManagedAuthStorage<User>(ManagedContext.defaultContext);
+    var authStorage = new ManagedAuthDelegate<User>(ManagedContext.defaultContext);
     authServer = new AuthServer(authStorage);
   }
 

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -98,7 +98,7 @@ class TestToken implements AuthToken, AuthCode {
   }
 }
 
-class InMemoryAuthStorage extends AuthStorage {
+class InMemoryAuthStorage extends AuthServerDelegate {
   static const String DefaultPassword = "foobaraxegrind21%";
 
   InMemoryAuthStorage() {

--- a/test/http/cors_test.dart
+++ b/test/http/cors_test.dart
@@ -612,22 +612,16 @@ class CORSChannel extends ApplicationChannel implements AuthValidator {
   }
 
   @override
-  Future<Authorization> fromBasicCredentials(
-      AuthBasicCredentials credentials) async {
-    return new Authorization("a", 1, this);
-  }
-
-  @override
-  Future<Authorization> fromBearerToken(
-      String bearerToken, {List<AuthScope> scopesRequired}) async {
-    if (bearerToken == "noauth") {
+  FutureOr<Authorization> validate<T>(AuthorizationParser<T> parser, T authorizationData,
+      {List<AuthScope> requiredScope}) {
+    if (authorizationData == "noauth") {
       return null;
     }
     return new Authorization("a", 1, this);
   }
 
   @override
-  List<APISecurityRequirement> requirementsForStrategy(AuthStrategy strategy) =>
+  List<APISecurityRequirement> requirementsForStrategy(AuthorizationParser strategy) =>
       null;
 }
 

--- a/test/managed_auth/managed_auth_role_storage_test.dart
+++ b/test/managed_auth/managed_auth_role_storage_test.dart
@@ -291,7 +291,7 @@ Future<List<User>> createUsers(int count) async {
   return list;
 }
 
-class RoleBasedAuthStorage extends ManagedAuthStorage<User> {
+class RoleBasedAuthStorage extends ManagedAuthDelegate<User> {
   RoleBasedAuthStorage(ManagedContext context, {int tokenLimit: 40}) :
         super(context, tokenLimit: tokenLimit);
 

--- a/test/managed_auth/managed_auth_storage_test.dart
+++ b/test/managed_auth/managed_auth_storage_test.dart
@@ -11,7 +11,7 @@ import '../context_helpers.dart';
 // These tests mostly duplicate authenticate_test.dart, but also add a few more
 // to manage long-term storage/cleanup of tokens and related items.
 void main() {
-  ManagedAuthStorage<User> storage;
+  ManagedAuthDelegate<User> storage;
   ManagedContext context;
 
   setUp(() async {
@@ -47,7 +47,7 @@ void main() {
       return q.insert();
     }));
 
-    storage = new ManagedAuthStorage<User>(context);
+    storage = new ManagedAuthDelegate<User>(context);
   });
 
   tearDown(() async {
@@ -783,7 +783,7 @@ void main() {
     test(
         "Oldest codes gets pruned after reaching limit, but only for that user",
         () async {
-      (auth.delegate as ManagedAuthStorage).tokenLimit = 3;
+      (auth.delegate as ManagedAuthDelegate).tokenLimit = 3;
 
       // Insert a code manually to simulate a race condition, but insert it after the others have been
       // so they don't strip it when inserted.
@@ -857,7 +857,7 @@ void main() {
     test(
         "Oldest tokens gets pruned after reaching tokenLimit, but only for that user",
         () async {
-      (auth.delegate as ManagedAuthStorage).tokenLimit = 3;
+      (auth.delegate as ManagedAuthDelegate).tokenLimit = 3;
 
       // Insert a token manually to simulate a race condition, but insert it after the others have been
       // so they don't strip it when inserted.

--- a/test/managed_auth/managed_auth_storage_test.dart
+++ b/test/managed_auth/managed_auth_storage_test.dart
@@ -756,7 +756,8 @@ void main() {
     AuthServer auth;
 
     setUp(() async {
-      auth = new AuthServer(storage);
+      var limitedStorage = new ManagedAuthDelegate<User>(context, tokenLimit: 3);
+      auth = new AuthServer(limitedStorage);
       createdUsers = await createUsers(3);
     });
 
@@ -783,8 +784,6 @@ void main() {
     test(
         "Oldest codes gets pruned after reaching limit, but only for that user",
         () async {
-      (auth.delegate as ManagedAuthDelegate).tokenLimit = 3;
-
       // Insert a code manually to simulate a race condition, but insert it after the others have been
       // so they don't strip it when inserted.
       var manualCode = new ManagedAuthToken()
@@ -850,15 +849,14 @@ void main() {
     AuthServer auth;
 
     setUp(() async {
-      auth = new AuthServer(storage);
+      var limitedStorage = new ManagedAuthDelegate<User>(context, tokenLimit: 3);
+      auth = new AuthServer(limitedStorage);
       createdUsers = await createUsers(10);
     });
 
     test(
         "Oldest tokens gets pruned after reaching tokenLimit, but only for that user",
         () async {
-      (auth.delegate as ManagedAuthDelegate).tokenLimit = 3;
-
       // Insert a token manually to simulate a race condition, but insert it after the others have been
       // so they don't strip it when inserted.
       var manualToken = new ManagedAuthToken()

--- a/test/managed_auth/managed_auth_storage_test.dart
+++ b/test/managed_auth/managed_auth_storage_test.dart
@@ -783,7 +783,7 @@ void main() {
     test(
         "Oldest codes gets pruned after reaching limit, but only for that user",
         () async {
-      (auth.storage as ManagedAuthStorage).tokenLimit = 3;
+      (auth.delegate as ManagedAuthStorage).tokenLimit = 3;
 
       // Insert a code manually to simulate a race condition, but insert it after the others have been
       // so they don't strip it when inserted.
@@ -857,7 +857,7 @@ void main() {
     test(
         "Oldest tokens gets pruned after reaching tokenLimit, but only for that user",
         () async {
-      (auth.storage as ManagedAuthStorage).tokenLimit = 3;
+      (auth.delegate as ManagedAuthStorage).tokenLimit = 3;
 
       // Insert a token manually to simulate a race condition, but insert it after the others have been
       // so they don't strip it when inserted.


### PR DESCRIPTION
In preparation for more authorization strategies and OpenAPI implementation. 

- Renames AuthStorage back to AuthServerDelegate
- Removes AuthStrategy, replace with abstract class AuthorizationParser<T>.
- Generalizes AuthValidator by removing fromBearerToken and fromBasicCredentials, replacing with validate.