### PR TITLE
Allows for more convenient building of insertion/update values in Query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 build/
 packages
 .packages
+.dart_tool/*
 
 # Or the files created by dart2js.
 *.dart.js

--- a/lib/src/commands/db_generate.dart
+++ b/lib/src/commands/db_generate.dart
@@ -68,7 +68,7 @@ class CLIDatabaseGenerate extends CLICommand
         "source": source,
         "tablesEvaluated" : dataModel
             .entities
-            .map((e) => MirrorSystem.getName(e.instanceType.simpleName))
+            .map((e) => e.name)
             .toList(),
         "changeList": changeList
       };

--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -112,10 +112,14 @@ class ManagedBuilderBacking extends ManagedBacking {
         throw _invalidValueConstruction;
       }
 
-      final original = (value as ManagedObject);
-      final replacementBacking = new ManagedForeignKeyBuilderBacking.from(original.entity, original.backing);
-      final replacement = original.entity.newInstance(backing: replacementBacking);
-      contents[property.name] = replacement;
+      if (value == null) {
+        contents[property.name] = null;
+      } else {
+        final original = (value as ManagedObject);
+        final replacementBacking = new ManagedForeignKeyBuilderBacking.from(original.entity, original.backing);
+        final replacement = original.entity.newInstance(backing: replacementBacking);
+        contents[property.name] = replacement;
+      }
     } else {
       contents[property.name] = value;
     }

--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -8,11 +8,11 @@ import 'exception.dart';
 
 class ManagedValueBacking extends ManagedBacking {
   @override
-  Map<String, dynamic> valueMap = {};
+  Map<String, dynamic> contents = {};
 
   @override
   dynamic valueForProperty(ManagedPropertyDescription property) {
-    return valueMap[property.name];
+    return contents[property.name];
   }
 
   @override
@@ -23,17 +23,17 @@ class ManagedValueBacking extends ManagedBacking {
       }
     }
 
-    valueMap[property.name] = value;
+    contents[property.name] = value;
   }
 }
 
 class ManagedBuilderBacking extends ManagedBacking {
   @override
-  Map<String, dynamic> valueMap = {};
+  Map<String, dynamic> contents = {};
 
   @override
   dynamic valueForProperty(ManagedPropertyDescription property) {
-    return valueMap[property.name];
+    return contents[property.name];
   }
 
   @override
@@ -44,7 +44,7 @@ class ManagedBuilderBacking extends ManagedBacking {
       }
     }
 
-    valueMap[property.name] = value;
+    contents[property.name] = value;
   }
 }
 
@@ -53,7 +53,7 @@ class ManagedAccessTrackingBacking extends ManagedBacking {
   KeyPath workingKeyPath;
 
   @override
-  Map<String, dynamic> get valueMap => null;
+  Map<String, dynamic> get contents => null;
 
   @override
   dynamic valueForProperty(ManagedPropertyDescription property) {

--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -38,18 +38,20 @@ class ManagedForeignKeyBuilderBacking extends ManagedBacking {
     }
 
 
-    throw new ArgumentError("Invalid property access. Object '${property.entity.name}'");
+    throw new ArgumentError("Invalid property access. '${property.entity.name}' "
+        "is being used in 'Query.values' to build a foreign key column. "
+        "Only its primary key can be set.");
   }
 
   @override
   void setValueForProperty(ManagedPropertyDescription property, dynamic value) {
-    if (value != null) {
-      if (!property.isAssignableWith(value)) {
-        throw new ValidationException(["invalid input value for '${property.name}'"]);
-      }
+    if (property is ManagedAttributeDescription && property.isPrimaryKey) {
+      contents[property.name] = value;
     }
 
-    contents[property.name] = value;
+    throw new ArgumentError("Invalid property access. '${property.entity.name}' "
+        "is being used in 'Query.values' to build a foreign key column. "
+        "Only its primary key can be set.");
   }
 }
 
@@ -74,10 +76,12 @@ class ManagedBuilderBacking extends ManagedBacking {
 
   @override
   void setValueForProperty(ManagedPropertyDescription property, dynamic value) {
-    if (value != null) {
-      if (!property.isAssignableWith(value)) {
-        throw new ValidationException(["invalid input value for '${property.name}'"]);
+    if (property is ManagedRelationshipDescription) {
+      if (!property.isBelongsTo) {
+        throw new StateError("Invalid property access. Cannot access has-one or has-many relationship when building 'Query.values'.");
       }
+
+
     }
 
     contents[property.name] = value;

--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -27,6 +27,27 @@ class ManagedValueBacking extends ManagedBacking {
   }
 }
 
+class ManagedBuilderBacking extends ManagedBacking {
+  @override
+  Map<String, dynamic> valueMap = {};
+
+  @override
+  dynamic valueForProperty(ManagedPropertyDescription property) {
+    return valueMap[property.name];
+  }
+
+  @override
+  void setValueForProperty(ManagedPropertyDescription property, dynamic value) {
+    if (value != null) {
+      if (!property.isAssignableWith(value)) {
+        throw new ValidationException(["invalid input value for '${property.name}'"]);
+      }
+    }
+
+    valueMap[property.name] = value;
+  }
+}
+
 class ManagedAccessTrackingBacking extends ManagedBacking {
   List<KeyPath> keyPaths;
   KeyPath workingKeyPath;

--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -27,56 +27,6 @@ class ManagedValueBacking extends ManagedBacking {
   }
 }
 
-class ManagedMatcherBacking extends ManagedBacking {
-  @override
-  Map<String, dynamic> valueMap = {};
-
-  @override
-  dynamic valueForProperty(ManagedPropertyDescription property) {
-    if (!valueMap.containsKey(property.name)) {
-      // For any relationships, automatically insert them into valueMap
-      // so that their properties can be accessed when building queries.
-      if (property is ManagedRelationshipDescription) {
-        if (property.relationshipType == ManagedRelationshipType.hasMany) {
-          valueMap[property.name] = new ManagedSet()
-            ..entity = property.destinationEntity;
-        } else if (property.relationshipType == ManagedRelationshipType.hasOne ||
-            property.relationshipType == ManagedRelationshipType.belongsTo) {
-          valueMap[property.name] = property.destinationEntity.newInstance(backing: new ManagedMatcherBacking());
-        }
-      }
-    }
-
-    return valueMap[property.name];
-  }
-
-  @override
-  void setValueForProperty(ManagedPropertyDescription property, dynamic value) {
-    if (value == null) {
-      valueMap.remove(property.name);
-      return;
-    }
-
-    if (value is PredicateExpression) {
-      if (property is ManagedRelationshipDescription) {
-        var innerObject = valueForProperty(property);
-        if (innerObject is ManagedObject) {
-          innerObject[innerObject.entity.primaryKey] = value;
-        } else if (innerObject is ManagedSet) {
-          innerObject.haveAtLeastOneWhere[innerObject.entity.primaryKey] =
-              value;
-        }
-      } else {
-        valueMap[property.name] = value;
-      }
-    } else {
-      final typeName = MirrorSystem.getName(property.entity.instanceType.simpleName);
-
-      throw new ArgumentError("Invalid query matcher assignment. Tried assigning value to 'Query<$typeName>.where.${property.name}'. Wrap value in 'whereEqualTo()'.");
-    }
-  }
-}
-
 class ManagedAccessTrackingBacking extends ManagedBacking {
   List<KeyPath> keyPaths;
   KeyPath workingKeyPath;

--- a/lib/src/db/managed/backing.dart
+++ b/lib/src/db/managed/backing.dart
@@ -112,11 +112,13 @@ class ManagedBuilderBacking extends ManagedBacking {
         throw _invalidValueConstruction;
       }
 
-      final obj = value as ManagedObject;
-      obj.backing = new ManagedForeignKeyBuilderBacking.from(property.entity, obj.backing);
+      final original = (value as ManagedObject);
+      final replacementBacking = new ManagedForeignKeyBuilderBacking.from(original.entity, original.backing);
+      final replacement = original.entity.newInstance(backing: replacementBacking);
+      contents[property.name] = replacement;
+    } else {
+      contents[property.name] = value;
     }
-
-    contents[property.name] = value;
   }
 }
 

--- a/lib/src/db/managed/entity.dart
+++ b/lib/src/db/managed/entity.dart
@@ -29,6 +29,11 @@ class ManagedEntity implements APIComponentDocumenter {
   /// You should never call this method directly, it will be called by [ManagedDataModel].
   ManagedEntity(this.dataModel, this._tableName, this.instanceType, this.persistentType);
 
+  /// The name of this entity.
+  ///
+  /// This name will match the name of [instanceType].
+  String get name => MirrorSystem.getName(instanceType.simpleName);
+
   /// The type of instances represented by this entity.
   ///
   /// Managed objects are made up of two components, a persistent type and an instance type. Applications
@@ -188,7 +193,7 @@ class ManagedEntity implements APIComponentDocumenter {
   void documentComponents(APIDocumentContext context) {
     final schemaProperties = <String, APISchemaObject>{};
     final obj = new APISchemaObject.object(schemaProperties)
-      ..title = "${MirrorSystem.getName(instanceType.simpleName)}";
+      ..title = "${name}";
 
     // Documentation comments
     context.defer(() async {
@@ -228,6 +233,6 @@ class ManagedEntity implements APIComponentDocumenter {
     });
 
     context.schema
-        .register(MirrorSystem.getName(instanceType.simpleName), obj, representation: instanceType.reflectedType);
+        .register(name, obj, representation: instanceType.reflectedType);
   }
 }

--- a/lib/src/db/managed/object.dart
+++ b/lib/src/db/managed/object.dart
@@ -32,11 +32,11 @@ abstract class ManagedBacking {
   ///
   /// Use this method to use any reference of a property from this instance.
   void removeProperty(String propertyName) {
-    valueMap.remove(propertyName);
+    contents.remove(propertyName);
   }
 
   /// A map of all set values of this instance.
-  Map<String, dynamic> get valueMap;
+  Map<String, dynamic> get contents;
 }
 
 /// An object that represents a database row.
@@ -68,7 +68,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   static ManagedObject instantiateDynamic(ManagedEntity entity, {ManagedBacking backing}) {
     ManagedObject object = entity.instanceType.newInstance(const Symbol(""), []).reflectee as ManagedObject;
     if (backing != null) {
-      object._backing = backing;
+      object.backing = backing;
     }
     object.entity = entity;
     return object;
@@ -77,16 +77,17 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   /// The [ManagedEntity] this instance is described by.
   ManagedEntity entity = ManagedContext.defaultContext.dataModel.entityForType(PersistentType);
 
-  /// The managed values of this instance.
+  /// The persistent values of this object.
   ///
-  /// Not all values are fetched or populated in a [ManagedObject] instance. This value contains
-  /// key-value pairs for the managed object that have been set, either manually
-  /// or when fetched from a database. When [ManagedObject] is instantiated, this map is empty.
-  Map<String, dynamic> get backingMap => _backing.valueMap;
+  /// Values stored by this object are stored in [backing]. A backing is a [Map], where each key
+  /// is a property name of this object. A backing adds some access logic to storing and retrieving
+  /// its key-value pairs.
+  ///
+  /// You rarely need to use [backing] directly. There are many implementations of [ManagedBacking]
+  /// for fulfilling the behavior of the ORM, so you cannot rely on its behavior.
+  ManagedBacking backing = new ManagedValueBacking();
 
-  ManagedBacking _backing = new ManagedValueBacking();
-
-  /// Retrieves a value by property name from the [backingMap].
+  /// Retrieves a value by property name from [backing].
   dynamic operator [](String propertyName) {
     final prop = entity.properties[propertyName];
     if (prop == null) {
@@ -94,10 +95,10 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
           "Property '$propertyName' does not exist on '${MirrorSystem.getName(entity.instanceType.simpleName)}'.");
     }
 
-    return _backing.valueForProperty(prop);
+    return backing.valueForProperty(prop);
   }
 
-  /// Sets a value by property name in the [backingMap].
+  /// Sets a value by property name in [backing].
   void operator []=(String propertyName, dynamic value) {
     final prop = entity.properties[propertyName];
     if (prop == null) {
@@ -105,19 +106,19 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
           "Property '$propertyName' does not exist on '${MirrorSystem.getName(entity.instanceType.simpleName)}'.");
     }
 
-    _backing.setValueForProperty(prop, value);
+    backing.setValueForProperty(prop, value);
   }
 
-  /// Removes a property from the [backingMap].
+  /// Removes a property from [backing].
   ///
   /// This will remove a value from the backing map.
   void removePropertyFromBackingMap(String propertyName) {
-    _backing.removeProperty(propertyName);
+    backing.removeProperty(propertyName);
   }
 
-  /// Checks whether or not a property has been set in this instances' [backingMap].
+  /// Checks whether or not a property has been set in this instances' [backing].
   bool hasValueForProperty(String propertyName) {
-    return backingMap.containsKey(propertyName);
+    return backing.contents.containsKey(propertyName);
   }
 
   /// Callback to modify an object prior to updating it with a [Query].
@@ -251,7 +252,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
 
       if (property is ManagedAttributeDescription) {
         if (!property.isTransient) {
-          _backing.setValueForProperty(property, property.convertFromPrimitiveValue(v));
+          backing.setValueForProperty(property, property.convertFromPrimitiveValue(v));
         } else {
           if (!property.transientStatus.isAvailableAsInput) {
             throw new ValidationException(["invalid input key '$k'"]);
@@ -265,7 +266,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
           mirror.setField(new Symbol(k), decodedValue);
         }
       } else {
-        _backing.setValueForProperty(property, property.convertFromPrimitiveValue(v));
+        backing.setValueForProperty(property, property.convertFromPrimitiveValue(v));
       }
     });
   }
@@ -274,7 +275,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   ///
   /// This method returns a map of the key-values pairs in this instance. This value is typically converted into a transmission format like JSON.
   ///
-  /// Only properties present in [backingMap] are serialized, otherwise, they are omitted from the map. If a property is present in [backingMap] and the value is null,
+  /// Only properties present in [backing] are serialized, otherwise, they are omitted from the map. If a property is present in [backing] and the value is null,
   /// the value null will be serialized for that property key.
   ///
   /// Usage:
@@ -283,7 +284,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   Map<String, dynamic> asMap() {
     var outputMap = <String, dynamic>{};
 
-    _backing.valueMap.forEach((k, v) {
+    backing.contents.forEach((k, v) {
       if (!_isPropertyPrivate(k)) {
         outputMap[k] = entity.properties[k].convertToPrimitiveValue(v);
       }

--- a/lib/src/db/managed/object.dart
+++ b/lib/src/db/managed/object.dart
@@ -91,8 +91,8 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   dynamic operator [](String propertyName) {
     final prop = entity.properties[propertyName];
     if (prop == null) {
-      throw new ArgumentError("Invalid property access for '${MirrorSystem.getName(entity.instanceType.simpleName)}'. "
-          "Property '$propertyName' does not exist on '${MirrorSystem.getName(entity.instanceType.simpleName)}'.");
+      throw new ArgumentError("Invalid property access for '${entity.name}'. "
+          "Property '$propertyName' does not exist on '${entity.name}'.");
     }
 
     return backing.valueForProperty(prop);
@@ -102,8 +102,8 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   void operator []=(String propertyName, dynamic value) {
     final prop = entity.properties[propertyName];
     if (prop == null) {
-      throw new ArgumentError("Invalid property access for '${MirrorSystem.getName(entity.instanceType.simpleName)}'. "
-          "Property '$propertyName' does not exist on '${MirrorSystem.getName(entity.instanceType.simpleName)}'.");
+      throw new ArgumentError("Invalid property access for '${entity.name}'. "
+          "Property '$propertyName' does not exist on '${entity.name}'.");
     }
 
     backing.setValueForProperty(prop, value);
@@ -213,9 +213,8 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
         entity.symbolMap[new Symbol(MirrorSystem.getName(invocation.memberName))];
 
     if (name == null) {
-      throw new ArgumentError("Invalid property access for '${MirrorSystem.getName(entity.instanceType.simpleName)}'. "
-          "Property '${MirrorSystem.getName(invocation.memberName)}' does not exist on '${MirrorSystem.getName(
-          entity.instanceType.simpleName)}'.");
+      throw new ArgumentError("Invalid property access for '${entity.name}'. "
+          "Property '${MirrorSystem.getName(invocation.memberName)}' does not exist on '${entity.name}'.");
     }
 
     return name;

--- a/lib/src/db/managed/property_description.dart
+++ b/lib/src/db/managed/property_description.dart
@@ -250,7 +250,7 @@ class ManagedAttributeDescription extends ManagedPropertyDescription {
 
   @override
   String toString() {
-    return "${MirrorSystem.getName(entity.instanceType.simpleName)}.$name";
+    return "${entity.name}.$name";
   }
 
   @override
@@ -411,8 +411,8 @@ class ManagedRelationshipDescription extends ManagedPropertyDescription {
       case ManagedRelationshipType.hasMany: relTypeString = "has-many"; break;
       case ManagedRelationshipType.hasOne: relTypeString = "has-a"; break;
     }
-    return "${MirrorSystem.getName(entity.instanceType.simpleName)}.$name - "
-        "$relTypeString '${MirrorSystem.getName(destinationEntity.instanceType.simpleName)}' "
+    return "${entity.name}.$name - "
+        "$relTypeString '${destinationEntity.name}' "
         "(inverse: ${MirrorSystem.getName(inverseKey)})";
   }
 }

--- a/lib/src/db/managed/property_description.dart
+++ b/lib/src/db/managed/property_description.dart
@@ -344,8 +344,8 @@ class ManagedRelationshipDescription extends ManagedPropertyDescription {
     } else if (value is ManagedObject) {
       // If we're only fetching the foreign key, don't do a full asMap
       if (relationshipType == ManagedRelationshipType.belongsTo &&
-          value.backingMap.length == 1 &&
-          value.backingMap.containsKey(destinationEntity.primaryKey)) {
+          value.backing.contents.length == 1 &&
+          value.backing.contents.containsKey(destinationEntity.primaryKey)) {
         return {destinationEntity.primaryKey: value[destinationEntity.primaryKey]};
       }
 

--- a/lib/src/db/managed/validate.dart
+++ b/lib/src/db/managed/validate.dart
@@ -44,21 +44,21 @@ class ManagedValidator {
       }
 
       if (validator.definition._builtinValidate == _BuiltinValidate.absent) {
-        if (object.backingMap.containsKey(validator.attribute.name)) {
+        if (object.backing.contents.containsKey(validator.attribute.name)) {
           valid = false;
 
           errors.add("Value for '${validator.attribute.name}' may not be included "
               "for ${_errorStringForOperation(operation)}s.");
         }
       } else if (validator.definition._builtinValidate == _BuiltinValidate.present) {
-        if (!object.backingMap.containsKey(validator.attribute.name)) {
+        if (!object.backing.contents.containsKey(validator.attribute.name)) {
           valid = false;
 
           errors.add("Value for '${validator.attribute.name}' must be included "
               "for ${_errorStringForOperation(operation)}s.");
         }
       } else {
-        var value = object.backingMap[validator.attribute.name];
+        var value = object.backing.contents[validator.attribute.name];
         if (value != null) {
           if (!validator._isValidFor(operation, validator.attribute, value, errors)) {
             valid = false;

--- a/lib/src/db/postgresql/postgresql_query.dart
+++ b/lib/src/db/postgresql/postgresql_query.dart
@@ -37,7 +37,7 @@ class PostgresQuery<InstanceType extends ManagedObject> extends Object
     validateInput(ValidateOperation.insert);
 
     var builder = new PostgresQueryBuilder(entity,
-        returningProperties: propertiesToFetch, values: valueMap ?? values?.backingMap);
+        returningProperties: propertiesToFetch, values: valueMap ?? values?.backing?.contents);
 
     var buffer = new StringBuffer();
     buffer.write("INSERT INTO ${builder.primaryTableDefinition} ");
@@ -65,7 +65,7 @@ class PostgresQuery<InstanceType extends ManagedObject> extends Object
 
     var builder = new PostgresQueryBuilder(entity,
         returningProperties: propertiesToFetch,
-        values: valueMap ?? values?.backingMap,
+        values: valueMap ?? values?.backing?.contents,
         expressions: expressions,
         predicate: predicate);
 

--- a/lib/src/db/postgresql/query_builder.dart
+++ b/lib/src/db/postgresql/query_builder.dart
@@ -166,7 +166,7 @@ class PostgresQueryBuilder extends Object with PredicateBuilder, RowInstantiator
 
         throw new ArgumentError("Invalid query. Column '$key' in '${entity.tableName}' does not exist. "
             "'$key' recognized as ORM relationship. Provided value must be 'Map' "
-            "or ${MirrorSystem.getName(property.destinationEntity.instanceType.simpleName)}.");
+            "or ${property.destinationEntity.name}.");
       }
     }
 

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -43,7 +43,8 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
   @override
   InstanceType get values {
     if (_valueObject == null) {
-      _valueObject = entity.newInstance(backing: new ManagedBuilderBacking()) as InstanceType;
+      _valueObject = entity.newInstance() as InstanceType;
+      _valueObject.backing = new ManagedBuilderBacking.from(_valueObject.entity, _valueObject.backing);
     }
     return _valueObject;
   }

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -165,7 +165,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
       if (entity.relationships.containsKey(propertyName)) {
         throw new ArgumentError(
             "Invalid property selection. Property '$propertyName' on "
-                "'${MirrorSystem.getName(entity.instanceType.simpleName)}' "
+                "'${entity.name}' "
                 "is a relationship and cannot be selected for this operation.");
       } else {
         throw new ArgumentError(

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -43,13 +43,14 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
   @override
   InstanceType get values {
     if (_valueObject == null) {
-      _valueObject = entity.newInstance() as InstanceType;
+      _valueObject = entity.newInstance(backing: new ManagedBuilderBacking()) as InstanceType;
     }
     return _valueObject;
   }
 
   @override
   set values(InstanceType obj) {
+
     _valueObject = obj;
   }
 

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -50,8 +50,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
 
   @override
   set values(InstanceType obj) {
-    obj.backing = new ManagedBuilderBacking.from(entity, obj.backing);
-    _valueObject = obj;
+    _valueObject = entity.newInstance(backing: new ManagedBuilderBacking.from(entity, obj.backing));
   }
 
   @override

--- a/lib/src/db/query/mixin.dart
+++ b/lib/src/db/query/mixin.dart
@@ -50,7 +50,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject> implements Query<I
 
   @override
   set values(InstanceType obj) {
-
+    obj.backing = new ManagedBuilderBacking.from(entity, obj.backing);
     _valueObject = obj;
   }
 

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -239,6 +239,9 @@ abstract class Query<InstanceType extends ManagedObject> {
   ///           ..values.name = "Sally"
   ///           ..values.manager.id = 10;
   ///         await q.insert();
+  ///
+  /// You may replace this property with a new instance of [InstanceType]. When doing so, the provided instance's [ManagedObject.backing]
+  /// is altered and any properties that are not allowed to be set on [values] are stripped away.
   InstanceType values;
 
   /// Configures the list of properties to be fetched for [InstanceType].

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -219,7 +219,7 @@ abstract class Query<InstanceType extends ManagedObject> {
   /// values for its properties immediately:
   ///
   ///         var q = Query<User>()
-  ///           ..values.name = 'Joe
+  ///           ..values.name = 'Joe'
   ///           ..values.job = 'programmer';
   ///         await q.insert();
   ///
@@ -240,8 +240,17 @@ abstract class Query<InstanceType extends ManagedObject> {
   ///           ..values.manager.id = 10;
   ///         await q.insert();
   ///
-  /// You may replace this property with a new instance of [InstanceType]. When doing so, the provided instance's [ManagedObject.backing]
-  /// is altered and any properties that are not allowed to be set on [values] are stripped away.
+  /// WARNING: You may replace this property with a new instance of [InstanceType]. When doing so, a copy
+  /// of the object is created and assigned to this property.
+  ///
+  ///         final o = SomeObject()
+  ///           ..id = 1;
+  ///         final q = Query<SomeObject>()
+  ///           ..values = o;
+  ///
+  ///         o.id = 2;
+  ///         assert(q.values.id == 1); // true
+  ///
   InstanceType values;
 
   /// Configures the list of properties to be fetched for [InstanceType].

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -202,20 +202,43 @@ abstract class Query<InstanceType extends ManagedObject> {
 
   /// Values to be used when inserting or updating an object.
   ///
-  /// Keys must be the name of the property on the model object. Prefer to use [values] instead.
+  /// This method is an unsafe version of [values]. Prefer to use [values] instead.
+  /// Keys in this map must be the name of a property of [InstanceType], otherwise an exception
+  /// is thrown. Values provided in this map are not run through any [Validate] annotations
+  /// declared by the [InstanceType].
+  ///
+  /// Do not set this property and [values] on the same query. If both this property and [values] are set,
+  /// the behavior is undefined.
   Map<String, dynamic> valueMap;
 
-  /// Values to be used when inserting or updating an object.
+  /// Values to be sent to database during an [update] or [insert] query.
   ///
-  /// Will generate the [valueMap] for this [Query] using values from this object. This object is created
-  /// once accessed, so it is not necessary to create an instance and set this property, but instead,
-  /// set properties of this property.
+  /// You set values for the properties of this object to insert a row or update one or more rows.
+  /// This property is the same type as the type being inserted or updated. [values] is empty (but not null)
+  /// when a [Query] is first created, therefore, you do not have to assign an instance to it and may set
+  /// values for its properties immediately:
   ///
-  /// For example, the following code would generate the values map {'name' = 'Joe', 'job' = 'programmer'}:
-  ///     var q = new Query<User>()
-  ///       ..values.name = 'Joe
-  ///       ..values.job = 'programmer';
+  ///         var q = Query<User>()
+  ///           ..values.name = 'Joe
+  ///           ..values.job = 'programmer';
+  ///         await q.insert();
   ///
+  /// You may only set values for properties that are backed by a column. This includes most properties, except
+  /// all [ManagedSet] properties and [ManagedObject] properties that do not have a [Relate] annotation. If you attempt
+  /// to set a property that isn't allowed on [values], an error is thrown.
+  ///
+  /// If a property of [values] is a [ManagedObject] with a [Relate] annotation, you may provide a value for its primary key
+  /// property. This value will be stored in the foreign key column that backs the property. You may set properties
+  /// of this type immediately, without having to create an instance of the related type:
+  ///
+  ///         // Assumes that Employee is declared with the following property:
+  ///         // @Relate(#employees)
+  ///         // Manager manager;
+  ///
+  ///         final q = Query<Employee>()
+  ///           ..values.name = "Sally"
+  ///           ..values.manager.id = 10;
+  ///         await q.insert();
   InstanceType values;
 
   /// Configures the list of properties to be fetched for [InstanceType].

--- a/lib/src/http/managed_object_controller.dart
+++ b/lib/src/http/managed_object_controller.dart
@@ -384,7 +384,7 @@ class ManagedObjectController<InstanceType extends ManagedObject> extends Resour
   Map<String, APIOperation> documentOperations(APIDocumentContext context, String route, APIPath path) {
     final ops = super.documentOperations(context, route, path);
 
-    final entityName = MirrorSystem.getName(_query.entity.instanceType.simpleName);
+    final entityName = _query.entity.name;
 
     if ((path.parameters?.where((p) => p.location == APIParameterLocation.path)?.length ?? 0) > 0) {
       ops["get"].id = "get$entityName";

--- a/test/db/model_controller_test.dart
+++ b/test/db/model_controller_test.dart
@@ -78,7 +78,7 @@ class TestModelController extends QueryController<TestModel> {
       statusCode = 400;
     }
 
-    if (query.values.backingMap.length != 0) {
+    if (query.values.backing.contents.length != 0) {
       statusCode = 400;
     }
 
@@ -99,7 +99,7 @@ class TestModelController extends QueryController<TestModel> {
       statusCode = 400;
     }
 
-    if (query.values.backingMap.length != 0) {
+    if (query.values.backing.contents.length != 0) {
       statusCode = 400;
     }
 

--- a/test/db/postgresql/belongs_to_fetch_test.dart
+++ b/test/db/postgresql/belongs_to_fetch_test.dart
@@ -11,6 +11,7 @@ import '../../helpers.dart';
 void main() {
   List<RootObject> rootObjects;
   ManagedContext ctx;
+
   setUpAll(() async {
     ctx = await contextWithModels([RootObject, RootJoinObject, OtherRootObject, ChildObject, GrandChildObject]);
     rootObjects = await populateModelGraph(ctx);

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -290,14 +290,14 @@ void main() {
 
     var result = await iq.insert();
     expect(result.id, greaterThan(0));
-    expect(result.backingMap["text"], isNull);
+    expect(result.backing.contents["text"], isNull);
 
     var fq = new Query<Omit>()
       ..predicate = new QueryPredicate("id=@id", {"id": result.id});
 
     var fResult = await fq.fetchOne();
     expect(fResult.id, result.id);
-    expect(fResult.backingMap["text"], isNull);
+    expect(fResult.backing.contents["text"], isNull);
   });
 
   test(
@@ -340,7 +340,7 @@ void main() {
 
     var result = await q.fetchOne();
     expect(result.owner.id, 1);
-    expect(result.owner.backingMap.length, 1);
+    expect(result.owner.backing.contents.length, 1);
 
 
     try {

--- a/test/db/postgresql/has_many_fetch_test.dart
+++ b/test/db/postgresql/has_many_fetch_test.dart
@@ -71,8 +71,8 @@ void main() {
         expect(p.pid, isNotNull);
         expect(p.children.first.cid, isNotNull);
         expect(p.children.first.name, "C5");
-        expect(p.children.first.backingMap.containsKey("toy"), false);
-        expect(p.children.first.backingMap.containsKey("vaccinations"), false);
+        expect(p.children.first.backing.contents.containsKey("toy"), false);
+        expect(p.children.first.backing.contents.containsKey("vaccinations"), false);
       };
       verifier(await q.fetchOne());
       verifier((await q.fetch()).first);
@@ -93,7 +93,7 @@ void main() {
         expect(p.pid, isNotNull);
         expect(p.children.first.cid, isNotNull);
         expect(p.children.first.name, "C3");
-        expect(p.children.first.backingMap.containsKey("toy"), true);
+        expect(p.children.first.backing.contents.containsKey("toy"), true);
         expect(p.children.first.toy, isNull);
         expect(p.children.first.vaccinations.length, 1);
         expect(p.children.first.vaccinations.first.vid, isNotNull);
@@ -101,7 +101,7 @@ void main() {
 
         expect(p.children.last.cid, isNotNull);
         expect(p.children.last.name, "C4");
-        expect(p.children.last.backingMap.containsKey("toy"), true);
+        expect(p.children.last.backing.contents.containsKey("toy"), true);
         expect(p.children.last.toy, isNull);
         expect(p.children.last.vaccinations, []);
       };
@@ -159,21 +159,21 @@ void main() {
       expect(results.first.name, "A");
       expect(results.first.children.length, 2);
       expect(results.first.children.first.name, "C1");
-      expect(results.first.children.first.backingMap.containsKey("toy"), false);
+      expect(results.first.children.first.backing.contents.containsKey("toy"), false);
       expect(
-          results.first.children.first.backingMap.containsKey("vaccinations"),
+          results.first.children.first.backing.contents.containsKey("vaccinations"),
           false);
       expect(results.first.children.last.name, "C2");
-      expect(results.first.children.last.backingMap.containsKey("toy"), false);
-      expect(results.first.children.last.backingMap.containsKey("vaccinations"),
+      expect(results.first.children.last.backing.contents.containsKey("toy"), false);
+      expect(results.first.children.last.backing.contents.containsKey("vaccinations"),
           false);
 
       expect(results[1].pid, isNotNull);
       expect(results[1].name, "C");
       expect(results[1].children.length, 1);
       expect(results[1].children.first.name, "C5");
-      expect(results[1].children.first.backingMap.containsKey("toy"), false);
-      expect(results[1].children.first.backingMap.containsKey("vaccinations"),
+      expect(results[1].children.first.backing.contents.containsKey("toy"), false);
+      expect(results[1].children.first.backing.contents.containsKey("vaccinations"),
           false);
 
       expect(results.last.pid, isNotNull);

--- a/test/db/postgresql/has_one_fetch_test.dart
+++ b/test/db/postgresql/has_one_fetch_test.dart
@@ -35,8 +35,8 @@ void main() {
       var verifier = (Parent p) {
         expect(p.name, "D");
         expect(p.pid, isNotNull);
-        expect(p.backingMap["child"], isNull);
-        expect(p.backingMap.containsKey("child"), true);
+        expect(p.backing.contents["child"], isNull);
+        expect(p.backing.contents.containsKey("child"), true);
       };
       verifier(await q.fetchOne());
       verifier((await q.fetch()).first);
@@ -54,8 +54,8 @@ void main() {
       var verifier = (Parent p) {
         expect(p.name, "D");
         expect(p.pid, isNotNull);
-        expect(p.backingMap["child"], isNull);
-        expect(p.backingMap.containsKey("child"), true);
+        expect(p.backing.contents["child"], isNull);
+        expect(p.backing.contents.containsKey("child"), true);
       };
       verifier(await q.fetchOne());
       verifier((await q.fetch()).first);
@@ -82,8 +82,8 @@ void main() {
         expect(p.pid, isNotNull);
         expect(p.child.cid, isNotNull);
         expect(p.child.name, "C3");
-        expect(p.child.backingMap.containsKey("toy"), false);
-        expect(p.child.backingMap.containsKey("vaccinations"), false);
+        expect(p.child.backing.contents.containsKey("toy"), false);
+        expect(p.child.backing.contents.containsKey("vaccinations"), false);
       };
       verifier(await q.fetchOne());
       verifier((await q.fetch()).first);
@@ -103,7 +103,7 @@ void main() {
         expect(p.pid, isNotNull);
         expect(p.child.cid, isNotNull);
         expect(p.child.name, "C2");
-        expect(p.child.backingMap.containsKey("toy"), true);
+        expect(p.child.backing.contents.containsKey("toy"), true);
         expect(p.child.toy, isNull);
         expect(p.child.vaccinations.length, 1);
         expect(p.child.vaccinations.first.vid, isNotNull);
@@ -128,7 +128,7 @@ void main() {
         expect(p.pid, isNotNull);
         expect(p.child.cid, isNotNull);
         expect(p.child.name, "C3");
-        expect(p.child.backingMap.containsKey("toy"), true);
+        expect(p.child.backing.contents.containsKey("toy"), true);
         expect(p.child.toy, isNull);
         expect(p.child.vaccinations, []);
       };
@@ -151,7 +151,7 @@ void main() {
 
       expect(results.last.pid, isNotNull);
       expect(results.last.name, "D");
-      expect(results.last.backingMap.containsKey("child"), true);
+      expect(results.last.backing.contents.containsKey("child"), true);
       expect(results.last.child, isNull);
     });
 
@@ -240,7 +240,7 @@ void main() {
 
       for (var other in results.sublist(1)) {
         expect(other.child, isNull);
-        expect(other.backingMap.containsKey("child"), true);
+        expect(other.backing.contents.containsKey("child"), true);
       }
     });
 
@@ -303,12 +303,12 @@ void main() {
       for (var p in parents) {
         expect(p.name, isNotNull);
         expect(p.pid, isNotNull);
-        expect(p.backingMap.length, 3);
+        expect(p.backing.contents.length, 3);
 
         if (p.child != null) {
           expect(p.child.name, isNotNull);
           expect(p.child.cid, isNotNull);
-          expect(p.child.backingMap.length, 3);
+          expect(p.child.backing.contents.length, 3);
 
           for (var v in p.child.vaccinations) {
             expect(v.kind, isNotNull);
@@ -330,15 +330,15 @@ void main() {
       var parents = await q.fetch();
       for (var p in parents) {
         expect(p.pid, isNotNull);
-        expect(p.backingMap.length, 2);
+        expect(p.backing.contents.length, 2);
 
         if (p.child != null) {
           expect(p.child.cid, isNotNull);
-          expect(p.child.backingMap.length, 2);
+          expect(p.child.backing.contents.length, 2);
 
           for (var v in p.child.vaccinations) {
             expect(v.vid, isNotNull);
-            expect(v.backingMap.length, 1);
+            expect(v.backing.contents.length, 1);
           }
         }
       }

--- a/test/db/postgresql/tiered_where_test.dart
+++ b/test/db/postgresql/tiered_where_test.dart
@@ -563,7 +563,7 @@ void main() {
       final result = await q.fetch();
       expect(result.length, 3);
       expect(result.map((g) => g.gid).toList(), [5, 6, 8]);
-      expect(result.any((g) => g.backing.contents["parents"].backingMap.keys.length != 1), false);
+      expect(result.any((g) => g.backing.contents["parents"].backing.contents.keys.length != 1), false);
     });
   });
 }

--- a/test/db/postgresql/tiered_where_test.dart
+++ b/test/db/postgresql/tiered_where_test.dart
@@ -37,10 +37,10 @@ void main() {
       var results = await q.fetch();
 
       for (var r in results) {
-        expect(r.backingMap.containsKey("child"), false);
-        expect(r.backingMap.length, r.entity.defaultProperties.length);
+        expect(r.backing.contents.containsKey("child"), false);
+        expect(r.backing.contents.length, r.entity.defaultProperties.length);
         for (var property in r.entity.defaultProperties) {
-          expect(r.backingMap.containsKey(property), true);
+          expect(r.backing.contents.containsKey(property), true);
         }
       }
     });
@@ -51,20 +51,20 @@ void main() {
 
       for (var r in results) {
         expect(
-            r.backingMap.length,
+            r.backing.contents.length,
             r.entity.defaultProperties.length +
                 1); // +1 is for key containing 'child'
         for (var property in r.entity.defaultProperties) {
-          expect(r.backingMap.containsKey(property), true);
+          expect(r.backing.contents.containsKey(property), true);
         }
 
         // Child may be null, but even if it is the key must be in the map
-        expect(r.backingMap.containsKey("child"), true);
+        expect(r.backing.contents.containsKey("child"), true);
         if (r.child != null) {
-          expect(r.child.backingMap.length,
+          expect(r.child.backing.contents.length,
               r.child.entity.defaultProperties.length);
           for (var property in r.child.entity.defaultProperties) {
-            expect(r.child.backingMap.containsKey(property), true);
+            expect(r.child.backing.contents.containsKey(property), true);
           }
         }
       }
@@ -80,22 +80,22 @@ void main() {
 
       for (var r in results) {
         expect(
-            r.backingMap.length,
+            r.backing.contents.length,
             r.entity.defaultProperties.length +
                 1); // +1 is for key containing 'child'
         for (var property in r.entity.defaultProperties) {
-          expect(r.backingMap.containsKey(property), true);
+          expect(r.backing.contents.containsKey(property), true);
         }
 
         // Child may be null, but even if it is the key must be in the map
-        expect(r.backingMap.containsKey("child"), true);
+        expect(r.backing.contents.containsKey("child"), true);
         if (r.child != null) {
-          expect(r.child.backingMap.length,
+          expect(r.child.backing.contents.length,
               r.child.entity.defaultProperties.length);
           for (var property in r.child.entity.defaultProperties) {
-            expect(r.child.backingMap.containsKey(property), true);
+            expect(r.child.backing.contents.containsKey(property), true);
           }
-          expect(r.child.backingMap.containsKey("grandChild"), false);
+          expect(r.child.backing.contents.containsKey("grandChild"), false);
         }
       }
     });
@@ -108,29 +108,29 @@ void main() {
       var results = await q.fetch();
       for (var r in results) {
         expect(
-            r.backingMap.length,
+            r.backing.contents.length,
             r.entity.defaultProperties.length +
                 1); // +1 is for key containing 'child'
         for (var property in r.entity.defaultProperties) {
-          expect(r.backingMap.containsKey(property), true);
+          expect(r.backing.contents.containsKey(property), true);
         }
 
-        expect(r.backingMap.containsKey("child"), true);
+        expect(r.backing.contents.containsKey("child"), true);
         if (r.child != null) {
           expect(
-              r.child.backingMap.length,
+              r.child.backing.contents.length,
               r.child.entity.defaultProperties.length +
                   1); // +1 is for key containing 'grandchild
           for (var property in r.child.entity.defaultProperties) {
-            expect(r.child.backingMap.containsKey(property), true);
+            expect(r.child.backing.contents.containsKey(property), true);
           }
 
-          expect(r.child.backingMap.containsKey("grandChild"), true);
+          expect(r.child.backing.contents.containsKey("grandChild"), true);
           if (r.child.grandChild != null) {
-            expect(r.child.grandChild.backingMap.length,
+            expect(r.child.grandChild.backing.contents.length,
                 r.child.grandChild.entity.defaultProperties.length);
             for (var property in r.child.grandChild.entity.defaultProperties) {
-              expect(r.child.grandChild.backingMap.containsKey(property), true);
+              expect(r.child.grandChild.backing.contents.containsKey(property), true);
             }
           }
         }
@@ -147,13 +147,13 @@ void main() {
 
       var results = await q.fetch();
       for (var r in results) {
-        expect(r.backingMap.length, 2 /* id + child */);
-        expect(r.backingMap.containsKey("rid"), true);
-        expect(r.backingMap.containsKey("child"), true);
+        expect(r.backing.contents.length, 2 /* id + child */);
+        expect(r.backing.contents.containsKey("rid"), true);
+        expect(r.backing.contents.containsKey("child"), true);
 
         if (r.child != null) {
-          expect(r.child.backingMap.length, 1);
-          expect(r.child.backingMap.containsKey("cid"), true);
+          expect(r.child.backing.contents.length, 1);
+          expect(r.child.backing.contents.containsKey("cid"), true);
         }
       }
     });
@@ -169,18 +169,18 @@ void main() {
 
       var results = await q.fetch();
       for (var r in results) {
-        expect(r.backingMap.length, 2 /* id + child */);
-        expect(r.backingMap.containsKey("rid"), true);
-        expect(r.backingMap.containsKey("child"), true);
+        expect(r.backing.contents.length, 2 /* id + child */);
+        expect(r.backing.contents.containsKey("rid"), true);
+        expect(r.backing.contents.containsKey("child"), true);
 
         if (r.child != null) {
-          expect(r.child.backingMap.length, 2 /* id + grandchild */);
-          expect(r.child.backingMap.containsKey("cid"), true);
-          expect(r.child.backingMap.containsKey("grandChild"), true);
+          expect(r.child.backing.contents.length, 2 /* id + grandchild */);
+          expect(r.child.backing.contents.containsKey("cid"), true);
+          expect(r.child.backing.contents.containsKey("grandChild"), true);
 
           if (r.child?.grandChild != null) {
-            expect(r.child.grandChild.backingMap.length, 1);
-            expect(r.child.grandChild.backingMap.containsKey("gid"), true);
+            expect(r.child.grandChild.backing.contents.length, 1);
+            expect(r.child.grandChild.backing.contents.containsKey("gid"), true);
           }
         }
       }
@@ -267,7 +267,7 @@ void main() {
 
       expect(results.length, 1);
       expect(results.first.rid, 1);
-      expect(results.first.backingMap.containsKey("children"), false);
+      expect(results.first.backing.contents.containsKey("children"), false);
 
       q = new Query<RootObject>()
         ..where((o) => o.children.haveAtLeastOneWhere.cid).equalTo(2)
@@ -292,7 +292,7 @@ void main() {
       expect(results.firstWhere((r) => r.child?.cid == 1).child, isNotNull);
       expect(
           results.where((r) => r.rid != 1).every(
-              (r) => r.backingMap.containsKey("child") && r.child == null),
+              (r) => r.backing.contents.containsKey("child") && r.child == null),
           true);
     });
 
@@ -418,13 +418,13 @@ void main() {
 
       var results = await q.fetch();
       for (var r in results) {
-        expect(r.backingMap.length,
+        expect(r.backing.contents.length,
             r.entity.defaultProperties.length + 1); // +1 is for child
         for (var property in r.entity.defaultProperties) {
-          expect(r.backingMap.containsKey(property), true);
+          expect(r.backing.contents.containsKey(property), true);
         }
-        expect(r.child.backingMap.length, 1);
-        expect(r.child.backingMap.containsKey("cid"), true);
+        expect(r.child.backing.contents.length, 1);
+        expect(r.child.backing.contents.containsKey("cid"), true);
       }
     });
 
@@ -459,7 +459,7 @@ void main() {
       expect(results.any((r) => r.rid == 1), true);
       expect(results.any((r) => r.rid == 2), true);
       expect(results.any((r) => r.rid == 4), true);
-      expect(results.every((r) => r.backingMap["children"] == null), true);
+      expect(results.every((r) => r.backing.contents["children"] == null), true);
     });
 
     test("WhereNull on hasMany", () async {
@@ -469,7 +469,7 @@ void main() {
       expect(results.length, 2);
       expect(results.any((r) => r.rid == 3), true);
       expect(results.any((r) => r.rid == 5), true);
-      expect(results.every((r) => r.backingMap["children"] == null), true);
+      expect(results.every((r) => r.backing.contents["children"] == null), true);
     });
 
     test("WhereNotNull on hasOne", () async {
@@ -480,7 +480,7 @@ void main() {
       expect(results.any((r) => r.rid == 1), true);
       expect(results.any((r) => r.rid == 2), true);
       expect(results.any((r) => r.rid == 3), true);
-      expect(results.every((r) => r.backingMap["child"] == null), true);
+      expect(results.every((r) => r.backing.contents["child"] == null), true);
     });
 
     test("WhereNull on hasOne", () async {
@@ -490,7 +490,7 @@ void main() {
       expect(results.length, 2);
       expect(results.any((r) => r.rid == 4), true);
       expect(results.any((r) => r.rid == 5), true);
-      expect(results.every((r) => r.backingMap["child"] == null), true);
+      expect(results.every((r) => r.backing.contents["child"] == null), true);
     });
   });
 
@@ -542,7 +542,7 @@ void main() {
       final result = await q.fetch();
       expect(result.length, 1);
       expect(result.first.rid, 1);
-      expect(result.first.backingMap.containsKey("child"), false);
+      expect(result.first.backing.contents.containsKey("child"), false);
     });
 
     test("From belongs-to-one", () async {
@@ -552,7 +552,7 @@ void main() {
       final result = await q.fetch();
       expect(result.length, 1);
       expect(result.first.gid, 1);
-      expect(result.first.backingMap["parent"].backingMap.keys.length, 1);
+      expect(result.first.backing.contents["parent"].backing.contents.keys.length, 1);
     });
 
     test("From belongs-to-many", () async {
@@ -563,7 +563,7 @@ void main() {
       final result = await q.fetch();
       expect(result.length, 3);
       expect(result.map((g) => g.gid).toList(), [5, 6, 8]);
-      expect(result.any((g) => g.backingMap["parents"].backingMap.keys.length != 1), false);
+      expect(result.any((g) => g.backing.contents["parents"].backingMap.keys.length != 1), false);
     });
   });
 }

--- a/test/db/postgresql/typing_test.dart
+++ b/test/db/postgresql/typing_test.dart
@@ -51,7 +51,7 @@ void main() {
 
     final entity = context.entityForType(TestModel);
     var builder = new PostgresQueryBuilder(entity,
-        returningProperties: [new KeyPath(entity.properties["id"])], values: q.values.backingMap);
+        returningProperties: [new KeyPath(entity.properties["id"])], values: q.values.backing.contents);
     var insertString = builder.insertionValueString;
     expect(insertString, contains("id:int8"));
     expect(insertString, contains("n:text"));

--- a/test/db/query_value_test.dart
+++ b/test/db/query_value_test.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:aqueduct/aqueduct.dart';
+import 'package:test/test.dart';
+
+import '../context_helpers.dart';
+
+void main() {
+  ManagedContext ctx;
+  setUpAll(() async {
+    ctx = await contextWithModels([Root, Child]);
+  });
+  
+  test("Can immediately access primary key of belongs-to relationship when building Query.values", () {
+    final q = new Query<Child>();
+    q.values.parent.id = 1;
+    expect(q.values.parent.id, 1);
+  });
+
+  test("Can immediately access document property when building Query.values", () {
+    final q = new Query<Root>();
+    q.values.document["id"] = 1;
+    expect(q.values.document["id"], 1);
+  });
+
+  test("Can immediately access nested document property when building Query.values", () {
+    final q = new Query<Root>();
+    q.values.document["object"]["key"] = 1;
+    expect(q.values.document["object"]["key"], 1);
+  });
+
+  test("Can immediately access nested document list property when building Query.values", () {
+    final q1 = new Query<Root>();
+    q1.values.document["object"][2] = 1;
+    expect(q1.values.document["object"][2], 1);
+
+    final q2 = new Query<Root>();
+    q2.values.document[2]["object"] = 1;
+    expect(q2.values.document[2]["object"], 1);
+  });
+
+  test("Access ManagedSet property of Query.values throws error", () {
+    final q = new Query<Root>();
+    try {
+      q.values.children = new ManagedSet<Child>();
+      fail('unreachable');
+    } on StateError catch (e) {
+      expect(e.toString(), "?>>?");
+    }
+  });
+
+  test("Accessing non-primary key of ManagedObject property in Query.values throws error", () {
+    final q = new Query<Child>();
+    try {
+      q.values.parent.name = "ok";
+      fail('unreachable');
+    } on StateError catch (e) {
+      expect(e.toString(), "?>>?");
+    }
+  });
+
+  test("Accessing primary key of has-one property in Query.values throws error", () {
+    final q = new Query<Child>();
+    try {
+      q.values.parentHasOne.id = 1;
+      fail('unreachable');
+    } on StateError catch (e) {
+      expect(e.toString(), "?>>?");
+    }
+  });
+}
+
+class _Root {
+  @primaryKey
+  int id;
+
+  String name;
+
+  ManagedSet<Child> children;
+  Document document;
+  Child child;
+}
+class Root extends ManagedObject<_Root> implements _Root {}
+
+class _Child {
+  @primaryKey
+  int id;
+
+  String name;
+
+  @Relate(#children)
+  Root parent;
+
+  @Relate(#child)
+  Root parentHasOne;
+
+}
+class Child extends ManagedObject<_Child> implements _Child {}

--- a/test/db/query_value_test.dart
+++ b/test/db/query_value_test.dart
@@ -6,7 +6,7 @@ import '../context_helpers.dart';
 void main() {
   ManagedContext ctx;
   setUpAll(() async {
-    ctx = await contextWithModels([Root, Child]);
+    ctx = await contextWithModels([Root, Child, Constructor]);
   });
   tearDownAll(() async {
     await ctx.persistentStore.close();
@@ -16,6 +16,11 @@ void main() {
     final q = new Query<Child>();
     q.values.parent.id = 1;
     expect(q.values.parent.id, 1);
+  });
+
+  test("Values set in constructor are replicated in Query.values", () async {
+    final q = new Query<Constructor>();
+    expect(q.values.name, "Bob");
   });
 
 //todo: Deferring these until next PR
@@ -197,3 +202,16 @@ class _Child {
 
 }
 class Child extends ManagedObject<_Child> implements _Child {}
+
+class _Constructor {
+  @primaryKey
+  int id;
+
+  String name;
+}
+
+class Constructor extends ManagedObject<_Constructor> implements _Constructor {
+  Constructor() {
+    name = "Bob";
+  }
+}

--- a/test/db/query_value_test.dart
+++ b/test/db/query_value_test.dart
@@ -45,8 +45,8 @@ void main() {
     try {
       q.values.children = new ManagedSet<Child>();
       fail('unreachable');
-    } on StateError catch (e) {
-      expect(e.toString(), "?>>?");
+    } on ArgumentError catch (e) {
+      expect(e.toString(), contains("Invalid property access"));
     }
   });
 
@@ -55,22 +55,47 @@ void main() {
     try {
       q.values.parent.name = "ok";
       fail('unreachable');
-    } on StateError catch (e) {
-      expect(e.toString(), "?>>?");
+    } on ArgumentError catch (e) {
+      expect(e.toString(), contains("Invalid property access"));
     }
   });
 
   test("Accessing primary key of has-one property in Query.values throws error", () {
-    final q = new Query<Child>();
+    final q = new Query<Root>();
     try {
-      q.values.parentHasOne.id = 1;
+      q.values.child.id = 1;
       fail('unreachable');
-    } on StateError catch (e) {
-      expect(e.toString(), "?>>?");
+    } on ArgumentError catch (e) {
+      expect(e.toString(), contains("Invalid property access"));
     }
   });
 
-  group("Query.values assigned to default instance", () {
+  test("Can set belongs-to relationship with default constructed object if it is empty", () {
+    final q = new Query<Child>();
+    q.values.parent = new Root();
+    q.values.parent.id = 1;
+    expect(q.values.parent.id, 1);
+  });
+
+  test("Can set belongs-to relationship with default constructed object if it only contains primary key", () {
+    final q = new Query<Child>();
+    q.values.parent = new Root()..id = 1;
+    expect(q.values.parent.id, 1);
+
+  });
+
+  test("Cannot set belongs-to relationship with default constructed object if it contains properties other than primary key", () {
+    final q = new Query<Child>();
+    try {
+      q.values.parent = new Root()
+        ..name = "bob";
+      fail('unreachable');
+    } on ArgumentError catch (e) {
+      expect(e.toString(), contains("Invalid property access"));
+    }
+  });
+
+  group("Query.values assigned to instance created by default constroct", () {
     test("Can still create subobjects", () {
       final q = new Query<Child>();
       q.values = new Child();
@@ -97,8 +122,8 @@ void main() {
       try {
         q.values = r;
         fail('unreachable');
-      } on StateError catch (e) {
-        expect(e.toString(), "???");
+      } on ArgumentError catch (e) {
+        expect(e.toString(), contains("Invalid property access"));
       }
     });
 
@@ -110,8 +135,8 @@ void main() {
       try {
         q.values = r;
         fail('unreachable');
-      } on StateError catch (e) {
-        expect(e.toString(), "???");
+      } on ArgumentError catch (e) {
+        expect(e.toString(), contains("Invalid property access"));
       }
     });
 
@@ -123,8 +148,8 @@ void main() {
       try {
         q.values = r;
         fail('unreachable');
-      } on StateError catch (e) {
-        expect(e.toString(), "???");
+      } on ArgumentError catch (e) {
+        expect(e.toString(), contains("Invalid property access"));
       }
     });
 

--- a/test/db/query_value_test.dart
+++ b/test/db/query_value_test.dart
@@ -1,6 +1,3 @@
-import 'dart:async';
-import 'dart:isolate';
-
 import 'package:aqueduct/aqueduct.dart';
 import 'package:test/test.dart';
 
@@ -10,6 +7,9 @@ void main() {
   ManagedContext ctx;
   setUpAll(() async {
     ctx = await contextWithModels([Root, Child]);
+  });
+  tearDownAll(() async {
+    await ctx.persistentStore.close();
   });
 
   test("Can immediately access primary key of belongs-to relationship when building Query.values", () {

--- a/test/db/query_value_test.dart
+++ b/test/db/query_value_test.dart
@@ -18,27 +18,28 @@ void main() {
     expect(q.values.parent.id, 1);
   });
 
-  test("Can immediately access document property when building Query.values", () {
-    final q = new Query<Root>();
-    q.values.document["id"] = 1;
-    expect(q.values.document["id"], 1);
-  });
-
-  test("Can immediately access nested document property when building Query.values", () {
-    final q = new Query<Root>();
-    q.values.document["object"]["key"] = 1;
-    expect(q.values.document["object"]["key"], 1);
-  });
-
-  test("Can immediately access nested document list property when building Query.values", () {
-    final q1 = new Query<Root>();
-    q1.values.document["object"][2] = 1;
-    expect(q1.values.document["object"][2], 1);
-
-    final q2 = new Query<Root>();
-    q2.values.document[2]["object"] = 1;
-    expect(q2.values.document[2]["object"], 1);
-  });
+//todo: Deferring these until next PR
+//  test("Can immediately access document property when building Query.values", () {
+//    final q = new Query<Root>();
+//    q.values.document["id"] = 1;
+//    expect(q.values.document["id"], 1);
+//  });
+//
+//  test("Can immediately access nested document property when building Query.values", () {
+//    final q = new Query<Root>();
+//    q.values.document["object"]["key"] = 1;
+//    expect(q.values.document["object"]["key"], 1);
+//  });
+//
+//  test("Can immediately access nested document list property when building Query.values", () {
+//    final q1 = new Query<Root>();
+//    q1.values.document["object"][2] = 1;
+//    expect(q1.values.document["object"][2], 1);
+//
+//    final q2 = new Query<Root>();
+//    q2.values.document[2]["object"] = 1;
+//    expect(q2.values.document[2]["object"], 1);
+//  });
 
   test("Access ManagedSet property of Query.values throws error", () {
     final q = new Query<Root>();

--- a/test/db/validate_value_test.dart
+++ b/test/db/validate_value_test.dart
@@ -182,7 +182,7 @@ void main() {
     });
 
     test("Implicitly added to enum types", () {
-      var e = new EnumObject()..backingMap["enumValues"] = "foobar";
+      var e = new EnumObject()..backing.contents["enumValues"] = "foobar";
       expect(e.validate(), false);
       e.enumValues = EnumValues.abcd;
       expect(e.validate(), true);


### PR DESCRIPTION
- Prevents user from setting has-* relationships in Query.values.
- Accessing belongs-to relationships automatically creates an empty instance if object is Query.values.
- Prevents user from setting values other than foreign key for belongs-to relationships in Query.values
- Allows user to set Query.values from an object created thru default constructor, and strips away invalid insertion values (has-many, has-one, etc.)