### PR TITLE
Expose ManagedRelationshipType

### DIFF
--- a/lib/aqueduct.dart
+++ b/lib/aqueduct.dart
@@ -47,4 +47,4 @@ export 'src/auth/auth.dart';
 export 'src/db/db.dart';
 export 'src/http/http.dart';
 export 'src/openapi/openapi.dart';
-
+export 'src/db/managed/relationship_type.dart';

--- a/lib/src/db/managed/relationship_type.dart
+++ b/lib/src/db/managed/relationship_type.dart
@@ -1,1 +1,2 @@
+/// The possible database relationships.
 enum ManagedRelationshipType { hasOne, hasMany, belongsTo }


### PR DESCRIPTION
ManagedRelationshipType is exposed via the relationshipType property on ManagedRelationshipDescription however the type itself is not exposed outside the package. This means that we cannot perform checks such as
`if (managedRelationshipDescription.relationshipType == ManagedRelationshipType.hasMany)`

This PR is to expose this type to enable such checks.