### PR TITLE
Simplifies controller linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.0.0
 
+- Controller linking is simplified. `generate` renamed to `link`. Removed `pipe`; all controllers must be instantiated per request.
+- `Controller.listen` renamed `Controller.linkFunction`.
 - Change default port for `aqueduct serve` to 8888.
 - Adds `MockHTTPServer.queueHandler` and `MockHTTPServer.queueOutage`.
 - Binding metadata - `HTTPPath`, `HTTPBody`, `HTTPQuery` and `HTTPHeader` - have been changed to `Bind.path`, `Bind.body`, `Bind.query` and `Bind.header`, respectively.

--- a/lib/src/application/channel.dart
+++ b/lib/src/application/channel.dart
@@ -19,7 +19,7 @@ import 'package:aqueduct/src/application/service_registry.dart';
 ///       class MyChannel extends ApplicationChannel {
 ///         Controller get entryPoint {
 ///           final router = new Router();
-///           router.route("/endpoint").listen((req) => new Response.ok('Hello, world!'));
+///           router.route("/endpoint").linkFunction((req) => new Response.ok('Hello, world!'));
 ///           return router;
 ///         }
 ///       }
@@ -262,7 +262,7 @@ abstract class ApplicationChannel extends Object with APIDocumentable {
 /// is only known to the isolate it established a connection on. This data must be sent to each isolate so that each websocket
 /// connected to that isolate can send the data:
 ///
-///         router.route("/broadcast").listen((req) async {
+///         router.route("/broadcast").linkFunction((req) async {
 ///           var message = await req.body.decodeAsString();
 ///           websocketsOnThisIsolate.forEach((s) => s.add(message);
 ///           messageHub.add({"event": "broadcastMessage", "data": message});

--- a/lib/src/auth/auth_code_controller.dart
+++ b/lib/src/auth/auth_code_controller.dart
@@ -37,7 +37,7 @@ abstract class AuthCodeControllerDelegate {
 ///
 ///       router
 ///         .route("/auth/code")
-///         .generate(() => new AuthCodeController(authServer));
+///         .link(() => new AuthCodeController(authServer));
 ///
 class AuthCodeController extends RESTController {
   /// Creates a new instance of an [AuthCodeController].

--- a/lib/src/auth/auth_controller.dart
+++ b/lib/src/auth/auth_controller.dart
@@ -15,7 +15,7 @@ import 'auth.dart';
 ///
 ///       router
 ///         .route("/auth/token")
-///         .generate(() => new AuthController(authServer));
+///         .link(() => new AuthController(authServer));
 ///
 class AuthController extends RESTController {
   /// Creates a new instance of an [AuthController].

--- a/lib/src/auth/authorization_server.dart
+++ b/lib/src/auth/authorization_server.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:crypto/crypto.dart';
 
 import '../http/documentable.dart';
-import 'package:aqueduct/src/application/channel.dart';
 import '../utilities/token_generator.dart';
 import 'auth.dart';
 
@@ -46,12 +45,12 @@ import 'auth.dart';
 ///             final router = new Router();
 ///             router
 ///               .route("/protected")
-///               .pipe(new Authorizer(authServer))
-///               .generate(() => new ProtectedResourceController());
+///               .link(() =>new Authorizer(authServer))
+///               .link(() => new ProtectedResourceController());
 ///
 ///             router
 ///               .route("/auth/token")
-///               .generate(() => new AuthController(authServer));
+///               .link(() => new AuthController(authServer));
 ///
 ///             return router;
 ///           }

--- a/lib/src/auth/authorizer.dart
+++ b/lib/src/auth/authorizer.dart
@@ -21,8 +21,8 @@ import 'auth.dart';
 ///
 ///         router
 ///           .route("/protected-route")
-///           .pipe(new Authorizer.bearer(authServer))
-///           .generate(() => new ProtectedResourceController());
+///           .link(() =>new Authorizer.bearer(authServer))
+///           .link(() => new ProtectedResourceController());
 class Authorizer extends Controller {
   /// Creates an instance of [Authorizer].
   ///

--- a/lib/src/commands/document_serve.dart
+++ b/lib/src/commands/document_serve.dart
@@ -59,7 +59,7 @@ class CLIDocumentServe extends CLICommand with CLIProject, CLIDocumentOptions {
         print("${rec.message} ${rec.stackTrace ?? ""}");
       });
 
-    _router.route("/*").pipe(fileController);
+    _router.route("/*").link(() => fileController);
     _router.prepare();
 
     server.map((req) => new Request(req)).listen((req) {

--- a/lib/src/http/controller.dart
+++ b/lib/src/http/controller.dart
@@ -311,24 +311,6 @@ class ControllerException implements Exception {
   String toString() => "ControllerException: $message";
 }
 
-
-/// Metadata for a [Controller] subclass that requires it must be instantiated for each request.
-///
-/// Requires that the [Controller] must be created through [Controller.link].
-///
-/// [Controller]s may carry some state throughout the course of their handling of a request. If
-/// that [Controller] is reused for another request, some of that state may carry over. Therefore,
-/// it is a better solution to instantiate the [Controller] for each incoming request. Marking
-/// a [Controller] subclass with this flag will ensure that an exception is thrown if an instance
-/// of [Controller] is chained in a [ApplicationChannel]. These instances must be generated with a closure:
-///
-///       router.route("/path").link(() => new Controller());
-const _RequiresInstantiation cannotBeReused = const _RequiresInstantiation();
-
-class _RequiresInstantiation {
-  const _RequiresInstantiation();
-}
-
 typedef Controller _ControllerGeneratorClosure();
 
 class _ControllerGenerator extends Controller {
@@ -362,19 +344,19 @@ class _ControllerGenerator extends Controller {
   @override
   Controller link(Controller instantiator()) {
     final c = super.link(instantiator);
-    nextInstanceToReceive?._nextController = c;
+    nextInstanceToReceive._nextController = c;
     return c;
   }
 
   Controller linkFunction(FutureOr<RequestOrResponse> handle(Request request)) {
     final c = super.linkFunction(handle);
-    nextInstanceToReceive?._nextController = c;
+    nextInstanceToReceive._nextController = c;
     return c;
   }
 
   @override
   Future receive(Request req) {
-    var next = nextInstanceToReceive;
+    final next = nextInstanceToReceive;
     nextInstanceToReceive = instantiate();
     return next.receive(req);
   }

--- a/lib/src/http/file_controller.dart
+++ b/lib/src/http/file_controller.dart
@@ -7,7 +7,6 @@ import 'http.dart';
 /// Serves files from a directory on the filesystem.
 ///
 /// See the constructor for usage.
-///
 class HTTPFileController extends Controller {
   static Map<String, ContentType> _defaultExtensionMap = {
     /* Web content */
@@ -41,7 +40,7 @@ class HTTPFileController extends Controller {
     "otf": new ContentType("font", "otf"),
   };
 
-  /// Constructor for a controller that serves files from [pathOfDirectoryToServe].
+  /// Creates a controller that serves files from [pathOfDirectoryToServe].
   ///
   /// File controllers append the path of an HTTP request to [pathOfDirectoryToServe] and attempt to read the file at that location.
   ///

--- a/lib/src/http/file_controller.dart
+++ b/lib/src/http/file_controller.dart
@@ -41,25 +41,25 @@ class HTTPFileController extends Controller {
     "otf": new ContentType("font", "otf"),
   };
 
-  /// Creates an instance of this type that serves files from [pathOfDirectoryToServe].
+  /// Constructor for a controller that serves files from [pathOfDirectoryToServe].
   ///
-  /// An instance of this type serves files by appending all or part of an HTTP request path to [pathOfDirectoryToServe] and streaming the bytes
-  /// of that file as a response.
+  /// File controllers append the path of an HTTP request to [pathOfDirectoryToServe] and attempt to read the file at that location.
   ///
-  /// Instances of this type are [pipe]d from a route that MUST contain the match-all route pattern (`*`). For example, consider the following:
+  /// If the file exists, its contents are sent in the HTTP Response body. If the file does not exist, a 404 Not Found error is returned by default.
+  ///
+  /// A route to this controller must contain the match-all segment (`*`). For example:
   ///
   ///       router
   ///        .route("/site/*")
-  ///        .pipe(new HTTPFileController("build/web"));
+  ///        .link(() => new HTTPFileController("build/web"));
   ///
-  /// In the above, `GET /site/index.html` would respond with the contents of the file `build/web/index.html`, relative to the project directory.
+  /// In the above, `GET /site/index.html` would return the file `build/web/index.html`.
   ///
   /// If [pathOfDirectoryToServe] contains a leading slash, it is an absolute path. Otherwise, it is relative to the current working directory
   /// of the running application.
   ///
   /// If no file is found, the default behavior is to return a 404 Not Found. (If the [Request] accepts 'text/html', a simple 404 page is returned.) You may
-  /// override this behavior by providing [onFileNotFound]. The first argument to [onFileNotFound  is the instance of this type that could not find the file and
-  /// may be accessed to use any settings like cache policies or content type mappings. The second argument is the request.
+  /// override this behavior by providing [onFileNotFound].
   ///
   /// The content type of the response is determined by the file extension of the served file. There are many built-in extension-to-content-type mappings and you may
   /// add more with [setContentTypeForExtension]. Unknown file extension will result in `application/octet-stream` content-type responses.

--- a/lib/src/http/request.dart
+++ b/lib/src/http/request.dart
@@ -28,7 +28,7 @@ class Request implements RequestOrResponse {
   /// remove this instance from the request channel. To remove a request from the channel, return null from a [Controller]
   /// handler method instead of a [Response] or [Request]. For example:
   ///
-  ///         router.route("/raw").listen((req) async {
+  ///         router.route("/raw").linkFunction((req) async {
   ///           req.response.statusCode = 200;
   ///           await req.response.close(); // Respond manually to request
   ///           return null; // Take request out of channel; no subsequent controllers will see this request.

--- a/lib/src/http/rest_controller.dart
+++ b/lib/src/http/rest_controller.dart
@@ -62,7 +62,6 @@ import 'rest_controller_internal/internal.dart';
 /// Bindings will automatically parse values into other types and validate that requests have the desired values. See [Bind] for all possible bindings and https://aqueduct.io/docs/http/rest_controller/ for more details.
 ///
 /// To access the request directly, use [request]. Note that the [Request.body] of [request] will be decoded prior to invoking an operation method.
-@cannotBeReused
 abstract class RESTController extends Controller {
   /// The request being processed by this [RESTController].
   ///

--- a/lib/src/http/rest_controller_binding.dart
+++ b/lib/src/http/rest_controller_binding.dart
@@ -174,9 +174,9 @@ class Bind {
         return new HTTPBody();
       case _BindType.path:
         return new HTTPPath(name);
-      default:
-        return null;
     }
+
+    throw new StateError("Invalid binding '$_type' on '$name'.");
   }
 }
 

--- a/lib/src/http/rest_controller_internal/parameter_binder.dart
+++ b/lib/src/http/rest_controller_internal/parameter_binder.dart
@@ -7,7 +7,10 @@ class RESTControllerParameterBinder {
   RESTControllerParameterBinder(VariableMirror mirror, {this.isRequired: false}) {
     symbol = mirror.simpleName;
 
-    Bind b = mirror.metadata.firstWhere((im) => im.reflectee is Bind).reflectee;
+    Bind b = mirror.metadata.firstWhere((im) => im.reflectee is Bind, orElse: () => null)?.reflectee;
+    if (b == null) {
+      throw new StateError("Invalid operation method parameter '${MirrorSystem.getName(symbol)}' for controller '${MirrorSystem.getName(mirror.owner.simpleName)}'. Must have @Bind annotation.");
+    }
     binding = b?.binding;
     boundValueType = mirror.type;
   }

--- a/lib/src/http/router.dart
+++ b/lib/src/http/router.dart
@@ -37,6 +37,7 @@ class Router extends Controller {
   ///
   /// Trailing and leading slashes have no impact on this value.
   String get basePath => "/${_basePathSegments.join("/")}";
+
   set basePath(String bp) {
     _basePathSegments = bp.split("/").where((str) => str.isNotEmpty).toList();
   }
@@ -50,11 +51,10 @@ class Router extends Controller {
     _unmatchedController = listener;
   }
 
-
-  /// Adds a route to this instance.
+  /// Adds a route that [Controller]s can be linked to.
   ///
-  /// Requests that match [pattern] will be sent to the [Controller] returned by this method. Controllers that
-  /// should receive these requests should be attached to the returned [Controller] (via [pipe], [generate], or [listen]).
+  /// Routers allow for multiple linked controllers. A request that matches [pattern]
+  /// will be sent to the controller linked to this method's return value.
   ///
   /// The [pattern] must follow the rules of route patterns (see also http://aqueduct.io/docs/http/routing/).
   ///
@@ -81,16 +81,14 @@ class Router extends Controller {
   ///         /files/*
   ///
   Controller route(String pattern) {
-    var routeController = new _RouteController(
-        RouteSpecification.specificationsForRoutePattern(pattern));
+    var routeController = new _RouteController(RouteSpecification.specificationsForRoutePattern(pattern));
     _routeControllers.add(routeController);
     return routeController;
   }
 
   @override
   void prepare() {
-    _rootRouteNode =
-        new RouteNode(_routeControllers.expand((rh) => rh.patterns).toList());
+    _rootRouteNode = new RouteNode(_routeControllers.expand((rh) => rh.patterns).toList());
 
     for (var c in _routeControllers) {
       c.prepare();
@@ -99,23 +97,13 @@ class Router extends Controller {
 
   /// Routers override this method to throw an exception. Use [route] instead.
   @override
-  Controller pipe(Controller n) {
-    throw new RouterException("Routers may not use pipe, use route instead.");
+  Controller link(Controller generatorFunction()) {
+    throw new StateError("Routers may not use generate, use route instead.");
   }
 
-  /// Routers override this method to throw an exception. Use [route] instead.
   @override
-  Controller generate(Controller generatorFunction()) {
-    throw new RouterException(
-        "Routers may not use generate, use route instead.");
-  }
-
-  /// Routers override this method to throw an exception. Use [route] instead.
-  @override
-  Controller listen(
-      FutureOr<RequestOrResponse> handler(
-          Request request)) {
-    throw new RouterException("Routers may not use listen, use route instead.");
+  Controller linkFunction(FutureOr<RequestOrResponse> handle(Request request)) {
+    throw new StateError("Routers may not use generate, use route instead.");
   }
 
   @override
@@ -155,8 +143,7 @@ class Router extends Controller {
   List<APIPath> documentPaths(PackagePathResolver resolver) {
     return _routeControllers
         .expand((rh) => rh.patterns)
-        .map((RouteSpecification routeSpec) =>
-            routeSpec.documentPaths(resolver).first)
+        .map((RouteSpecification routeSpec) => routeSpec.documentPaths(resolver).first)
         .toList();
   }
 
@@ -169,8 +156,8 @@ class Router extends Controller {
     var response = new Response.notFound();
     if (req.acceptsContentType(ContentType.HTML)) {
       response
-          ..body = "<html><h3>404 Not Found</h3></html>"
-          ..contentType = ContentType.HTML;
+        ..body = "<html><h3>404 Not Found</h3></html>"
+        ..contentType = ContentType.HTML;
     }
 
     applyCORSHeadersIfNecessary(req, response);
@@ -178,7 +165,6 @@ class Router extends Controller {
     logger.info("${req.toDebugString()}");
   }
 }
-
 
 class _RouteController extends Controller {
   /// Do not create instances of this class manually.

--- a/templates/db/lib/channel.dart
+++ b/templates/db/lib/channel.dart
@@ -33,7 +33,7 @@ class WildfireChannel extends ApplicationChannel {
 
     router
         .route("/model/[:id]")
-        .generate(() => new ManagedObjectController<Model>());
+        .link(() => new ManagedObjectController<Model>());
 
     return router;
   }

--- a/templates/db_and_auth/lib/channel.dart
+++ b/templates/db_and_auth/lib/channel.dart
@@ -44,27 +44,27 @@ class WildfireChannel extends ApplicationChannel implements AuthCodeControllerDe
     final router = new Router();
 
     /* OAuth 2.0 Endpoints */
-    router.route("/auth/token").generate(() => new AuthController(authServer));
+    router.route("/auth/token").link(() => new AuthController(authServer));
 
-    router.route("/auth/code").generate(() => new AuthCodeController(authServer, delegate: this));
+    router.route("/auth/code").link(() => new AuthCodeController(authServer, delegate: this));
 
     /* Create an account */
     router
         .route("/register")
-        .pipe(new Authorizer.basic(authServer))
-        .generate(() => new RegisterController(authServer));
+        .link(() =>new Authorizer.basic(authServer))
+        .link(() => new RegisterController(authServer));
 
     /* Gets profile for user with bearer token */
     router
         .route("/me")
-        .pipe(new Authorizer.bearer(authServer))
-        .generate(() => new IdentityController());
+        .link(() =>new Authorizer.bearer(authServer))
+        .link(() => new IdentityController());
 
     /* Gets all users or one specific user by id */
     router
         .route("/users/[:id]")
-        .pipe(new Authorizer.bearer(authServer))
-        .generate(() => new UserController(authServer));
+        .link(() =>new Authorizer.bearer(authServer))
+        .link(() => new UserController(authServer));
 
     return router;
   }

--- a/templates/default/lib/channel.dart
+++ b/templates/default/lib/channel.dart
@@ -26,11 +26,11 @@ class WildfireChannel extends ApplicationChannel {
   Controller get entryPoint {
     final router = new Router();
 
-    // Prefer to use `pipe` and `generate` instead of `listen`.
+    // Prefer to use `link` instead of `linkFunction`.
     // See: https://aqueduct.io/docs/http/request_controller/
     router
       .route("/example")
-      .listen((request) async {
+      .linkFunction((request) async {
         return new Response.ok({"key": "value"});
       });
 

--- a/test/auth/auth_code_controller_test.dart
+++ b/test/auth/auth_code_controller_test.dart
@@ -543,9 +543,9 @@ class TestChannel extends ApplicationChannel implements AuthCodeControllerDelega
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/auth/code").generate(() => new AuthCodeController(authServer, delegate: this));
+    router.route("/auth/code").link(() => new AuthCodeController(authServer, delegate: this));
 
-    router.route("/nopage").generate(() => new AuthCodeController(authServer));
+    router.route("/nopage").link(() => new AuthCodeController(authServer));
     return router;
   }
 

--- a/test/auth/auth_controller_test.dart
+++ b/test/auth/auth_controller_test.dart
@@ -59,7 +59,7 @@ void main() {
     router = new Router();
     router
         .route("/auth/token")
-        .generate(() => new AuthController(authenticationServer));
+        .link(() => new AuthController(authenticationServer));
     router.prepare();
 
     server =

--- a/test/auth/authorizer_test.dart
+++ b/test/auth/authorizer_test.dart
@@ -414,7 +414,7 @@ void main() {
 
 Future<HttpServer> enableAuthorizer(Authorizer authorizer) async {
   var router = new Router();
-  router.route("/").pipe(authorizer).listen(respond);
+  router.route("/").link(() => authorizer).link(() => new Controller(respond));
   router.prepare();
 
   var server = await HttpServer.bind(InternetAddress.ANY_IP_V4, 8000);

--- a/test/command/serve_test_project/lib/wildfire.dart
+++ b/test/command/serve_test_project/lib/wildfire.dart
@@ -4,7 +4,7 @@ class WildfireChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final r = new Router();
-    r.route("/endpoint").listen((req) async => new Response.ok(null));
+    r.route("/endpoint").linkFunction((req) async => new Response.ok(null));
     return r;
   }
 }

--- a/test/db/model_controller_test.dart
+++ b/test/db/model_controller_test.dart
@@ -19,8 +19,8 @@ void main() {
 
     server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
     var router = new Router();
-    router.route("/users/[:id]").generate(() => new TestModelController());
-    router.route("/string/:id").generate(() => new StringController());
+    router.route("/users/[:id]").link(() => new TestModelController());
+    router.route("/string/:id").link(() => new StringController());
     router.prepare();
 
     server.listen((req) async {

--- a/test/http/application_test.dart
+++ b/test/http/application_test.dart
@@ -135,7 +135,7 @@ class CrashingTestChannel extends ApplicationChannel {
     if (options.context["crashIn"] == "addRoutes") {
       throw new TestException("addRoutes");
     }
-    router.route("/t").generate(() => new TController());
+    router.route("/t").link(() => new TController());
     return router;
   }
 
@@ -157,9 +157,9 @@ class TestChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/t").generate(() => new TController());
-    router.route("/r").generate(() => new RController());
-    router.route("startup").listen((r) async {
+    router.route("/t").link(() => new TController());
+    router.route("/r").link(() => new RController());
+    router.route("startup").linkFunction((r) async {
       var total = options.context["startup"].fold(0, (a, b) => a + b);
       return new Response.ok("$total");
     });

--- a/test/http/body_decoder_test.dart
+++ b/test/http/body_decoder_test.dart
@@ -581,7 +581,7 @@ void main() {
       // body stream
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.listen((req) async {
+        next.linkFunction((req) async {
           // This'll crash
           var _ = await req.body.decodedData;
 
@@ -632,7 +632,7 @@ void main() {
       HTTPRequestBody.maxSize = 8193;
 
       var controller = new Controller()
-        ..listen((req) async {
+        ..linkFunction((req) async {
           var body = await req.body.decodeAsMap();
           return new Response.ok(body);
         });
@@ -666,7 +666,7 @@ void main() {
       HTTPRequestBody.maxSize = 8193;
 
       var controller = new Controller()
-        ..listen((req) async {
+        ..linkFunction((req) async {
           var body = await req.body.decodedData;
           return new Response.ok(body)..contentType = new ContentType("application", "octet-stream");
         });

--- a/test/http/body_encoder_streaming_test.dart
+++ b/test/http/body_encoder_streaming_test.dart
@@ -255,7 +255,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.listen((req) async {
+        next.linkFunction((req) async {
           initiateResponseCompleter.complete();
           return response;
         });
@@ -308,7 +308,7 @@ void main() {
       HTTPRequestBody.maxSize = 8193;
 
       var controller = new Controller()
-        ..listen((req) async {
+        ..linkFunction((req) async {
           var body = await req.body.decodeAsMap();
           return new Response.ok(body);
         });
@@ -353,7 +353,7 @@ void main() {
       HTTPRequestBody.maxSize = 8193;
 
       var controller = new Controller()
-        ..listen((req) async {
+        ..linkFunction((req) async {
           var body = await req.body.decodedData;
           return new Response.ok(body)..contentType = new ContentType("application", "octet-stream");
         });
@@ -404,7 +404,7 @@ Future<HttpServer> bindAndRespondWith(Response response) async {
   var server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
   server.map((req) => new Request(req)).listen((req) async {
     var next = new Controller();
-    next.listen((req) async {
+    next.linkFunction((req) async {
       return response;
     });
     await next.receive(req);

--- a/test/http/body_encoder_test.dart
+++ b/test/http/body_encoder_test.dart
@@ -222,7 +222,7 @@ Future<HttpServer> bindAndRespondWith(Response response) async {
   var server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
   server.map((req) => new Request(req)).listen((req) async {
     var next = new Controller();
-    next.listen((req) async {
+    next.linkFunction((req) async {
       return response;
     });
     await next.receive(req);

--- a/test/http/cache_policy_test.dart
+++ b/test/http/cache_policy_test.dart
@@ -33,7 +33,7 @@ Future<HttpServer> bindAndRespondWith(Response response) async {
   var server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
   server.map((req) => new Request(req)).listen((req) async {
     var next = new Controller();
-    next.listen((req) async {
+    next.linkFunction((req) async {
       return response;
     });
     await next.receive(req);

--- a/test/http/client_test_test.dart
+++ b/test/http/client_test_test.dart
@@ -11,7 +11,7 @@ void main() {
     HttpServer server =
         await HttpServer.bind("localhost", 8888, v6Only: false, shared: false);
     var router = new Router();
-    router.route("/na").generate(() => new TestController());
+    router.route("/na").link(() => new TestController());
     router.prepare();
     server.map((req) => new Request(req)).listen(router.receive);
 

--- a/test/http/controller_test.dart
+++ b/test/http/controller_test.dart
@@ -23,9 +23,9 @@ void main() {
     });
 
     test("Can add change status code", () async {
-      root.listen((r) async {
+      root.linkFunction((r) async {
         return r..addResponseModifier((resp) => resp.statusCode = 201);
-      }).listen((r) async {
+      }).linkFunction((r) async {
         return new Response.ok(null);
       });
 
@@ -34,9 +34,9 @@ void main() {
     });
 
     test("Can remove header", () async {
-      root.listen((r) async {
+      root.linkFunction((r) async {
         return r..addResponseModifier((resp) => resp.headers.remove("x-foo"));
-      }).listen((r) async {
+      }).linkFunction((r) async {
         return new Response.ok(null, headers: {"x-foo": "foo"});
       });
 
@@ -45,9 +45,9 @@ void main() {
     });
 
     test("Can add header", () async {
-      root.listen((r) async {
+      root.linkFunction((r) async {
         return r..addResponseModifier((resp) => resp.headers["x-foo"] = "bar");
-      }).listen((r) async {
+      }).linkFunction((r) async {
         return new Response.ok(null);
       });
 
@@ -56,9 +56,9 @@ void main() {
     });
 
     test("Can change header value", () async {
-      root.listen((r) async {
+      root.linkFunction((r) async {
         return r..addResponseModifier((resp) => resp.headers["x-foo"] = "bar");
-      }).listen((r) async {
+      }).linkFunction((r) async {
         return new Response.ok(null, headers: {"x-foo": "foo"});
       });
 
@@ -67,9 +67,9 @@ void main() {
     });
 
     test("Can modify body prior to encoding", () async {
-      root.listen((r) async {
+      root.linkFunction((r) async {
         return r..addResponseModifier((resp) => resp.body["foo"] = "y");
-      }).listen((r) async {
+      }).linkFunction((r) async {
         return new Response.ok({"x": "a"});
       });
 
@@ -101,13 +101,13 @@ void main() {
     test("Return null", () async {
       var set = false;
       root
-        .listen((req) {
+        .linkFunction((req) {
           req.raw.response.statusCode = 200;
           req.raw.response.close();
 
           return null;
         })
-        .listen((req) {
+        .linkFunction((req) {
           set = true;
         });
 
@@ -201,7 +201,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8000);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.listen(handler);
+        next.linkFunction(handler);
         await next.receive(req);
       });
 
@@ -218,7 +218,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.listen((req) async {
+        next.linkFunction((req) async {
           var obj = new SomeObject()..name = "Bob";
           return new Response.ok(obj);
         });
@@ -236,7 +236,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.listen((req) async {
+        next.linkFunction((req) async {
           return new Response.ok({"a": "b"});
         });
         await next.receive(req);
@@ -253,7 +253,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.listen((req) async {
+        next.linkFunction((req) async {
           return new Response.ok(new DateTime.now());
         });
         await next.receive(req);
@@ -271,7 +271,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.listen((req) async {
+        next.linkFunction((req) async {
           return new Response.ok(null);
         });
         await next.receive(req);
@@ -289,7 +289,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.generate(() => new Always200Controller());
+        next.link(() => new Always200Controller());
         await next.receive(req);
       });
 
@@ -324,7 +324,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.generate(() => new Always200Controller());
+        next.link(() => new Always200Controller());
         await next.receive(req);
       });
 
@@ -353,7 +353,7 @@ void main() {
       server = await HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
-        next.listen((r) async {
+        next.linkFunction((r) async {
           await r.body.decodeAsMap();
           return new Response.ok(null);
         });
@@ -413,7 +413,7 @@ class OutlierChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final r = new Router();
-    r.route("/detach").listen((Request req) async {
+    r.route("/detach").linkFunction((Request req) async {
       if (count == 0) {
         var socket = await req.raw.response.detachSocket();
         socket.destroy();
@@ -433,7 +433,7 @@ class OutlierChannel extends ApplicationChannel {
       return new Response.ok(null);
     });
 
-    r.route("/closed").listen((Request req) async {
+    r.route("/closed").linkFunction((Request req) async {
       if (count == 0) {
         req.raw.response.statusCode = 200;
         await req.response.close();
@@ -444,7 +444,7 @@ class OutlierChannel extends ApplicationChannel {
       return new Response.ok(null);
     });
 
-    r.route("/closed_exception").listen((Request req) async {
+    r.route("/closed_exception").linkFunction((Request req) async {
       await req.response.close();
 
       // To stop the analyzer from complaining, since it see through the bullshit of 'if (true)' and the return type would be dead code.

--- a/test/http/cors_test.dart
+++ b/test/http/cors_test.dart
@@ -19,8 +19,7 @@ void main() {
     await app?.stop();
   });
 
-  group(
-      "Normal/Simple Requests: If the origin header is not present, terminate this set of steps. (No CORS Headers.)",
+  group("Normal/Simple Requests: If the origin header is not present, terminate this set of steps. (No CORS Headers.)",
       () {
     // This group ensures that if a controller has or doesn't have a policy, if it is not a CORS request,
     // no CORS headers/processing occurs.
@@ -30,8 +29,7 @@ void main() {
       expectThatNoCORSProcessingOccurred(resp);
     });
 
-    test("Controller with permissive default policy returns correctly",
-        () async {
+    test("Controller with permissive default policy returns correctly", () async {
       var resp = await http.get("http://localhost:8000/defaultpolicy");
       expect(resp.statusCode, 200);
       expectThatNoCORSProcessingOccurred(resp);
@@ -55,24 +53,20 @@ void main() {
       () {
     // This group ensures that if the Origin is invalid for a resource, that CORS processing aborts.
     test("Valid endpoint returns correctly, mis-matched origin", () async {
-      var resp = await http.get("http://localhost:8000/restrictive",
-          headers: {"Origin": "not this"});
+      var resp = await http.get("http://localhost:8000/restrictive", headers: {"Origin": "not this"});
       expect(resp.statusCode, 200);
       expectThatNoCORSProcessingOccurred(resp);
     });
 
     test("Valid endpoint, case match failure", () async {
-      var resp = await http.get("http://localhost:8000/restrictive",
-          headers: {"Origin": "http://Exclusive.com"});
+      var resp = await http.get("http://localhost:8000/restrictive", headers: {"Origin": "http://Exclusive.com"});
       expect(resp.statusCode, 200);
       expectThatNoCORSProcessingOccurred(resp);
     });
 
-    test("Invalid resource gets CORS headers to expose 404 to calling client",
-        () async {
+    test("Invalid resource gets CORS headers to expose 404 to calling client", () async {
       // In this case, there is no 'resource', so we add the origin so the calling client can see the 404. Not sure on this behavior.
-      var resp = await http.get("http://localhost:8000/foobar",
-          headers: {"Origin": "http://abc.com"});
+      var resp = await http.get("http://localhost:8000/foobar", headers: {"Origin": "http://abc.com"});
       expect(resp.statusCode, 404);
       expect(resp.headers["access-control-allow-origin"], "http://abc.com");
       expect(resp.headers["access-control-allow-headers"], isNull);
@@ -81,14 +75,9 @@ void main() {
       expect(resp.headers["access-control-allow-credentials"], isNull);
     });
 
-    test(
-        "Unauthorized resource with invalid origin does not attach CORS headers",
-        () async {
+    test("Unauthorized resource with invalid origin does not attach CORS headers", () async {
       var resp = await http.get("http://localhost:8000/restrictive_auth",
-          headers: {
-            "Origin": "http://Exclusive.com",
-            "Authorization": "Bearer noauth"
-          });
+          headers: {"Origin": "http://Exclusive.com", "Authorization": "Bearer noauth"});
       expect(resp.statusCode, 401);
       expectThatNoCORSProcessingOccurred(resp);
     });
@@ -101,11 +90,9 @@ void main() {
     test(
         "Origin and credentials are returned if credentials are supported and origin is specific, origin must be non-*",
         () async {
-      var resp = await http.get("http://localhost:8000/restrictive",
-          headers: {"Origin": "http://exclusive.com"});
+      var resp = await http.get("http://localhost:8000/restrictive", headers: {"Origin": "http://exclusive.com"});
       expect(resp.statusCode, 200);
-      expect(
-          resp.headers["access-control-allow-origin"], "http://exclusive.com");
+      expect(resp.headers["access-control-allow-origin"], "http://exclusive.com");
       expect(resp.headers["access-control-allow-headers"], isNull);
       expect(resp.headers["access-control-allow-methods"], isNull);
       expect(resp.headers["access-control-expose-headers"], "foobar, x-foo");
@@ -115,8 +102,7 @@ void main() {
     test(
         "Normal/Simple Requests: Origin and credentials are returned if credentials are supported and origin is catch-all, origin must be non-*",
         () async {
-      var resp = await http.get("http://localhost:8000/defaultpolicy",
-          headers: {"Origin": "http://foobar.com"});
+      var resp = await http.get("http://localhost:8000/defaultpolicy", headers: {"Origin": "http://foobar.com"});
       expect(resp.statusCode, 200);
       expect(resp.headers["access-control-allow-origin"], "http://foobar.com");
       expect(resp.headers["access-control-allow-headers"], isNull);
@@ -125,14 +111,11 @@ void main() {
       expect(resp.headers["access-control-allow-credentials"], "true");
     });
 
-    test(
-        "Normal/Simple Requests: If credentials are not supported and origin is valid, only set origin",
-        () async {
-      var resp = await http.get("http://localhost:8000/restrictive_nocreds",
-          headers: {"Origin": "http://exclusive.com"});
+    test("Normal/Simple Requests: If credentials are not supported and origin is valid, only set origin", () async {
+      var resp =
+          await http.get("http://localhost:8000/restrictive_nocreds", headers: {"Origin": "http://exclusive.com"});
       expect(resp.statusCode, 200);
-      expect(
-          resp.headers["access-control-allow-origin"], "http://exclusive.com");
+      expect(resp.headers["access-control-allow-origin"], "http://exclusive.com");
       expect(resp.headers["access-control-allow-headers"], isNull);
       expect(resp.headers["access-control-allow-methods"], isNull);
       expect(resp.headers["access-control-expose-headers"], "foobar");
@@ -145,8 +128,7 @@ void main() {
       () {
     // This group ensures that headers are exposed correctly
     test("Empty exposed headers returns no header to indicate them", () async {
-      var resp = await http.get("http://localhost:8000/defaultpolicy",
-          headers: {"Origin": "http://foobar.com"});
+      var resp = await http.get("http://localhost:8000/defaultpolicy", headers: {"Origin": "http://foobar.com"});
       expect(resp.statusCode, 200);
       expect(resp.headers["access-control-allow-origin"], "http://foobar.com");
       expect(resp.headers["access-control-allow-headers"], isNull);
@@ -156,11 +138,10 @@ void main() {
     });
 
     test("If one exposed header, return it in ACEH", () async {
-      var resp = await http.get("http://localhost:8000/restrictive_nocreds",
-          headers: {"Origin": "http://exclusive.com"});
+      var resp =
+          await http.get("http://localhost:8000/restrictive_nocreds", headers: {"Origin": "http://exclusive.com"});
       expect(resp.statusCode, 200);
-      expect(
-          resp.headers["access-control-allow-origin"], "http://exclusive.com");
+      expect(resp.headers["access-control-allow-origin"], "http://exclusive.com");
       expect(resp.headers["access-control-allow-headers"], isNull);
       expect(resp.headers["access-control-allow-methods"], isNull);
       expect(resp.headers["access-control-expose-headers"], "foobar");
@@ -168,14 +149,11 @@ void main() {
     });
 
     test("If multiple exposed headers, return them in ACEH", () async {
-      var resp = await http.get("http://localhost:8000/restrictive", headers: {
-        "Authorization": "Bearer auth",
-        "Origin": "http://exclusive.com"
-      });
+      var resp = await http.get("http://localhost:8000/restrictive",
+          headers: {"Authorization": "Bearer auth", "Origin": "http://exclusive.com"});
 
       expect(resp.statusCode, 200);
-      expect(
-          resp.headers["access-control-allow-origin"], "http://exclusive.com");
+      expect(resp.headers["access-control-allow-origin"], "http://exclusive.com");
       expect(resp.headers["access-control-allow-headers"], isNull);
       expect(resp.headers["access-control-allow-methods"], isNull);
       expect(resp.headers["access-control-expose-headers"], "foobar, x-foo");
@@ -186,11 +164,8 @@ void main() {
   // Make sure preflights don't get exposed headers
   group("Preflight: If the origin header is not present", () {
     // This group ensures that an OPTIONS request without CORS headers gets treated like a normal OPTIONS request
-    test(
-        "Return 200 if there is an actual endpoint for OPTIONS (No CORS Headers)",
-        () async {
-      var req =
-          await (new HttpClient().open("OPTIONS", "localhost", 8000, "opts"));
+    test("Return 200 if there is an actual endpoint for OPTIONS (No CORS Headers)", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "opts"));
       req.headers.set("Authorization", "Bearer auth");
       var resp = await req.close();
       await resp.drain();
@@ -199,11 +174,9 @@ void main() {
       expectThatNoCORSProcessingOccurred(resp);
     });
 
-    test(
-        "Return 401 if there is an actual endpoint for OPTIONS and request is unauthorized (No CORS Headers)",
+    test("Return 401 if there is an actual endpoint for OPTIONS and request is unauthorized (No CORS Headers)",
         () async {
-      var req =
-          await (new HttpClient().open("OPTIONS", "localhost", 8000, "opts"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "opts"));
       var resp = await req.close();
       await resp.drain();
 
@@ -211,10 +184,8 @@ void main() {
       expectThatNoCORSProcessingOccurred(resp);
     });
 
-    test("Return 404 if there is no endpoint for OPTIONS (No CORS Headers)",
-        () async {
-      var req =
-          await (new HttpClient().open("OPTIONS", "localhost", 8000, "foobar"));
+    test("Return 404 if there is no endpoint for OPTIONS (No CORS Headers)", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "foobar"));
       var resp = await req.close();
       await resp.drain();
 
@@ -222,11 +193,8 @@ void main() {
       expectThatNoCORSProcessingOccurred(resp);
     });
 
-    test(
-        "Return 405 if there is an endpoint, but OPTIONS not supported (No CORS Headers)",
-        () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "nopolicy"));
+    test("Return 405 if there is an endpoint, but OPTIONS not supported (No CORS Headers)", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "nopolicy"));
       var resp = await req.close();
       await resp.drain();
 
@@ -235,34 +203,26 @@ void main() {
     });
   });
 
-  group(
-      "Preflight: If the value of Origin header is not a case-sensitive match for list of origins...",
-      () {
+  group("Preflight: If the value of Origin header is not a case-sensitive match for list of origins...", () {
     // This group ensures that if the Origin is invalid, we return a 403.
 
     test("If origin is correct, get 200 from OPTIONS", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "restrictive"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "restrictive"));
       req.headers.set("Origin", "http://exclusive.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://exclusive.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://exclusive.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), "true");
     });
 
-    test(
-        "If origin is invalid because of case-sensitivity, get 403 from OPTIONS",
-        () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "restrictive"));
+    test("If origin is invalid because of case-sensitivity, get 403 from OPTIONS", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "restrictive"));
       req.headers.set("Origin", "http://Exclusive.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       var resp = await req.close();
@@ -272,8 +232,7 @@ void main() {
     });
 
     test("If origin is invalid, get 403 from OPTIONS", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "restrictive"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "restrictive"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       var resp = await req.close();
@@ -283,8 +242,7 @@ void main() {
     });
 
     test("If no policy defined, return 403", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "nopolicy"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "nopolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       var resp = await req.close();
@@ -297,8 +255,7 @@ void main() {
   group("Preflight: Validate headers and methods", () {
     // This group ensures that if the Origin is valid, but there is no Access-Control-Request-Method, we return a 403.
     test("If allow method is not available", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "PATCH");
       var resp = await req.close();
@@ -308,33 +265,28 @@ void main() {
     });
 
     test("If allow method is available", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), "true");
     });
 
     test("Just one allowed method returns that", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "single_method"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "single_method"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "GET");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
       expect(resp.headers.value("access-control-allow-methods"), "GET");
@@ -344,102 +296,85 @@ void main() {
     });
 
     test("If one allow header is available", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       req.headers.set("Access-Control-Request-Headers", "authorization");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), "true");
     });
 
     test("Headers are case insensitive", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
-      req.headers.set("Access-Control-Request-Headers",
-          "Authorization, X-Requested-With, X-Forwarded-For, Content-Type");
+      req.headers
+          .set("Access-Control-Request-Headers", "Authorization, X-Requested-With, X-Forwarded-For, Content-Type");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), "true");
     });
 
     test("If multiple allow header is available", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
-      req.headers.set("Access-Control-Request-Headers",
-          "authorization, x-requested-with, x-forwarded-for, content-type");
+      req.headers
+          .set("Access-Control-Request-Headers", "authorization, x-requested-with, x-forwarded-for, content-type");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), "true");
     });
 
     test("If allow header is a simple header, return 200", () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
-      req.headers
-          .set("Access-Control-Request-Headers", "accept, authorization");
+      req.headers.set("Access-Control-Request-Headers", "accept, authorization");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), "true");
     });
 
-    test("If one allow header is not available, but others are, get a 403",
-        () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+    test("If one allow header is not available, but others are, get a 403", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
-      req.headers.set("Access-Control-Request-Headers",
-          "authorization, x-requested-with, x-forwarded-for, content-type, x-foo");
+      req.headers.set(
+          "Access-Control-Request-Headers", "authorization, x-requested-with, x-forwarded-for, content-type, x-foo");
       var resp = await req.close();
 
       expect(resp.statusCode, 403);
       expectThatNoCORSProcessingOccurred(resp);
     });
 
-    test("If one specified allow headers are not available, get a 403",
-        () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+    test("If one specified allow headers are not available, get a 403", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       req.headers.set("Access-Control-Request-Headers", "x-foo");
@@ -449,10 +384,8 @@ void main() {
       expectThatNoCORSProcessingOccurred(resp);
     });
 
-    test("If all specified allow headers are not available, get a 403",
-        () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+    test("If all specified allow headers are not available, get a 403", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       req.headers.set("Access-Control-Request-Headers", "x-foo, x-bar");
@@ -463,48 +396,35 @@ void main() {
     });
   });
 
-  group(
-      "Preflight: Add Access-Control-Allow-Origin and Access-Control-Allow-Credentials",
-      () {
+  group("Preflight: Add Access-Control-Allow-Origin and Access-Control-Allow-Credentials", () {
     // This group ensures that if we have a valid origin, we add the allow-origin and optionally allow-credentials
-    test(
-        "If valid origin and endpoint allows credentials, add allow origin/creds",
-        () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+    test("If valid origin and endpoint allows credentials, add allow origin/creds", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
-      req.headers
-          .set("Access-Control-Request-Headers", "accept, authorization");
+      req.headers.set("Access-Control-Request-Headers", "accept, authorization");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), "true");
     });
 
-    test(
-        "If valid origin and endpoint do not allow credentials, add allow origin but not creds",
-        () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "restrictive_nocreds"));
+    test("If valid origin and endpoint do not allow credentials, add allow origin but not creds", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "restrictive_nocreds"));
       req.headers.set("Origin", "http://exclusive.com");
       req.headers.set("Access-Control-Request-Method", "POST");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://exclusive.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://exclusive.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), isNull);
     });
@@ -512,24 +432,18 @@ void main() {
 
   group("Preflight: Optionally add a single Acces-Control-Max-Age header", () {
     // This group ensures that we add Access-Control-Max-Age if defined and everything else is valid
-    test(
-        "If valid origin and endpoint allows credentials, add allow origin/creds",
-        () async {
-      var req = await (new HttpClient()
-          .open("OPTIONS", "localhost", 8000, "defaultpolicy"));
+    test("If valid origin and endpoint allows credentials, add allow origin/creds", () async {
+      var req = await (new HttpClient().open("OPTIONS", "localhost", 8000, "defaultpolicy"));
       req.headers.set("Origin", "http://foobar.com");
       req.headers.set("Access-Control-Request-Method", "POST");
-      req.headers
-          .set("Access-Control-Request-Headers", "accept, authorization");
+      req.headers.set("Access-Control-Request-Headers", "accept, authorization");
       var resp = await req.close();
 
       expect(resp.statusCode, 200);
-      expect(resp.headers.value("access-control-allow-origin"),
-          "http://foobar.com");
+      expect(resp.headers.value("access-control-allow-origin"), "http://foobar.com");
       expect(resp.headers.value("access-control-allow-headers"),
           "origin, authorization, x-requested-with, x-forwarded-for, content-type");
-      expect(resp.headers.value("access-control-allow-methods"),
-          "POST, PUT, DELETE, GET");
+      expect(resp.headers.value("access-control-allow-methods"), "POST, PUT, DELETE, GET");
       expect(resp.headers.value("access-control-expose-headers"), isNull);
       expect(resp.headers.value("access-control-allow-credentials"), "true");
       expect(resp.headers.value("access-control-max-age"), "86400");
@@ -541,20 +455,13 @@ void main() {
       http.Response lastResponse;
 
       for (var i = 0; i < 10; i++) {
-        lastResponse = await http.get("http://localhost:8000/add",
-            headers: {"Origin": "http://www.a.com"});
+        lastResponse = await http.get("http://localhost:8000/add", headers: {"Origin": "http://www.a.com"});
         expect(lastResponse.statusCode, 200);
       }
 
-      expect(
-          lastResponse.headers["access-control-expose-headers"]
-              .indexOf("X-Header"),
-          greaterThanOrEqualTo(0));
-      expect(
-          lastResponse.headers["access-control-expose-headers"]
-              .indexOf("X-Header"),
-          lastResponse.headers["access-control-expose-headers"]
-              .lastIndexOf("X-Header"));
+      expect(lastResponse.headers["access-control-expose-headers"].indexOf("X-Header"), greaterThanOrEqualTo(0));
+      expect(lastResponse.headers["access-control-expose-headers"].indexOf("X-Header"),
+          lastResponse.headers["access-control-expose-headers"].lastIndexOf("X-Header"));
     });
   });
 }
@@ -579,35 +486,17 @@ class CORSChannel extends ApplicationChannel implements AuthValidator {
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/add").generate(() => new AdditiveController());
+    router.route("/add").link(() => new AdditiveController());
 
-    router
-        .route("/opts")
-        .pipe(new Authorizer(this))
-        .generate(() => new OptionsController());
-    router
-        .route("/restrictive")
-        .generate(() => new RestrictiveOriginController());
-    router.route("/single_method").generate(() => new SingleMethodController());
-    router
-        .route("/restrictive_auth")
-        .pipe(new Authorizer(this))
-        .generate(() => new RestrictiveOriginController());
-    router
-        .route("/restrictive_nocreds")
-        .generate(() => new RestrictiveNoCredsOriginController());
-    router.route("/nopolicy").generate(() => new NoPolicyController());
-    router
-        .route("/defaultpolicy")
-        .generate(() => new DefaultPolicyController());
-    router
-        .route("/nopolicyauth")
-        .pipe(new Authorizer(this))
-        .generate(() => new NoPolicyController());
-    router
-        .route("/defaultpolicyauth")
-        .pipe(new Authorizer(this))
-        .generate(() => new DefaultPolicyController());
+    router.route("/opts").link(() => new Authorizer(this)).link(() => new OptionsController());
+    router.route("/restrictive").link(() => new RestrictiveOriginController());
+    router.route("/single_method").link(() => new SingleMethodController());
+    router.route("/restrictive_auth").link(() => new Authorizer(this)).link(() => new RestrictiveOriginController());
+    router.route("/restrictive_nocreds").link(() => new RestrictiveNoCredsOriginController());
+    router.route("/nopolicy").link(() => new NoPolicyController());
+    router.route("/defaultpolicy").link(() => new DefaultPolicyController());
+    router.route("/nopolicyauth").link(() => new Authorizer(this)).link(() => new NoPolicyController());
+    router.route("/defaultpolicyauth").link(() => new Authorizer(this)).link(() => new DefaultPolicyController());
     return router;
   }
 
@@ -621,8 +510,7 @@ class CORSChannel extends ApplicationChannel implements AuthValidator {
   }
 
   @override
-  List<APISecurityRequirement> requirementsForStrategy(AuthorizationParser strategy) =>
-      null;
+  List<APISecurityRequirement> requirementsForStrategy(AuthorizationParser strategy) => null;
 }
 
 class NoPolicyController extends RESTController {

--- a/test/http/default_resource_controller_test.dart
+++ b/test/http/default_resource_controller_test.dart
@@ -420,11 +420,11 @@ class TestChannel extends ApplicationChannel {
     final router = new Router();
     router
         .route("/controller/[:id]")
-        .generate(() => new ManagedObjectController<TestModel>());
+        .link(() => new ManagedObjectController<TestModel>());
 
     router
       .route("/dynamic/[:id]")
-      .generate(() => new ManagedObjectController.forEntity(context.dataModel.entityForType(TestModel)));
+      .link(() => new ManagedObjectController.forEntity(context.dataModel.entityForType(TestModel)));
     return router;
   }
 }

--- a/test/http/document_test.dart
+++ b/test/http/document_test.dart
@@ -425,17 +425,17 @@ class TestChannel extends ApplicationChannel {
     final router = new Router();
     router
         .route("/auth/code")
-        .pipe(new Authorizer.basic(authServer))
-        .generate(() => new AuthCodeController(authServer));
+        .link(() => new Authorizer.basic(authServer))
+        .link(() => new AuthCodeController(authServer));
     router
         .route("/auth/token")
-        .pipe(new Authorizer.basic(authServer))
-        .generate(() => new AuthController(authServer));
+        .link(() => new Authorizer.basic(authServer))
+        .link(() => new AuthController(authServer));
     router
         .route("/t[/:id[/:notID]]")
-        .pipe(new Authorizer.bearer(authServer))
-        .generate(() => new TController());
-    router.route("/h[/:var]").listen((Request req) async {
+        .link(() => new Authorizer.bearer(authServer))
+        .link(() => new TController());
+    router.route("/h[/:var]").linkFunction((Request req) async {
       return new Response.ok("");
     });
     return router;

--- a/test/http/file_controller_test.dart
+++ b/test/http/file_controller_test.dart
@@ -51,12 +51,12 @@ void main() {
                   .any((suffix) => path.endsWith(suffix)));
 
     var router = new Router()
-      ..route("/files/*").pipe(new HTTPFileController("temp_files"))
-      ..route("/redirect/*").pipe(new HTTPFileController("temp_files", onFileNotFound: (c, r) async {
+      ..route("/files/*").link(() => new HTTPFileController("temp_files"))
+      ..route("/redirect/*").link(() => new HTTPFileController("temp_files", onFileNotFound: (c, r) async {
         return new Response.ok({"k": "v"});
       }))
-      ..route("/cache/*").pipe(cachingController)
-      ..route("/silly/*").pipe(
+      ..route("/cache/*").link(() =>cachingController)
+      ..route("/silly/*").link(() =>
           new HTTPFileController("temp_files")
             ..setContentTypeForExtension("silly", new ContentType("text", "html", charset: "utf-8")));
     router.prepare();

--- a/test/http/isolate/isolate_application_test.dart
+++ b/test/http/isolate/isolate_application_test.dart
@@ -118,9 +118,9 @@ class TestChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/t").listen((req) async => new Response.ok("t_ok"));
-    router.route("/r").listen((req) async => new Response.ok("r_ok"));
-    router.route("startup").listen((r) async {
+    router.route("/t").linkFunction((req) async => new Response.ok("t_ok"));
+    router.route("/r").linkFunction((req) async => new Response.ok("r_ok"));
+    router.route("startup").linkFunction((r) async {
       var total = options.context["startup"].fold(0, (a, b) => a + b);
       return new Response.ok("$total");
     });

--- a/test/http/isolate/isolate_failure_test.dart
+++ b/test/http/isolate/isolate_failure_test.dart
@@ -152,7 +152,7 @@ class CrashChannel extends ApplicationChannel {
     if (options.context["crashIn"] == "addRoutes") {
       throw new TestException("addRoutes");
     }
-    router.route("/t").listen((req) async => new Response.ok("t_ok"));
+    router.route("/t").linkFunction((req) async => new Response.ok("t_ok"));
     return router;
   }
 
@@ -174,9 +174,9 @@ class TestChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/t").listen((req) async => new Response.ok("t_ok"));
-    router.route("/r").listen((req) async => new Response.ok("r_ok"));
-    router.route("startup").listen((r) async {
+    router.route("/t").linkFunction((req) async => new Response.ok("t_ok"));
+    router.route("/r").linkFunction((req) async => new Response.ok("r_ok"));
+    router.route("startup").linkFunction((r) async {
       var total = options.context["startup"].fold(0, (a, b) => a + b);
       return new Response.ok("$total");
     });

--- a/test/http/isolate/message_hub_test.dart
+++ b/test/http/isolate/message_hub_test.dart
@@ -237,19 +237,19 @@ class HubChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/messages").listen((req) async {
+    router.route("/messages").linkFunction((req) async {
       var msgs = new List.from(messages);
       messages = [];
       return new Response.ok(msgs);
     });
 
-    router.route("/errors").listen((req) async {
+    router.route("/errors").linkFunction((req) async {
       var msgs = new List.from(errors);
       errors = [];
       return new Response.ok(msgs);
     });
 
-    router.route("/send").listen((req) async {
+    router.route("/send").linkFunction((req) async {
       var msg = await req.body.decodeAsString();
       if (msg == "garbage") {
         messageHub.add((x) => x);

--- a/test/http/isolate/recovery_test.dart
+++ b/test/http/isolate/recovery_test.dart
@@ -75,7 +75,7 @@ class TestChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/[:id]").generate(() => new UncaughtCrashController());
+    router.route("/[:id]").link(() => new UncaughtCrashController());
     return router;
   }
 }

--- a/test/http/rest_controller_body_binding_test.dart
+++ b/test/http/rest_controller_body_binding_test.dart
@@ -264,7 +264,7 @@ class CrashController extends RESTController {
 
 Future<HttpServer> enableController(String pattern, Type controller) async {
   var router = new Router();
-  router.route(pattern).generate(
+  router.route(pattern).link(
           () => reflectClass(controller).newInstance(new Symbol(""), []).reflectee);
   router.prepare();
 

--- a/test/http/rest_controller_test.dart
+++ b/test/http/rest_controller_test.dart
@@ -772,7 +772,7 @@ class UnboundController extends RESTController {
 
 Future<HttpServer> enableController(String pattern, Type controller) async {
   var router = new Router();
-  router.route(pattern).generate(
+  router.route(pattern).link(
       () => reflectClass(controller).newInstance(new Symbol(""), []).reflectee);
   router.prepare();
 

--- a/test/http/sink_test.dart
+++ b/test/http/sink_test.dart
@@ -3,21 +3,6 @@ import 'package:test/test.dart';
 import 'package:aqueduct/aqueduct.dart';
 
 void main() {
-  test(
-      "Controller requiring instantion throws exception when instantiated early",
-      () async {
-    var app = new Application<TestChannel>();
-    try {
-      await app.start();
-      expect(true, false);
-    } on ApplicationStartupException catch (e) {
-      expect(
-          e.toString(),
-          contains(
-              "'FailingController' instances cannot be reused between requests. Rewrite as .generate(() => new FailingController())"));
-    }
-  });
-
   test("Find default ApplicationChannel", () {
     expect(ApplicationChannel.defaultType, equals(TestChannel));
   });
@@ -27,7 +12,7 @@ class TestChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/controller/[:id]").pipe(new FailingController());
+    router.route("/controller/[:id]").link(() =>new FailingController());
     return router;
   }
 }

--- a/test/http/ssl_test.dart
+++ b/test/http/ssl_test.dart
@@ -37,7 +37,7 @@ class TestChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final router = new Router();
-    router.route("/r").listen((r) async => new Response.ok(null));
+    router.route("/r").linkFunction((r) async => new Response.ok(null));
     return router;
   }
 }

--- a/test/http/subclass_managed_object_controller_test.dart
+++ b/test/http/subclass_managed_object_controller_test.dart
@@ -127,7 +127,7 @@ class TestChannel extends ApplicationChannel {
     final router = new Router();
     router
         .route("/controller/[:id]")
-        .generate(() => new Subclass());
+        .link(() => new Subclass());
     return router;
   }
 }

--- a/test/testing/test_client_test.dart
+++ b/test/testing/test_client_test.dart
@@ -314,7 +314,7 @@ class SomeChannel extends ApplicationChannel {
   @override
   Controller get entryPoint {
     final r = new Router();
-    r.route("/").listen((r) async => new Response.ok(null));
+    r.route("/").linkFunction((r) async => new Response.ok(null));
     return r;
   }
 }


### PR DESCRIPTION
1. `generate` renamed to `link`

2. Removed `pipe` to prevent confusion of reusing same instance in default scenarios

3. Renamed `listen` to `linkFunction`.