### PR TITLE
Unifies ManagedObject property access

### DIFF
--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -42,7 +42,7 @@ class ManagedMatcherBacking extends ManagedBacking {
             ..entity = property.destinationEntity;
         } else if (property.relationshipType == ManagedRelationshipType.hasOne ||
             property.relationshipType == ManagedRelationshipType.belongsTo) {
-          valueMap[property.name] = property.destinationEntity.newInstance(forMatching: true);
+          valueMap[property.name] = property.destinationEntity.newInstance(backing: new ManagedMatcherBacking());
         }
       }
     }

--- a/lib/src/db/managed/data_model_builder.dart
+++ b/lib/src/db/managed/data_model_builder.dart
@@ -22,10 +22,6 @@ class DataModelBuilder {
       persistentTypeToEntityMap[entity.persistentType.reflectedType] = entity;
 
       entity.attributes = attributesForEntity(entity);
-      if (entity.primaryKey == null) {
-        throw new ManagedDataModelError.noPrimaryKey(entity);
-      }
-
       entity.validators = entity.attributes.values
           .map((desc) => desc.validators.map((v) => new ManagedValidator(desc, v)))
           .expand((e) => e)
@@ -51,6 +47,16 @@ class DataModelBuilder {
       });
 
       entity.uniquePropertySet = instanceUniquePropertiesForEntity(entity);
+
+      entity.symbolMap = {};
+      entity.attributes.forEach((name, _) {
+        entity.symbolMap[new Symbol(name)] = name;
+        entity.symbolMap[new Symbol("$name=")] = name;
+      });
+      entity.relationships.forEach((name, _) {
+        entity.symbolMap[new Symbol(name)] = name;
+        entity.symbolMap[new Symbol("$name=")] = name;
+      });
     });
   }
 

--- a/lib/src/db/managed/entity.dart
+++ b/lib/src/db/managed/entity.dart
@@ -1,5 +1,4 @@
 import 'dart:mirrors';
-import 'package:aqueduct/src/db/managed/backing.dart';
 import 'package:aqueduct/src/openapi/openapi.dart';
 import 'package:aqueduct/src/utilities/mirror_helpers.dart';
 
@@ -164,12 +163,13 @@ class ManagedEntity implements APIComponentDocumenter {
   }
 
   /// Creates a new instance of this entity's instance type.
-  ManagedObject newInstance({bool forMatching: false, bool forPropertyIdentification: false}) {
-    if (forMatching) {
-      return ManagedObject.instantiateDynamic(this, backing: new ManagedMatcherBacking());
-    } else if (forPropertyIdentification) {
-      return ManagedObject.instantiateDynamic(this, backing: new ManagedAccessTrackingBacking());
+  ///
+  /// By default, the returned object will use a normal value backing map. 
+  ManagedObject newInstance({ManagedBacking backing}) {
+    if (backing != null) {
+      return ManagedObject.instantiateDynamic(this, backing: backing);
     }
+
     return ManagedObject.instantiateDynamic(this);
   }
 

--- a/lib/src/db/managed/object.dart
+++ b/lib/src/db/managed/object.dart
@@ -64,6 +64,7 @@ abstract class ManagedBacking {
 ///
 /// See more documentation on defining a data model at http://aqueduct.io/docs/db/modeling_data/
 class ManagedObject<PersistentType> implements HTTPSerializable {
+  /// Creates a new instance of [entity] with [backing].
   static ManagedObject instantiateDynamic(ManagedEntity entity, {ManagedBacking backing}) {
     ManagedObject object = entity.instanceType.newInstance(const Symbol(""), []).reflectee as ManagedObject;
     if (backing != null) {

--- a/lib/src/db/managed/object.dart
+++ b/lib/src/db/managed/object.dart
@@ -23,11 +23,10 @@ import 'exception.dart';
 /// and query-building.
 abstract class ManagedBacking {
   /// Retrieve a property by its entity and name.
-  dynamic valueForProperty(ManagedEntity entity, String propertyName);
+  dynamic valueForProperty(ManagedPropertyDescription property);
 
   /// Sets a property by its entity and name.
-  void setValueForProperty(
-      ManagedEntity entity, String propertyName, dynamic value);
+  void setValueForProperty(ManagedPropertyDescription property, dynamic value);
 
   /// Removes a property from this instance.
   ///
@@ -65,33 +64,54 @@ abstract class ManagedBacking {
 ///
 /// See more documentation on defining a data model at http://aqueduct.io/docs/db/modeling_data/
 class ManagedObject<PersistentType> implements HTTPSerializable {
+  static ManagedObject instantiateDynamic(ManagedEntity entity, {ManagedBacking backing}) {
+    ManagedObject object = entity.instanceType.newInstance(const Symbol(""), []).reflectee as ManagedObject;
+    if (backing != null) {
+      object._backing = backing;
+    }
+    object.entity = entity;
+    return object;
+  }
+
   /// The [ManagedEntity] this instance is described by.
-  ManagedEntity entity =
-      ManagedContext.defaultContext.dataModel.entityForType(PersistentType);
+  ManagedEntity entity = ManagedContext.defaultContext.dataModel.entityForType(PersistentType);
 
   /// The managed values of this instance.
   ///
   /// Not all values are fetched or populated in a [ManagedObject] instance. This value contains
   /// key-value pairs for the managed object that have been set, either manually
   /// or when fetched from a database. When [ManagedObject] is instantiated, this map is empty.
-  Map<String, dynamic> get backingMap => backing.valueMap;
+  Map<String, dynamic> get backingMap => _backing.valueMap;
 
-  ManagedBacking backing = new ManagedValueBacking();
+  ManagedBacking _backing = new ManagedValueBacking();
 
   /// Retrieves a value by property name from the [backingMap].
-  dynamic operator [](String propertyName) =>
-      backing.valueForProperty(entity, propertyName);
+  dynamic operator [](String propertyName) {
+    final prop = entity.properties[propertyName];
+    if (prop == null) {
+      throw new ArgumentError("Invalid property access for '${MirrorSystem.getName(entity.instanceType.simpleName)}'. "
+          "Property '$propertyName' does not exist on '${MirrorSystem.getName(entity.instanceType.simpleName)}'.");
+    }
+
+    return _backing.valueForProperty(prop);
+  }
 
   /// Sets a value by property name in the [backingMap].
   void operator []=(String propertyName, dynamic value) {
-    backing.setValueForProperty(entity, propertyName, value);
+    final prop = entity.properties[propertyName];
+    if (prop == null) {
+      throw new ArgumentError("Invalid property access for '${MirrorSystem.getName(entity.instanceType.simpleName)}'. "
+          "Property '$propertyName' does not exist on '${MirrorSystem.getName(entity.instanceType.simpleName)}'.");
+    }
+
+    _backing.setValueForProperty(prop, value);
   }
 
   /// Removes a property from the [backingMap].
   ///
   /// This will remove a value from the backing map.
   void removePropertyFromBackingMap(String propertyName) {
-    backing.removeProperty(propertyName);
+    _backing.removeProperty(propertyName);
   }
 
   /// Checks whether or not a property has been set in this instances' [backingMap].
@@ -116,9 +136,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   ///
   /// This method is only invoked when a query is configured by its [Query.values]. This method is not invoked
   /// if [Query.valueMap] is used to configure a query.
-  void willUpdate() {
-
-  }
+  void willUpdate() {}
 
   /// Callback to modify an object prior to inserting it with a [Query].
   ///
@@ -137,9 +155,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   ///
   /// This method is only invoked when a query is configured by its [Query.values]. This method is not invoked
   /// if [Query.valueMap] is used to configure a query.
-  void willInsert() {
-
-  }
+  void willInsert() {}
 
   /// Validates an object according to its property [Validate] metadata.
   ///
@@ -173,21 +189,30 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   @override
   dynamic noSuchMethod(Invocation invocation) {
     if (invocation.isGetter) {
-      var propertyName = MirrorSystem.getName(invocation.memberName);
-
-      return this[propertyName];
+      return this[_getPropertyNameFromInvocation(invocation)];
     } else if (invocation.isSetter) {
-      var propertyName = MirrorSystem.getName(invocation.memberName);
-      if (propertyName.endsWith("=")) {
-        propertyName = propertyName.substring(0, propertyName.length - 1);
-      }
-
-      this[propertyName] = invocation.positionalArguments.first;
+      this[_getPropertyNameFromInvocation(invocation)] = invocation.positionalArguments.first;
 
       return null;
     }
 
     return super.noSuchMethod(invocation);
+  }
+
+  String _getPropertyNameFromInvocation(Invocation invocation) {
+    // It memberName is not in symbolMap, it may be because that property doesn't exist for this object's entity.
+    // But it also may occur for private ivars, in which case, we reconstruct the symbol and try that.
+
+    var name = entity.symbolMap[invocation.memberName] ??
+        entity.symbolMap[new Symbol(MirrorSystem.getName(invocation.memberName))];
+
+    if (name == null) {
+      throw new ArgumentError("Invalid property access for '${MirrorSystem.getName(entity.instanceType.simpleName)}'. "
+          "Property '${MirrorSystem.getName(invocation.memberName)}' does not exist on '${MirrorSystem.getName(
+          entity.instanceType.simpleName)}'.");
+    }
+
+    return name;
   }
 
   @Deprecated("3.0, use readFromMap instead")
@@ -221,7 +246,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
 
       if (property is ManagedAttributeDescription) {
         if (!property.isTransient) {
-          backing.setValueForProperty(entity, k, property.convertFromPrimitiveValue(v));
+          _backing.setValueForProperty(property, property.convertFromPrimitiveValue(v));
         } else {
           if (!property.transientStatus.isAvailableAsInput) {
             throw new ValidationException(["invalid input key '$k'"]);
@@ -235,7 +260,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
           mirror.setField(new Symbol(k), decodedValue);
         }
       } else {
-        backing.setValueForProperty(entity, k, property.convertFromPrimitiveValue(v));
+        _backing.setValueForProperty(property, property.convertFromPrimitiveValue(v));
       }
     });
   }
@@ -253,16 +278,14 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   Map<String, dynamic> asMap() {
     var outputMap = <String, dynamic>{};
 
-    backing.valueMap.forEach((k, v) {
+    _backing.valueMap.forEach((k, v) {
       if (!_isPropertyPrivate(k)) {
         outputMap[k] = entity.properties[k].convertToPrimitiveValue(v);
       }
     });
 
     var reflectedThis = reflect(this);
-    entity.attributes.values
-        .where((attr) => attr.transientStatus?.isAvailableAsOutput ?? false)
-        .forEach((attr) {
+    entity.attributes.values.where((attr) => attr.transientStatus?.isAvailableAsOutput ?? false).forEach((attr) {
       var value = reflectedThis.getField(new Symbol(attr.name)).reflectee;
       if (value != null) {
         outputMap[attr.name] = value;
@@ -272,6 +295,5 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
     return outputMap;
   }
 
-  static bool _isPropertyPrivate(String propertyName) =>
-      propertyName.startsWith("_");
+  static bool _isPropertyPrivate(String propertyName) => propertyName.startsWith("_");
 }

--- a/lib/src/db/managed/set.dart
+++ b/lib/src/db/managed/set.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 
-import 'backing.dart';
 import 'managed.dart';
 import '../query/query.dart';
 
@@ -50,8 +49,7 @@ class ManagedSet<InstanceType extends ManagedObject> extends Object
   /// constrain the values returned from the [Query].
   InstanceType get haveAtLeastOneWhere {
     if (_whereBuider == null) {
-      _whereBuider = entity.newInstance() as InstanceType;
-      _whereBuider.backing = new ManagedMatcherBacking();
+      _whereBuider = entity.newInstance(forMatching: true) as InstanceType;
     }
     return _whereBuider;
   }

--- a/lib/src/db/managed/set.dart
+++ b/lib/src/db/managed/set.dart
@@ -1,5 +1,7 @@
 import 'dart:collection';
 
+import 'package:aqueduct/src/db/managed/backing.dart';
+
 import 'managed.dart';
 import '../query/query.dart';
 
@@ -49,7 +51,7 @@ class ManagedSet<InstanceType extends ManagedObject> extends Object
   /// constrain the values returned from the [Query].
   InstanceType get haveAtLeastOneWhere {
     if (_whereBuider == null) {
-      _whereBuider = entity.newInstance(forMatching: true) as InstanceType;
+      _whereBuider = entity.newInstance(backing: new ManagedMatcherBacking()) as InstanceType;
     }
     return _whereBuider;
   }

--- a/lib/src/db/postgresql/mappers/column.dart
+++ b/lib/src/db/postgresql/mappers/column.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:aqueduct/src/db/managed/key_path.dart';
 import 'package:aqueduct/src/db/managed/managed.dart';
 import 'package:aqueduct/src/db/managed/relationship_type.dart';

--- a/lib/src/db/postgresql/postgresql_query_reduce.dart
+++ b/lib/src/db/postgresql/postgresql_query_reduce.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:aqueduct/src/db/managed/backing.dart';
+
 import '../query/query.dart';
 import '../managed/object.dart';
 import 'postgresql_query.dart';
@@ -37,7 +39,7 @@ class PostgresQueryReduce<T extends ManagedObject> extends QueryReduceOperation<
   }
 
   String _columnName(dynamic selector(T object)) {
-    var obj = query.entity.newInstance(forPropertyIdentification: true);
+    var obj = query.entity.newInstance(backing: new ManagedAccessTrackingBacking());
     return selector(obj as T) as String;
   }
 

--- a/lib/src/db/postgresql/postgresql_query_reduce.dart
+++ b/lib/src/db/postgresql/postgresql_query_reduce.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import '../query/query.dart';
 import '../managed/object.dart';
-import '../managed/backing.dart';
 import 'postgresql_query.dart';
 import 'postgresql_persistent_store.dart';
 import 'query_builder.dart';
@@ -38,8 +37,7 @@ class PostgresQueryReduce<T extends ManagedObject> extends QueryReduceOperation<
   }
 
   String _columnName(dynamic selector(T object)) {
-    var tracker = new ManagedAccessTrackingBacking();
-    var obj = query.entity.newInstance()..backing = tracker;
+    var obj = query.entity.newInstance(forPropertyIdentification: true);
     return selector(obj as T) as String;
   }
 

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -53,14 +53,14 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
   @override
   InstanceType get where {
     if (_whereBuilder == null) {
-      _whereBuilder = entity.newInstance(forMatching: true) as InstanceType;
+      _whereBuilder = entity.newInstance(backing: new ManagedMatcherBacking()) as InstanceType;
     }
     return _whereBuilder;
   }
 
   @override
   Query<T> join<T extends ManagedObject>({T object(InstanceType x), ManagedSet<T> set(InstanceType x)}) {
-    var obj = entity.newInstance(forPropertyIdentification: true);
+    var obj = entity.newInstance(backing: new ManagedAccessTrackingBacking());
     var matchingKey;
     if (object != null) {
       matchingKey = object(obj as InstanceType) as String;
@@ -89,7 +89,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
 
   @override
   void pageBy<T>(T propertyIdentifier(InstanceType x), QuerySortOrder order, {T boundingValue}) {
-    var obj = entity.newInstance(forPropertyIdentification: true);
+    var obj = entity.newInstance(backing: new ManagedAccessTrackingBacking());
     var propertyName = propertyIdentifier(obj as InstanceType) as String;
 
     var attribute = entity.attributes[propertyName];
@@ -109,7 +109,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
 
   @override
   void sortBy<T>(T propertyIdentifier(InstanceType x), QuerySortOrder order) {
-    var obj = entity.newInstance(forPropertyIdentification: true);
+    var obj = entity.newInstance(backing: new ManagedAccessTrackingBacking());
     var propertyName = propertyIdentifier(obj as InstanceType) as String;
 
     var attribute = entity.attributes[propertyName];
@@ -130,7 +130,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
 
   @override
   void returningProperties(List<dynamic> propertyIdentifiers(InstanceType x)) {
-    var obj = entity.newInstance(forPropertyIdentification: true);
+    var obj = entity.newInstance(backing: new ManagedAccessTrackingBacking());
     var propertyNames = propertyIdentifiers(obj as InstanceType) as List<String>;
 
     _propertiesToFetch = propertyNames;

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -53,16 +53,14 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
   @override
   InstanceType get where {
     if (_whereBuilder == null) {
-      _whereBuilder = entity.newInstance() as InstanceType;
-      _whereBuilder.backing = new ManagedMatcherBacking();
+      _whereBuilder = entity.newInstance(forMatching: true) as InstanceType;
     }
     return _whereBuilder;
   }
 
   @override
   Query<T> join<T extends ManagedObject>({T object(InstanceType x), ManagedSet<T> set(InstanceType x)}) {
-    var tracker = new ManagedAccessTrackingBacking();
-    var obj = entity.newInstance()..backing = tracker;
+    var obj = entity.newInstance(forPropertyIdentification: true);
     var matchingKey;
     if (object != null) {
       matchingKey = object(obj as InstanceType) as String;
@@ -91,8 +89,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
 
   @override
   void pageBy<T>(T propertyIdentifier(InstanceType x), QuerySortOrder order, {T boundingValue}) {
-    var tracker = new ManagedAccessTrackingBacking();
-    var obj = entity.newInstance()..backing = tracker;
+    var obj = entity.newInstance(forPropertyIdentification: true);
     var propertyName = propertyIdentifier(obj as InstanceType) as String;
 
     var attribute = entity.attributes[propertyName];
@@ -112,8 +109,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
 
   @override
   void sortBy<T>(T propertyIdentifier(InstanceType x), QuerySortOrder order) {
-    var tracker = new ManagedAccessTrackingBacking();
-    var obj = entity.newInstance()..backing = tracker;
+    var obj = entity.newInstance(forPropertyIdentification: true);
     var propertyName = propertyIdentifier(obj as InstanceType) as String;
 
     var attribute = entity.attributes[propertyName];
@@ -134,8 +130,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
 
   @override
   void returningProperties(List<dynamic> propertyIdentifiers(InstanceType x)) {
-    var tracker = new ManagedAccessTrackingBacking();
-    var obj = entity.newInstance()..backing = tracker;
+    var obj = entity.newInstance(forPropertyIdentification: true);
     var propertyNames = propertyIdentifiers(obj as InstanceType) as List<String>;
 
     _propertiesToFetch = propertyNames;

--- a/test/db/model_test.dart
+++ b/test/db/model_test.dart
@@ -15,9 +15,15 @@ void main() {
       EnumObject,
       TransientBelongsTo,
       TransientOwner,
-      DocumentTest
+      DocumentTest,
+      ConstructorOverride
     ]);
     var _ = new ManagedContext(dm, ps);
+  });
+
+  test("Can set properties in constructor", () {
+    final obj = new ConstructorOverride();
+    expect(obj.value, "foo");
   });
 
   test("NoSuchMethod still throws", () {
@@ -74,7 +80,7 @@ void main() {
       reflect(user).setField(#foo, "hey");
       expect(true, false);
     } on ArgumentError catch (e) {
-      expect(e.toString(), contains("Property 'foo' does not exist on 'User'"));
+      expect(e.toString(), contains("Property 'foo=' does not exist on 'User'"));
     }
   });
 
@@ -476,7 +482,7 @@ void main() {
       }
 
       try {
-        e.backing.setValueForProperty(e.entity, "enumValues", "foobar");
+        e["enumValues"] = "foobar";
         expect(true, false);
       } on ValidationException catch (e) {
         expectError(e, contains("invalid input value for 'enumValues'"));
@@ -812,4 +818,16 @@ class _DocumentTest {
   int id;
 
   Document document;
+}
+
+class ConstructorOverride extends ManagedObject<_ConstructorOverride> implements _ConstructorOverride {
+  ConstructorOverride() {
+    value = "foo";
+  }
+}
+class _ConstructorOverride {
+  @primaryKey
+  int id;
+
+  String value;
 }

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -122,9 +122,9 @@ void main() {
       expect(true, false);
     } on ArgumentError catch (e) {
       expect(e.toString(), allOf([
-        contains("does not exist on table"),
+        contains("does not exist on"),
         contains("'nonexisting'"),
-        contains("'simple'"),
+        contains("'TestModel'"),
       ]));
     }
   });
@@ -202,14 +202,14 @@ void main() {
     var req = new Query<TestModel>()..values = m;
     await req.insert();
 
-    req = new Query<TestModel>()
-      ..returningProperties((t) => [t.id, t["badkey"]]);
 
     try {
-      await req.fetch();
-      expect(true, false);
+      req = new Query<TestModel>()
+        ..returningProperties((t) => [t.id, t["badkey"]]);
+
+      fail("unreachable");
     } on ArgumentError catch (e) {
-      expect(e.toString(), contains("Column 'badkey' does not exist for table 'simple'"));
+      expect(e.toString(), contains("Property 'badkey' does not exist on 'TestModel'"));
     }
   });
 
@@ -329,23 +329,23 @@ void main() {
     expect(result.owner.id, 1);
     expect(result.owner.backingMap.length, 1);
 
-    q = new Query<GenPost>()..returningProperties((p) => [p.id, p["owner_id"]]);
+
     try {
-      await q.fetchOne();
+      q = new Query<GenPost>()..returningProperties((p) => [p.id, p["owner_id"]]);
       expect(true, false);
     } on ArgumentError catch (e) {
       expect(e.toString(),
-          contains("Column 'owner_id' does not exist for table '_GenPost'"));
+          contains("Property 'owner_id' does not exist on 'GenPost'"));
     }
   });
 
-  test("Can use public accessor to private property in where", () async {
+  test("Can use public accessor to private property", () async {
     context = await contextWithModels([PrivateField]);
 
     await (new Query<PrivateField>()).insert();
     var q = new Query<PrivateField>();
-    var result = await q.fetch();
-    expect(result.first.public, "x");
+    var result = await q.fetchOne();
+    expect(result.public, "x");
   });
 
   test("When fetching valid enum value from db, is available as enum value and in where", () async {

--- a/test/db/postgresql/paging_test.dart
+++ b/test/db/postgresql/paging_test.dart
@@ -314,7 +314,7 @@ void main() {
 
         expect(true, false);
       } on ArgumentError catch (e) {
-        expect(e.toString(), contains("Column 'foobar' does not exist on table '_PageableTestModel'"));
+        expect(e.toString(), contains("Property 'foobar' does not exist on 'PageableTestModel'"));
       }
     });
 


### PR DESCRIPTION
- Unifies property access for managed object so that property-checking occurs at a single level
- Optimizes accessor lookup by using a symbol->name table.
- Cleans up some internal interfaces for creating managed objects for different purposes