### PR TITLE
Require explicit ManagedContext for Query. Allow for multiple ManagedContexts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.0
 
+- Removes `ManagedContext.defaultContext`; context usage must be explicit.
 - Adds 'Scope' annotation to add granular scoping to `ResourceController` methods.
 - Adds support for storing PostgreSQL JSONB data with `Document` data type.
 - Adds support for OpenAPI 3.0.0 documentation generation.

--- a/lib/managed_auth.dart
+++ b/lib/managed_auth.dart
@@ -435,7 +435,7 @@ class ManagedAuthDelegate<T extends ManagedAuthResourceOwner>
 
     var results = await oldTokenQuery.fetch();
     if (results.length == 1) {
-      var deleteQ = new Query<ManagedAuthToken>()
+      var deleteQ = new Query<ManagedAuthToken>(context)
         ..where((o) => o.resourceOwner).identifiedBy(resourceOwnerIdentifier)
         ..where((o) => o.expirationDate).lessThanEqualTo(results.first.expirationDate);
 

--- a/lib/src/commands/auth.dart
+++ b/lib/src/commands/auth.dart
@@ -80,7 +80,7 @@ class CLIAuthScopeClient extends CLIDatabaseConnectingCommand {
     }
 
     var dataModel = new ManagedDataModel.fromCurrentMirrorSystem();
-    context = new ManagedContext.standalone(dataModel, persistentStore);
+    context = new ManagedContext(dataModel, persistentStore);
 
     var scopingClient = new AuthClient.public(clientID, allowedScopes: scopes?.map((s) => new AuthScope(s))?.toList());
 
@@ -102,7 +102,7 @@ class CLIAuthScopeClient extends CLIDatabaseConnectingCommand {
 
   @override
   Future cleanup() async {
-    await context?.persistentStore?.close();
+    await context?.close();
   }
 
   @override
@@ -232,7 +232,7 @@ class CLIAuthAddClient extends CLIDatabaseConnectingCommand {
 
   @override
   Future cleanup() async {
-    await context?.persistentStore?.close();
+    await context?.close();
   }
 
   @override

--- a/lib/src/db/managed/context.dart
+++ b/lib/src/db/managed/context.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:aqueduct/src/application/service_registry.dart';
 import 'package:aqueduct/src/db/managed/data_model_manager.dart';
 
 import 'managed.dart';
@@ -38,6 +39,7 @@ class ManagedContext implements APIComponentDocumenter {
   /// This is the default constructor.
   ManagedContext(this.dataModel, this.persistentStore) {
     ManagedDataModelManager.add(dataModel);
+    ApplicationServiceRegistry.defaultInstance.register<ManagedContext>(this, (o) => o.close());
   }
 
   /// The persistent store that [Query]s on this context are executed through.

--- a/lib/src/db/managed/context.dart
+++ b/lib/src/db/managed/context.dart
@@ -28,26 +28,12 @@ import 'package:aqueduct/src/openapi/documentable.dart';
 /// so the most recently [ManagedContext] instantiated becomes the [ManagedContext.defaultContext]. By default, [Query]s
 /// target the [ManagedContext.defaultContext] and need not be specified.
 class ManagedContext implements APIComponentDocumenter {
-  /// The default context that a [Query] runs on.
-  ///
-  /// For classes that require a [ManagedContext] - like [Query] - this is the default context when none
-  /// is specified.
-  ///
-  /// This value is set when a [ManagedContext] is instantiated in an isolate; the last context created
-  /// is the default context. Most applications
-  /// will not use more than one [ManagedContext]. When running tests, you should set
-  /// this value each time you instantiate a [ManagedContext] to ensure that a previous test isolate
-  /// state did not set this property.
-  static ManagedContext defaultContext;
-
   /// Creates an instance of [ManagedContext] from a [ManagedDataModel] and [PersistentStore].
   ///
   /// This instance will become the [ManagedContext.defaultContext], unless another [ManagedContext]
   /// is created, in which the new context becomes the default context. See [ManagedContext.standalone]
   /// to create a context without setting it as the default context.
-  ManagedContext(this.dataModel, this.persistentStore) {
-    defaultContext = this;
-  }
+  ManagedContext(this.dataModel, this.persistentStore);
 
   /// Creates an instance of [ManagedContext] from a [ManagedDataModel] and [PersistentStore].
   ///

--- a/lib/src/db/managed/context.dart
+++ b/lib/src/db/managed/context.dart
@@ -18,7 +18,7 @@ import 'package:aqueduct/src/openapi/documentable.dart';
 /// A context must have a [PersistentStore] (that determines the database queries are sent to) and a [ManagedDataModel] (that determines
 /// the [ManagedObject]s that can be used).
 ///
-/// Example initialization:
+/// Example usage:
 ///
 ///         class Channel extends ApplicationChannel {
 ///            ManagedContext context;
@@ -31,7 +31,11 @@ import 'package:aqueduct/src/openapi/documentable.dart';
 ///            }
 ///
 ///            @override
-///            Controller get entryPoint => ...;
+///            Controller get entryPoint {
+///              final router = new Router();
+///              router.route("/path").link(() => new DBController(context));
+///              return router;
+///            }
 ///         }
 class ManagedContext implements APIComponentDocumenter {
   /// Creates an instance of [ManagedContext] from a [ManagedDataModel] and [PersistentStore].
@@ -48,9 +52,13 @@ class ManagedContext implements APIComponentDocumenter {
   /// The data model containing the [ManagedEntity]s that describe the [ManagedObject]s this instance works with.
   final ManagedDataModel dataModel;
 
+  /// Closes this context and release its underlying resources.
+  ///
+  /// This method closes the connection to [persistentStore] and releases [dataModel].
+  /// A context may not be reused once it has been closed.
   Future close() async {
     await persistentStore?.close();
-    dataModel.release();
+    dataModel?.release();
   }
 
   /// Returns an entity for a type from [dataModel].

--- a/lib/src/db/managed/context.dart
+++ b/lib/src/db/managed/context.dart
@@ -10,13 +10,15 @@ import 'package:aqueduct/src/application/channel.dart';
 import 'package:aqueduct/src/http/http.dart';
 import 'package:aqueduct/src/openapi/documentable.dart';
 
-/// A service object required to execute [Query]s.
+/// A service object that handles connecting to and sending queries to a database.
 ///
 /// You create objects of this type to use the Aqueduct ORM. Create instances in [ApplicationChannel.prepare]
 /// and inject them into controllers that execute database queries.
 ///
-/// A context must have a [PersistentStore] (that determines the database queries are sent to) and a [ManagedDataModel] (that determines
-/// the [ManagedObject]s that can be used).
+/// A context contains two types of objects:
+///
+/// - [PersistentStore] : Maintains a connection to a specific database. Transfers data between your application and the database.
+/// - [ManagedDataModel] : Contains information about the [ManagedObject] subclasses in your application.
 ///
 /// Example usage:
 ///
@@ -41,6 +43,9 @@ class ManagedContext implements APIComponentDocumenter {
   /// Creates an instance of [ManagedContext] from a [ManagedDataModel] and [PersistentStore].
   ///
   /// This is the default constructor.
+  ///
+  /// A [Query] is sent to the database described by [persistentStore]. A [Query] may only be executed
+  /// on this context if its type is in [dataModel].
   ManagedContext(this.dataModel, this.persistentStore) {
     ManagedDataModelManager.add(dataModel);
     ApplicationServiceRegistry.defaultInstance.register<ManagedContext>(this, (o) => o.close());

--- a/lib/src/db/managed/data_model.dart
+++ b/lib/src/db/managed/data_model.dart
@@ -1,5 +1,6 @@
 import 'dart:mirrors';
 import 'package:aqueduct/src/openapi/documentable.dart';
+import 'package:aqueduct/src/utilities/reference_counting_list.dart';
 
 import 'managed.dart';
 import 'data_model_builder.dart';
@@ -14,7 +15,7 @@ import '../query/query.dart';
 ///
 /// Most applications do not need to access instances of this type.
 ///
-class ManagedDataModel implements APIComponentDocumenter {
+class ManagedDataModel extends Object with ReferenceCountable implements APIComponentDocumenter {
   /// Creates an instance of [ManagedDataModel] from a list of types that extend [ManagedObject]. It is preferable
   /// to use [ManagedDataModel.fromCurrentMirrorSystem] over this method.
   ///

--- a/lib/src/db/managed/data_model_manager.dart
+++ b/lib/src/db/managed/data_model_manager.dart
@@ -1,0 +1,32 @@
+import 'package:aqueduct/src/db/managed/data_model.dart';
+import 'package:aqueduct/src/db/managed/entity.dart';
+import 'package:aqueduct/src/utilities/reference_counting_list.dart';
+
+class ManagedDataModelManager {
+  static ReferenceCountingList<ManagedDataModel> dataModels = new ReferenceCountingList<ManagedDataModel>();
+
+  static ManagedEntity findEntity(Type type, {ManagedEntity orElse()}) {
+    for (final d in ManagedDataModelManager.dataModels) {
+      final entity = d.entityForType(type);
+      if (entity != null) {
+        return entity;
+      }
+    }
+
+    if (orElse == null) {
+      throw new StateError("No entity found for '${type}. Did you forget to create a 'ManagedContext'?");
+    }
+
+
+    return orElse();
+  }
+
+  static void add(ManagedDataModel model) {
+    final idx = dataModels.indexOf(model);
+    if (idx == -1) {
+      dataModels.add(model);
+    }
+
+    model.retain();
+  }
+}

--- a/lib/src/db/managed/entity.dart
+++ b/lib/src/db/managed/entity.dart
@@ -227,8 +227,8 @@ class ManagedEntity implements APIComponentDocumenter {
           attrDocs = entityDocs[new Symbol(name)];
         }
 
-        schemaProperty.title = attrDocs.summary;
-        schemaProperty.description = (attrDocs.description ?? "") + (schemaProperty.description ?? "");
+        schemaProperty.title = attrDocs?.summary;
+        schemaProperty.description = (attrDocs?.description ?? "") + (schemaProperty.description ?? "");
       });
     });
 

--- a/lib/src/db/managed/object.dart
+++ b/lib/src/db/managed/object.dart
@@ -1,5 +1,7 @@
 import 'dart:mirrors';
 
+import 'package:aqueduct/src/db/managed/data_model_manager.dart';
+
 import '../../http/serializable.dart';
 import 'managed.dart';
 import 'backing.dart';
@@ -75,7 +77,7 @@ class ManagedObject<PersistentType> implements HTTPSerializable {
   }
 
   /// The [ManagedEntity] this instance is described by.
-  ManagedEntity entity = ManagedContext.defaultContext.dataModel.entityForType(PersistentType);
+  ManagedEntity entity = ManagedDataModelManager.findEntity(PersistentType);
 
   /// The persistent values of this object.
   ///

--- a/lib/src/db/managed/set.dart
+++ b/lib/src/db/managed/set.dart
@@ -25,21 +25,14 @@ class ManagedSet<InstanceType extends ManagedObject> extends Object
   /// Creates an empty [ManagedSet].
   ManagedSet() {
     _innerValues = [];
-    entity =
-        ManagedContext.defaultContext.dataModel.entityForType(InstanceType);
   }
 
   /// Creates a [ManagedSet] from an [Iterable] of [InstanceType]s.
   ManagedSet.from(Iterable<InstanceType> items) {
     _innerValues = items.toList();
-    entity =
-        ManagedContext.defaultContext.dataModel.entityForType(InstanceType);
   }
 
   List<InstanceType> _innerValues;
-
-  /// The [ManagedEntity] that represents the [InstanceType].
-  ManagedEntity entity;
 
   /// Filters [Query] results based on the criteria of the objects in this collection.
   ///

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -13,21 +13,20 @@ export 'predicate.dart';
 export 'reduce.dart';
 
 
-/// Instances of this type configure and execute database commands.
+/// An object for configuring and executing a database query.
 ///
-/// Queries are used to fetch, update, insert, delete and count objects in a database. A query's [InstanceType] indicates
-/// the type of [ManagedObject] subclass' that this query will return as well. The [InstanceType]'s corresponding [ManagedEntity] determines
-/// the database table and columns to work with.
+/// Queries are used to fetch, update, insert, delete and count [InstanceType]s in a database.
+/// [InstanceType] must be a [ManagedObject].
 ///
-///         var query = new Query<Employee>()
-///           ..where.salary = whereGreaterThan(50000);
-///         var employees = await query.fetch();
+///         final query = new Query<Employee>()
+///           ..where((e) => e.salary).greaterThan(50000);
+///         final employees = await query.fetch();
 abstract class Query<InstanceType extends ManagedObject> {
   /// Creates a new [Query].
   ///
-  ///
+  /// The query will be sent to the database described by [context].
   factory Query(ManagedContext context) {
-    var entity = context.dataModel.entityForType(InstanceType);
+    final entity = context.dataModel.entityForType(InstanceType);
     if (entity == null) {
       throw new ArgumentError("Invalid context. The data model of 'context' does not contain '$InstanceType'.");
     }

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -27,11 +27,10 @@ abstract class Query<InstanceType extends ManagedObject> {
   ///
   /// By default, [context] is [ManagedContext.defaultContext]. The [entity] of this instance is found by
   /// evaluating [InstanceType] in [context].
-  factory Query([ManagedContext context]) {
-    var ctx = context ?? ManagedContext.defaultContext;
-    var entity = ctx.dataModel.entityForType(InstanceType);
+  factory Query(ManagedContext context) {
+    var entity = context.dataModel.entityForType(InstanceType);
 
-    return ctx.persistentStore.newQuery<InstanceType>(ctx, entity);
+    return context.persistentStore.newQuery<InstanceType>(context, entity);
   }
 
   /// Creates a new [Query] without a static type.
@@ -40,13 +39,12 @@ abstract class Query<InstanceType extends ManagedObject> {
   /// where the static type argument cannot be defined. Behaves just like the unnamed constructor.
   ///
   /// If [entity] is not in [context]'s [ManagedContext.dataModel], throws a internal failure [QueryException].
-  factory Query.forEntity(ManagedEntity entity, [ManagedContext context]) {
-    var ctx = context ?? ManagedContext.defaultContext;
-    if (!ctx.dataModel.entities.any((e) => identical(entity, e))) {
+  factory Query.forEntity(ManagedEntity entity, ManagedContext context) {
+    if (!context.dataModel.entities.any((e) => identical(entity, e))) {
       throw new StateError("Invalid query construction. Entity for '${entity.tableName}' is from different context than specified for query.");
     }
 
-    return ctx.persistentStore.newQuery<InstanceType>(ctx, entity);
+    return context.persistentStore.newQuery<InstanceType>(context, entity);
   }
 
   /// Configures this instance to fetch a relationship property identified by [object] or [set].

--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -25,10 +25,12 @@ export 'reduce.dart';
 abstract class Query<InstanceType extends ManagedObject> {
   /// Creates a new [Query].
   ///
-  /// By default, [context] is [ManagedContext.defaultContext]. The [entity] of this instance is found by
-  /// evaluating [InstanceType] in [context].
+  ///
   factory Query(ManagedContext context) {
     var entity = context.dataModel.entityForType(InstanceType);
+    if (entity == null) {
+      throw new ArgumentError("Invalid context. The data model of 'context' does not contain '$InstanceType'.");
+    }
 
     return context.persistentStore.newQuery<InstanceType>(context, entity);
   }

--- a/lib/src/http/managed_object_controller.dart
+++ b/lib/src/http/managed_object_controller.dart
@@ -39,10 +39,8 @@ import 'http.dart';
 /// - sortBy (string): indicates the sort order. The syntax is 'sortBy=key,order' where key is a property of [InstanceType] and order is either 'asc' or 'desc'. You may specify multiple sortBy parameters.
 class ManagedObjectController<InstanceType extends ManagedObject> extends ResourceController {
   /// Creates an instance of a [ManagedObjectController].
-  ///
-  /// [context] defaults to [ManagedContext.defaultContext].
-  ManagedObjectController([ManagedContext context]) : super() {
-    _query = new Query<InstanceType>(context ?? ManagedContext.defaultContext);
+  ManagedObjectController(ManagedContext context) : super() {
+    _query = new Query<InstanceType>(context);
   }
 
   /// Creates a new [ManagedObjectController] without a static type.
@@ -50,8 +48,8 @@ class ManagedObjectController<InstanceType extends ManagedObject> extends Resour
   /// This method is used when generating instances of this type dynamically from runtime values,
   /// where the static type argument cannot be defined. Behaves just like the unnamed constructor.
   ///
-  ManagedObjectController.forEntity(ManagedEntity entity, [ManagedContext context]) : super() {
-    _query = new Query.forEntity(entity, context ?? ManagedContext.defaultContext);
+  ManagedObjectController.forEntity(ManagedEntity entity, ManagedContext context) : super() {
+    _query = new Query.forEntity(entity, context);
   }
 
   /// Returns a route pattern for using [ManagedObjectController]s.

--- a/lib/src/http/query_controller.dart
+++ b/lib/src/http/query_controller.dart
@@ -20,9 +20,9 @@ import 'http.dart';
 /// 3. If the [Request] contains a body, it will be decoded per the [acceptedContentTypes] and deserialized into the [Query.values] property via [ManagedObject.readFromMap].
 abstract class QueryController<InstanceType extends ManagedObject>
     extends ResourceController {
-  /// Create an instance of [QueryController]. By default, [context] is the [ManagedContext.defaultContext].
-  QueryController([ManagedContext context]) : super() {
-    query = new Query<InstanceType>(context ?? ManagedContext.defaultContext);
+  /// Create an instance of [QueryController].
+  QueryController(ManagedContext context) : super() {
+    query = new Query<InstanceType>(context);
   }
   
   /// A query representing the values received from the [request] being processed.

--- a/lib/src/utilities/reference_counting_list.dart
+++ b/lib/src/utilities/reference_counting_list.dart
@@ -36,6 +36,7 @@ class ReferenceCountable {
     _retainCount --;
     if (_retainCount <= 0) {
       _owner?.remove(this);
+      _owner = null;
     }
   }
   void retain() {

--- a/lib/src/utilities/reference_counting_list.dart
+++ b/lib/src/utilities/reference_counting_list.dart
@@ -1,0 +1,44 @@
+import 'dart:collection';
+
+class ReferenceCountingList<T extends ReferenceCountable> extends ListBase<T> {
+  List<T> _inner = new List<T>();
+
+  @override
+  T operator [](int index) {
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T object) {
+    _inner[index] = object.._owner = this;
+  }
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  set length(int l) => _inner.length = l;
+
+  @override
+  void add(T element) => _inner.add(element.._owner = this);
+
+  @override
+  void addAll(Iterable<T> iterable) {
+    _inner.addAll(iterable.map((i) => i.._owner = this));
+  }
+}
+
+class ReferenceCountable {
+  ReferenceCountingList _owner;
+  int _retainCount = 0;
+
+  void release() {
+    _retainCount --;
+    if (_retainCount <= 0) {
+      _owner?.remove(this);
+    }
+  }
+  void retain() {
+    _retainCount ++;
+  }
+}

--- a/templates/db/lib/channel.dart
+++ b/templates/db/lib/channel.dart
@@ -7,6 +7,8 @@ import 'model/model.dart';
 /// Override methods in this class to set up routes and initialize services like
 /// database connections. See http://aqueduct.io/docs/http/channel/.
 class WildfireChannel extends ApplicationChannel {
+  ManagedContext context;
+
   /// Initialize services in this method.
   ///
   /// Implement this method to initialize services, read values from [options]
@@ -18,7 +20,7 @@ class WildfireChannel extends ApplicationChannel {
     logger.onRecord.listen((rec) => print("$rec ${rec.error ?? ""} ${rec.stackTrace ?? ""}"));
 
     var config = new WildfireConfiguration(options.configurationFilePath);
-    ManagedContext.defaultContext = contextWithConnectionInfo(config.database);
+    context = contextWithConnectionInfo(config.database);
   }
 
   /// Construct the request channel.
@@ -31,7 +33,7 @@ class WildfireChannel extends ApplicationChannel {
   Controller get entryPoint {
     final router = new Router();
 
-    router.route("/model/[:id]").link(() => new ManagedObjectController<Model>());
+    router.route("/model/[:id]").link(() => new ManagedObjectController<Model>(context));
 
     return router;
   }

--- a/templates/db/test/harness/app.dart
+++ b/templates/db/test/harness/app.dart
@@ -59,14 +59,14 @@ class TestApplication {
   }
 
   Future initializeDatabase() async {
-    await createDatabaseSchema(ManagedContext.defaultContext);
+    await createDatabaseSchema(application.channel.context);
   }
 
   /// Discards any persistent data stored during a test.
   ///
   /// Invoke this method in tearDown() to clear data between tests.
   Future discardPersistentData() async {
-    await ManagedContext.defaultContext.persistentStore.close();
+    await application.channel.context.persistentStore.close();
     await initializeDatabase();
   }
 

--- a/templates/db/test/harness/app.dart
+++ b/templates/db/test/harness/app.dart
@@ -66,7 +66,7 @@ class TestApplication {
   ///
   /// Invoke this method in tearDown() to clear data between tests.
   Future discardPersistentData() async {
-    await application.channel.context.persistentStore.close();
+    await application.channel.context.close();
     await initializeDatabase();
   }
 

--- a/templates/db/test/harness/app.dart
+++ b/templates/db/test/harness/app.dart
@@ -66,7 +66,7 @@ class TestApplication {
   ///
   /// Invoke this method in tearDown() to clear data between tests.
   Future discardPersistentData() async {
-    await application.channel.context.close();
+    await application.channel.context.persistentStore.close();
     await initializeDatabase();
   }
 

--- a/templates/db_and_auth/lib/channel.dart
+++ b/templates/db_and_auth/lib/channel.dart
@@ -13,6 +13,7 @@ import 'utility/html_template.dart';
 class WildfireChannel extends ApplicationChannel implements AuthCodeControllerDelegate {
   HTMLRenderer htmlRenderer = new HTMLRenderer();
   AuthServer authServer;
+  ManagedContext context;
 
   /// Initialize services in this method.
   ///
@@ -26,9 +27,9 @@ class WildfireChannel extends ApplicationChannel implements AuthCodeControllerDe
 
     var config = new WildfireConfiguration(options.configurationFilePath);
 
-    ManagedContext.defaultContext = contextWithConnectionInfo(config.database);
+    context = contextWithConnectionInfo(config.database);
 
-    var authStorage = new ManagedAuthDelegate<User>(ManagedContext.defaultContext);
+    var authStorage = new ManagedAuthDelegate<User>(context);
     authServer = new AuthServer(authStorage);
   }
 
@@ -51,16 +52,16 @@ class WildfireChannel extends ApplicationChannel implements AuthCodeControllerDe
     router
         .route("/register")
         .link(() => new Authorizer.basic(authServer))
-        .link(() => new RegisterController(authServer));
+        .link(() => new RegisterController(context, authServer));
 
     /* Gets profile for user with bearer token */
-    router.route("/me").link(() => new Authorizer.bearer(authServer)).link(() => new IdentityController());
+    router.route("/me").link(() => new Authorizer.bearer(authServer)).link(() => new IdentityController(context));
 
     /* Gets all users or one specific user by id */
     router
         .route("/users/[:id]")
         .link(() => new Authorizer.bearer(authServer))
-        .link(() => new UserController(authServer));
+        .link(() => new UserController(context, authServer));
 
     return router;
   }

--- a/templates/db_and_auth/lib/controller/identity_controller.dart
+++ b/templates/db_and_auth/lib/controller/identity_controller.dart
@@ -2,9 +2,13 @@ import '../wildfire.dart';
 import '../model/user.dart';
 
 class IdentityController extends ResourceController {
+  IdentityController(this.context);
+
+  final ManagedContext context;
+
   @Operation.get()
   Future<Response> getIdentity() async {
-    var q = new Query<User>()
+    var q = new Query<User>(context)
       ..where((o) => o.id).equalTo(request.authorization.resourceOwnerIdentifier);
 
     var u = await q.fetchOne();

--- a/templates/db_and_auth/lib/controller/register_controller.dart
+++ b/templates/db_and_auth/lib/controller/register_controller.dart
@@ -2,7 +2,7 @@ import '../wildfire.dart';
 import '../model/user.dart';
 
 class RegisterController extends QueryController<User> {
-  RegisterController(this.authServer);
+  RegisterController(ManagedContext context, this.authServer) : super(context);
 
   AuthServer authServer;
 

--- a/templates/db_and_auth/lib/controller/user_controller.dart
+++ b/templates/db_and_auth/lib/controller/user_controller.dart
@@ -2,7 +2,7 @@ import '../wildfire.dart';
 import '../model/user.dart';
 
 class UserController extends QueryController<User> {
-  UserController(this.authServer);
+  UserController(ManagedContext context, this.authServer) : super(context);
 
   AuthServer authServer;
 
@@ -41,8 +41,7 @@ class UserController extends QueryController<User> {
     }
 
     await authServer.revokeAuthenticatableAccessForIdentifier(id);
-    var q = new Query<User>()..where((o) => o.id).equalTo(id);
-    await q.delete();
+    await query.delete();
 
     return new Response.ok(null);
   }

--- a/templates/db_and_auth/test/harness/app.dart
+++ b/templates/db_and_auth/test/harness/app.dart
@@ -56,9 +56,9 @@ class TestApplication {
   }
 
   Future initializeDatabase() async {
-    await createDatabaseSchema(ManagedContext.defaultContext);
-    await addClientRecord();
-    await addClientRecord(clientID: DefaultPublicClientID, clientSecret: null);
+    await createDatabaseSchema(application.channel.context);
+    await addClientRecord(application.channel.context);
+    await addClientRecord(application.channel.context, clientID: DefaultPublicClientID, clientSecret: null);
   }
 
   /// Stops running this application harness.
@@ -73,7 +73,7 @@ class TestApplication {
   ///
   /// Invoke this method in tearDown() to clear data between tests.
   Future discardPersistentData() async {
-    await ManagedContext.defaultContext.persistentStore.close();
+    await application.channel.context.persistentStore.close();
     await initializeDatabase();
   }
 
@@ -82,7 +82,7 @@ class TestApplication {
   /// [start] must have already been called prior to executing this method. By default,
   /// every application harness inserts a default client record during [start]. See [start]
   /// for more details.
-  static Future<ManagedAuthClient> addClientRecord(
+  static Future<ManagedAuthClient> addClientRecord(ManagedContext context,
       {String clientID: DefaultClientID, String clientSecret: DefaultClientSecret}) async {
     var salt;
     var hashedPassword;
@@ -91,7 +91,7 @@ class TestApplication {
       hashedPassword = AuthUtility.generatePasswordHash(clientSecret, salt);
     }
 
-    var clientQ = new Query<ManagedAuthClient>()
+    var clientQ = new Query<ManagedAuthClient>(context)
       ..values.id = clientID
       ..values.salt = salt
       ..values.hashedSecret = hashedPassword;

--- a/templates/db_and_auth/test/harness/app.dart
+++ b/templates/db_and_auth/test/harness/app.dart
@@ -73,7 +73,7 @@ class TestApplication {
   ///
   /// Invoke this method in tearDown() to clear data between tests.
   Future discardPersistentData() async {
-    await application.channel.context.persistentStore.close();
+    await application.channel.context.close();
     await initializeDatabase();
   }
 

--- a/templates/db_and_auth/test/harness/app.dart
+++ b/templates/db_and_auth/test/harness/app.dart
@@ -73,7 +73,7 @@ class TestApplication {
   ///
   /// Invoke this method in tearDown() to clear data between tests.
   Future discardPersistentData() async {
-    await application.channel.context.close();
+    await application.channel.context.persistentStore.close();
     await initializeDatabase();
   }
 

--- a/test/command/auth_test.dart
+++ b/test/command/auth_test.dart
@@ -45,7 +45,6 @@ void main() {
     test("Can create public client", () async {
 
       await terminal.runAqueductCommand("auth", ["add-client", "--id", "a.b.c"]);
-      print("${terminal.output}");
 
       var q = new Query<ManagedAuthClient>(context);
       var results = await q.fetch();

--- a/test/command/auth_test.dart
+++ b/test/command/auth_test.dart
@@ -21,7 +21,7 @@ void main() {
       }
     }
 
-    context = new ManagedContext.standalone(dataModel, store);
+    context = new ManagedContext(dataModel, store);
 
     terminal = new Terminal.current()
       ..defaultAqueductArgs = ["--connect","postgres://dart:dart@localhost:5432/dart_test"];
@@ -34,7 +34,7 @@ void main() {
         await store.execute(c);
       }
     }
-    await context.persistentStore.close();
+    await context.close();
   });
 
   tearDownAll(() async {
@@ -45,6 +45,7 @@ void main() {
     test("Can create public client", () async {
 
       await terminal.runAqueductCommand("auth", ["add-client", "--id", "a.b.c"]);
+      print("${terminal.output}");
 
       var q = new Query<ManagedAuthClient>(context);
       var results = await q.fetch();

--- a/test/command/auth_test.dart
+++ b/test/command/auth_test.dart
@@ -28,7 +28,6 @@ void main() {
   });
 
   tearDown(() async {
-    ManagedContext.defaultContext = null;
     for (var t in schema.dependencyOrderedTables.reversed) {
       var tableCommands = store.deleteTable(t);
       for (var c in tableCommands) {

--- a/test/context_helpers.dart
+++ b/test/context_helpers.dart
@@ -8,7 +8,6 @@ Future<ManagedContext> contextWithModels(List<Type> instanceTypes) async {
   var dataModel = new ManagedDataModel(instanceTypes);
   var commands = commandsFromDataModel(dataModel, temporary: true);
   var context = new ManagedContext(dataModel, persistentStore);
-  ManagedContext.defaultContext = context;
 
   for (var cmd in commands) {
     await persistentStore.execute(cmd);

--- a/test/db/context_test.dart
+++ b/test/db/context_test.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:aqueduct/aqueduct.dart';
+import 'package:test/test.dart';
+import '../helpers.dart';
+
+void main() {
+  group("Multiple contexts, same data model", () {
+    final dm = new ManagedDataModel([T, U]);
+
+    ManagedContext ctx1;
+    ManagedContext ctx2;
+
+    setUp(() async {
+      ctx1 = await contextWithDataModel(dm);
+      ctx2 = await contextWithDataModel(dm);
+    });
+
+    tearDown(() async {
+      await ctx1?.close();
+      await ctx2?.close();
+    });
+
+    test("Queries are sent to the correct database", () async {
+      var q = new Query<T>(ctx1)..values.name = "bob";
+      await q.insert();
+
+      final t1 = await (new Query<T>(ctx1)).fetch();
+      final t2 = await (new Query<T>(ctx2)).fetch();
+
+      expect(t1.length, 1);
+      expect(t1.first.name, "bob");
+      expect(t2.length, 0);
+    });
+
+    test("If one context is released, other context's is OK", () async {
+      var q = new Query<T>(ctx1)..values.name = "bob";
+      await q.insert();
+
+      await ctx1.close();
+      ctx1 = null;
+
+      q = new Query<T>(ctx2)..values.name = "fred";
+      await q.insert();
+
+      final t2 = await (new Query<T>(ctx2)).fetch();
+
+      expect(t2.length, 1);
+      expect(t2.first.name, "fred");
+    });
+  });
+
+  group("Multiple contexts, different data model", () {
+    ManagedContext ctx1;
+    ManagedContext ctx2;
+
+    setUp(() async {
+      ctx1 = await contextWithDataModel(new ManagedDataModel([T]));
+      ctx2 = await contextWithDataModel(new ManagedDataModel([U]));
+    });
+
+    tearDown(() async {
+      await ctx1?.close();
+      await ctx2?.close();
+    });
+
+    test("Queries are sent to the appropriate database", () async {
+      final t1 = await (new Query<T>(ctx1)).fetch();
+      final t2 = await (new Query<U>(ctx2)).fetch();
+
+      expect(t1.length, 0);
+      expect(t2.length, 0);
+    });
+
+    test("Cannot create query on context whose data model doesn't contain query type", () async {
+      try {
+        new Query<T>(ctx2);
+        fail('unreachable');
+      } on ArgumentError catch (e) {
+        expect(e.toString(), contains("Invalid context"));
+      }
+
+      try {
+        new Query<U>(ctx1);
+        fail('unreachable');
+      } on ArgumentError catch (e) {
+        expect(e.toString(), contains("Invalid context"));
+      }
+    });
+  });
+}
+
+class _T {
+  @primaryKey
+  int id;
+
+  String name;
+}
+
+class T extends ManagedObject<_T> implements _T {}
+
+class _U {
+  @primaryKey
+  int id;
+  String name;
+}
+
+class U extends ManagedObject<_U> implements _U {}
+
+Future<ManagedContext> contextWithDataModel(ManagedDataModel dataModel) async {
+  var persistentStore = new PostgreSQLPersistentStore("dart", "dart", "localhost", 5432, "dart_test");
+
+  var commands = commandsFromDataModel(dataModel, temporary: true);
+  var context = new ManagedContext(dataModel, persistentStore);
+
+  for (var cmd in commands) {
+    await persistentStore.execute(cmd);
+  }
+
+  return context;
+}

--- a/test/db/data_model_manager_test.dart
+++ b/test/db/data_model_manager_test.dart
@@ -1,0 +1,75 @@
+import 'package:test/test.dart';
+import 'package:aqueduct/aqueduct.dart';
+
+import '../helpers.dart';
+
+void main() {
+  ManagedContext ctx;
+
+  tearDown(() async {
+    await ctx?.close();
+  });
+
+  test("Throws exception if no context has been created", () {
+    try {
+      new T();
+      fail('unreachable');
+    } on StateError catch (e) {
+      expect(e.toString(), contains("Did you forget to create a 'ManagedContext'?"));
+    }
+  });
+
+  test("Can find entity creating managedobject", () {
+    ctx = new ManagedContext(new ManagedDataModel.fromCurrentMirrorSystem(), new DefaultPersistentStore());
+    final o = new T();
+    o.id = 1;
+    expect(o.id, 1);
+  });
+
+  test("Close context destroys data model", () async {
+    ctx = new ManagedContext(new ManagedDataModel.fromCurrentMirrorSystem(), new DefaultPersistentStore());
+
+    final o = new T();
+    o.id = 1;
+    expect(o.id, 1);
+
+    await ctx.close();
+    ctx = null;
+
+    try {
+      new T();
+      fail('unreachable');
+    } on StateError catch (e) {
+      expect(e.toString(), contains("Did you forget to create a 'ManagedContext'?"));
+    }
+  });
+
+  test("Retained data model allows instantiation of ManagedObject", () async {
+    final dm = new ManagedDataModel.fromCurrentMirrorSystem();
+    ctx = new ManagedContext(dm, new DefaultPersistentStore());
+    final retainedCtx = new ManagedContext(dm, new DefaultPersistentStore());
+    await retainedCtx.close();
+
+    final o = new T();
+    o.id = 1;
+    expect(o.id, 1);
+
+    await ctx.close();
+    ctx = null;
+
+    try {
+      new T();
+      fail('unreachable');
+    } on StateError catch (e) {
+      expect(e.toString(), contains("Did you forget to create a 'ManagedContext'?"));
+    }
+  });
+
+}
+
+class _T {
+  @primaryKey
+  int id;
+}
+
+class T extends ManagedObject<_T> implements _T {}

--- a/test/db/data_model_test.dart
+++ b/test/db/data_model_test.dart
@@ -9,8 +9,7 @@ void main() {
     ManagedDataModel dataModel;
     setUp(() {
       dataModel = new ManagedDataModel([User, Item, Manager, EnumObject, DocumentObject]);
-      ManagedContext.defaultContext =
-          new ManagedContext(dataModel, new DefaultPersistentStore());
+      new ManagedContext(dataModel, new DefaultPersistentStore());
     });
 
     test("Entities have appropriate types", () {

--- a/test/db/data_model_test.dart
+++ b/test/db/data_model_test.dart
@@ -236,8 +236,6 @@ void main() {
   group("Valid data model with deferred types", () {
     test("Entities have correct properties and relationships", () {
       var dataModel = new ManagedDataModel([TotalModel, PartialReferenceModel]);
-      ManagedContext.defaultContext =
-          new ManagedContext(dataModel, new DefaultPersistentStore());
 
       expect(dataModel.entities.length, 2);
 
@@ -265,8 +263,6 @@ void main() {
 
     test("Will use tableName of base class if not declared in subclass", () {
       var dataModel = new ManagedDataModel([TotalModel, PartialReferenceModel]);
-      ManagedContext.defaultContext =
-          new ManagedContext(dataModel, new DefaultPersistentStore());
       expect(dataModel.entityForType(TotalModel).tableName, "predefined");
     });
 

--- a/test/db/data_model_test.dart
+++ b/test/db/data_model_test.dart
@@ -6,10 +6,15 @@ import 'package:aqueduct/src/db/managed/relationship_type.dart';
 
 void main() {
   group("Valid data model", () {
+    ManagedContext context;
     ManagedDataModel dataModel;
     setUp(() {
       dataModel = new ManagedDataModel([User, Item, Manager, EnumObject, DocumentObject]);
-      new ManagedContext(dataModel, new DefaultPersistentStore());
+      context = new ManagedContext(dataModel, new DefaultPersistentStore());
+    });
+
+    tearDown(() async {
+      await context.close();
     });
 
     test("Entities have appropriate types", () {

--- a/test/db/model_graph.dart
+++ b/test/db/model_graph.dart
@@ -241,27 +241,27 @@ Future<List<RootObject>> populateModelGraph(ManagedContext ctx) async {
   ];
 
   for (var root in rootObjects) {
-    var q = new Query<RootObject>()..values = root;
+    var q = new Query<RootObject>(ctx)..values = root;
     var r = await q.insert();
     root.rid = r.rid;
 
     if (root.child != null) {
       var child = root.child;
       child.parent = root;
-      var cQ = new Query<ChildObject>()..values = child;
+      var cQ = new Query<ChildObject>(ctx)..values = child;
       child.cid = (await cQ.insert()).cid;
 
       if (child.grandChild != null) {
         var gc = child.grandChild;
         gc.parent = child;
-        var gq = new Query<GrandChildObject>()..values = gc;
+        var gq = new Query<GrandChildObject>(ctx)..values = gc;
         gc.gid = (await gq.insert()).gid;
       }
 
       if (child?.grandChildren != null) {
         for (var gc in child.grandChildren) {
           gc.parents = child;
-          var gq = new Query<GrandChildObject>()..values = gc;
+          var gq = new Query<GrandChildObject>(ctx)..values = gc;
           gc.gid = (await gq.insert()).gid;
         }
       }
@@ -270,20 +270,20 @@ Future<List<RootObject>> populateModelGraph(ManagedContext ctx) async {
     if (root.children != null) {
       for (var child in root.children) {
         child.parents = root;
-        var cQ = new Query<ChildObject>()..values = child;
+        var cQ = new Query<ChildObject>(ctx)..values = child;
         child.cid = (await cQ.insert()).cid;
 
         if (child.grandChild != null) {
           var gc = child.grandChild;
           gc.parent = child;
-          var gq = new Query<GrandChildObject>()..values = gc;
+          var gq = new Query<GrandChildObject>(ctx)..values = gc;
           gc.gid = (await gq.insert()).gid;
         }
 
         if (child?.grandChildren != null) {
           for (var gc in child.grandChildren) {
             gc.parents = child;
-            var gq = new Query<GrandChildObject>()..values = gc;
+            var gq = new Query<GrandChildObject>(ctx)..values = gc;
             gc.gid = (await gq.insert()).gid;
           }
         }
@@ -292,12 +292,12 @@ Future<List<RootObject>> populateModelGraph(ManagedContext ctx) async {
 
     if (root.join != null) {
       for (var join in root.join) {
-        var otherQ = new Query<OtherRootObject>()..values = join.other;
+        var otherQ = new Query<OtherRootObject>(ctx)..values = join.other;
         join.other.id = (await otherQ.insert()).id;
 
         join.root = new RootObject()..rid = root.rid;
 
-        var joinQ = new Query<RootJoinObject>()..values = join;
+        var joinQ = new Query<RootJoinObject>(ctx)..values = join;
         await joinQ.insert();
       }
     }

--- a/test/db/model_test.dart
+++ b/test/db/model_test.dart
@@ -23,6 +23,10 @@ void main() {
     context = new ManagedContext(dm, ps);
   });
 
+  tearDownAll(() async {
+    await context.close();
+  });
+
   test("Can set properties in constructor", () {
     final obj = new ConstructorOverride();
     expect(obj.value, "foo");
@@ -90,7 +94,7 @@ void main() {
     var user = new User();
     user.id = 1;
     user.name = "Bob";
-    var posts = [
+    List<Post> posts = <Post>[
       new Post()
         ..text = "A"
         ..id = 1
@@ -105,7 +109,7 @@ void main() {
         ..owner = user,
     ];
 
-    user.posts = new ManagedSet.from(posts);
+    user.posts = new ManagedSet<Post>.from(posts);
 
     expect(user.posts.length, 3);
     expect(user.posts.first.owner, user);
@@ -138,7 +142,7 @@ void main() {
         ..text = "C"
         ..id = 3,
     ];
-    user.posts = new ManagedSet.from(posts);
+    user.posts = new ManagedSet<Post>.from(posts);
 
     var m = user.asMap();
     expect(m is Map, true);

--- a/test/db/model_test.dart
+++ b/test/db/model_test.dart
@@ -4,6 +4,8 @@ import 'dart:mirrors';
 import '../helpers.dart';
 
 void main() {
+  ManagedContext context;
+
   setUpAll(() {
     var ps = new DefaultPersistentStore();
     ManagedDataModel dm = new ManagedDataModel([
@@ -18,7 +20,7 @@ void main() {
       DocumentTest,
       ConstructorOverride
     ]);
-    var _ = new ManagedContext(dm, ps);
+    context = new ManagedContext(dm, ps);
   });
 
   test("Can set properties in constructor", () {
@@ -492,7 +494,7 @@ void main() {
 
   group("Private fields", () {
     test("Private fields on entity", () {
-      var entity = ManagedContext.defaultContext.dataModel.entityForType(PrivateField);
+      var entity = context.dataModel.entityForType(PrivateField);
       expect(entity.attributes["_private"], isNotNull);
     });
 

--- a/test/db/postgresql/aggregate_function_test.dart
+++ b/test/db/postgresql/aggregate_function_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   tearDown(() async {
-    await ctx.persistentStore.close();
+    await ctx.close();
   });
 
   group("Average", () {

--- a/test/db/postgresql/aggregate_function_test.dart
+++ b/test/db/postgresql/aggregate_function_test.dart
@@ -23,19 +23,19 @@ void main() {
     });
 
     test("Average produces average for int type", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.average((t) => t.i);
       expect(result, objects.fold(0, (p, n) => p + n.i) / objects.length);
     });
 
     test("Average produces average for double type", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.average((t) => t.d);
       expect(result, objects.fold(0, (p, n) => p + n.d) / objects.length);
     });
 
     test("Average with predicate", () async {
-      var q = new Query<Test>()
+      var q = new Query<Test>(ctx)
         ..where((p) => p.id).lessThanEqualTo(5);
       var result = await q.reduce.average((t) => t.i);
       expect(result, objects.sublist(0, 5).fold(0, (p, n) => p + n.i) / 5);
@@ -51,13 +51,13 @@ void main() {
     });
 
     test("Count produces number of objects", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.count();
       expect(result, objects.length);
     });
 
     test("Count with predicate", () async {
-      var q = new Query<Test>()
+      var q = new Query<Test>(ctx)
         ..where((p) => p.id).lessThanEqualTo(5);
       var result = await q.reduce.count();
       expect(result, 5);
@@ -73,31 +73,31 @@ void main() {
     });
 
     test("Maximum of int", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.maximum((t) => t.i);
       expect(result, objects.last.i);
     });
 
     test("Maximum of double", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.maximum((t) => t.d);
       expect(result, objects.last.d);
     });
 
     test("Maximum of String", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.maximum((t) => t.s);
       expect(result, objects.last.s);
     });
 
     test("Maximum of DateTime", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.maximum((t) => t.dt);
       expect(result, objects.last.dt);
     });
 
     test("Maximum with predicate", () async {
-      var q = new Query<Test>()
+      var q = new Query<Test>(ctx)
         ..where((p) => p.id).lessThanEqualTo(5);
       var result = await q.reduce.maximum((t) => t.i);
       expect(result, objects[4].i);
@@ -113,31 +113,31 @@ void main() {
     });
 
     test("Minimum of int", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.minimum((t) => t.i);
       expect(result, objects.first.i);
     });
 
     test("Minimum of double", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.minimum((t) => t.d);
       expect(result, objects.first.d);
     });
 
     test("Minimum of String", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.minimum((t) => t.s);
       expect(result, objects.first.s);
     });
 
     test("Minimum of DateTime", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.minimum((t) => t.dt);
       expect(result, objects.first.dt);
     });
 
     test("Minimum with predicate", () async {
-      var q = new Query<Test>()
+      var q = new Query<Test>(ctx)
         ..where((p) => p.id).greaterThan(5);
       var result = await q.reduce.minimum((t) => t.i);
       expect(result, objects[5].i);
@@ -153,19 +153,19 @@ void main() {
     });
 
     test("Sum produces sum for int type", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.sum((t) => t.i);
       expect(result, objects.fold(0, (p, n) => p + n.i));
     });
 
     test("Sum produces sum for double type", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.sum((t) => t.d);
       expect(result, objects.fold(0, (p, n) => p + n.d));
     });
 
     test("Sum with predicate", () async {
-      var q = new Query<Test>()
+      var q = new Query<Test>(ctx)
         ..where((p) => p.id).lessThanEqualTo(5);
       var result = await q.reduce.sum((t) => t.i);
       expect(result, objects.sublist(0, 5).fold(0, (p, a) => p + a.i));
@@ -181,13 +181,13 @@ void main() {
     });
 
     test("Sum with large integer numbers", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.sum((t) => t.i);
       expect(result, objects.fold(0, (p, n) => p + n.i));
     });
 
     test("Sum with fractional", () async {
-      var q = new Query<Test>();
+      var q = new Query<Test>(ctx);
       var result = await q.reduce.sum((t) => t.d);
       expect(result, objects.fold(0, (p, n) => p + n.d));
     });

--- a/test/db/postgresql/belongs_to_fetch_test.dart
+++ b/test/db/postgresql/belongs_to_fetch_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   group("Assign non-join matchers to belongsToProperty", () {
     test("Can use identifiedBy", () async {
-      var q = new Query<ChildObject>()..where((o) => o.parents).identifiedBy(1);
+      var q = new Query<ChildObject>(ctx)..where((o) => o.parents).identifiedBy(1);
       var results = await q.fetch();
 
       expect(results.length, rootObjects.firstWhere((r) => r.rid == 1).children.length);
@@ -36,7 +36,7 @@ void main() {
     });
 
     test("Can match on belongsTo relationship's primary key, does not cause join", () async {
-      var q = new Query<ChildObject>()..where((o) => o.parents.rid).equalTo(1);
+      var q = new Query<ChildObject>(ctx)..where((o) => o.parents.rid).equalTo(1);
       var results = await q.fetch();
 
       expect(results.length, rootObjects.firstWhere((r) => r.rid == 1).children.length);
@@ -49,7 +49,7 @@ void main() {
     });
 
     test("Can use whereNull", () async {
-      var q = new Query<ChildObject>()..where((o) => o.parents).isNull();
+      var q = new Query<ChildObject>(ctx)..where((o) => o.parents).isNull();
       var results = await q.fetch();
 
       var childNotChildren = rootObjects.expand((r) => [r.child]).where((c) => c != null).toList();
@@ -59,7 +59,7 @@ void main() {
         expect(results.firstWhere((resultChild) => c.cid == resultChild.cid), isNotNull);
       });
 
-      q = new Query<ChildObject>()..where((o) => o.parent).isNull();
+      q = new Query<ChildObject>(ctx)..where((o) => o.parent).isNull();
       results = await q.fetch();
 
       var childrenNotChild = rootObjects.expand((r) => r.children ?? []).toList();
@@ -71,7 +71,7 @@ void main() {
     });
 
     test("Can use whereNotNull", () async {
-      var q = new Query<ChildObject>()..where((o) => o.parents).isNotNull();
+      var q = new Query<ChildObject>(ctx)..where((o) => o.parents).isNotNull();
       var results = await q.fetch();
 
       var childrenNotChild = rootObjects.expand((r) => r.children ?? []).where((c) => c != null).toList();
@@ -81,7 +81,7 @@ void main() {
         expect(results.firstWhere((resultChild) => c.cid == resultChild.cid), isNotNull);
       });
 
-      q = new Query<ChildObject>()..where((o) => o.parent).isNotNull();
+      q = new Query<ChildObject>(ctx)..where((o) => o.parent).isNotNull();
       results = await q.fetch();
       var childNotChildren = rootObjects.expand((r) => [r.child]).where((c) => c != null).toList();
 
@@ -93,7 +93,7 @@ void main() {
   });
 
   test("Multiple joins from same table", () async {
-    var q = new Query<ChildObject>()
+    var q = new Query<ChildObject>(ctx)
       ..sortBy((c) => c.cid, QuerySortOrder.ascending)
       ..join(object: (c) => c.parent)
       ..join(object: (c) => c.parents);
@@ -116,7 +116,7 @@ void main() {
 
   group("Join on parent of hasMany relationship", () {
     test("Standard join", () async {
-      var q = new Query<ChildObject>()..join(object: (c) => c.parents);
+      var q = new Query<ChildObject>(ctx)..join(object: (c) => c.parents);
       var results = await q.fetch();
 
       expect(
@@ -144,7 +144,7 @@ void main() {
     });
 
     test("Nested join", () async {
-      var q = new Query<GrandChildObject>();
+      var q = new Query<GrandChildObject>(ctx);
       q.join(object: (c) => c.parents)..join(object: (c) => c.parents);
       var results = await q.fetch();
 
@@ -193,7 +193,7 @@ void main() {
     });
 
     test("Bidirectional join", () async {
-      var q = new Query<ChildObject>()
+      var q = new Query<ChildObject>(ctx)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
         ..join(set: (c) => c.grandChildren).sortBy((g) => g.gid, QuerySortOrder.descending)
         ..join(object: (c) => c.parents);
@@ -265,7 +265,7 @@ void main() {
 
   group("Join on parent of hasOne relationship", () {
     test("Standard join", () async {
-      var q = new Query<ChildObject>()
+      var q = new Query<ChildObject>(ctx)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
         ..join(object: (c) => c.parent);
       var results = await q.fetch();
@@ -304,7 +304,7 @@ void main() {
     });
 
     test("Nested join", () async {
-      var q = new Query<GrandChildObject>()..sortBy((g) => g.gid, QuerySortOrder.ascending);
+      var q = new Query<GrandChildObject>(ctx)..sortBy((g) => g.gid, QuerySortOrder.ascending);
 
       q.join(object: (c) => c.parent)..join(object: (c) => c.parent);
 
@@ -357,7 +357,7 @@ void main() {
 
   group("Implicit joins", () {
     test("Standard implicit join", () async {
-      var q = new Query<ChildObject>()..where((c) => c.parents.value1).equalTo(1);
+      var q = new Query<ChildObject>(ctx)..where((c) => c.parents.value1).equalTo(1);
       var results = await q.fetch();
 
       expect(
@@ -383,7 +383,7 @@ void main() {
     });
 
     test("Nested implicit joins", () async {
-      var q = new Query<GrandChildObject>()
+      var q = new Query<GrandChildObject>(ctx)
         ..where((g) => g.parents.parents.value1).equalTo(1)
         ..sortBy((g) => g.gid, QuerySortOrder.ascending);
 
@@ -406,7 +406,7 @@ void main() {
             }),
           ]));
 
-      q = new Query<GrandChildObject>()
+      q = new Query<GrandChildObject>(ctx)
         ..where((o) => o.parents.parents).identifiedBy(1)
         ..sortBy((g) => g.gid, QuerySortOrder.ascending);
       results = await q.fetch();
@@ -430,7 +430,7 @@ void main() {
     });
 
     test("Bidirectional implicit join", () async {
-      var q = new Query<ChildObject>()
+      var q = new Query<ChildObject>(ctx)
         ..where((o) => o.parents.rid).equalTo(1)
         ..where((o) => o.grandChild).isNotNull();
       var results = await q.fetch();

--- a/test/db/postgresql/belongs_to_fetch_test.dart
+++ b/test/db/postgresql/belongs_to_fetch_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
 
   tearDownAll(() async {
-    await ctx.persistentStore.close();
+    await ctx.close();
   });
 
   group("Assign non-join matchers to belongsToProperty", () {

--- a/test/db/postgresql/delete_test.dart
+++ b/test/db/postgresql/delete_test.dart
@@ -17,18 +17,18 @@ void main() {
     var m = new TestModel()
       ..email = "a@a.com"
       ..name = "joe";
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
 
     var inserted = await req.insert();
     expect(inserted.id, greaterThan(0));
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("id = @id", {"id": inserted.id});
 
     var count = await req.delete();
     expect(count, 1);
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("id = @id", {"id": inserted.id});
 
     var result = await req.fetch();
@@ -45,21 +45,21 @@ void main() {
         ..email = "$i@a.com"
         ..name = "joe";
 
-      var req = new Query<TestModel>()..values = m;
+      var req = new Query<TestModel>(context)..values = m;
 
       await req.insert();
     }
 
-    var req = new Query<TestModel>();
+    var req = new Query<TestModel>(context);
     var result = await req.fetch();
     expect(result.length, 10);
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("id = @id", {"id": 1});
     var count = await req.delete();
     expect(count, 1);
 
-    req = new Query<TestModel>();
+    req = new Query<TestModel>(context);
     result = await req.fetch();
     expect(result.length, 9);
   });
@@ -73,20 +73,20 @@ void main() {
         ..email = "$i@a.com"
         ..name = "joe";
 
-      var req = new Query<TestModel>()..values = m;
+      var req = new Query<TestModel>(context)..values = m;
 
       await req.insert();
     }
 
-    var req = new Query<TestModel>();
+    var req = new Query<TestModel>(context);
     var result = await req.fetch();
     expect(result.length, 10);
 
-    req = new Query<TestModel>()..canModifyAllInstances = true;
+    req = new Query<TestModel>(context)..canModifyAllInstances = true;
     var count = await req.delete();
     expect(count, 10);
 
-    req = new Query<TestModel>();
+    req = new Query<TestModel>(context);
     result = await req.fetch();
     expect(result.length, 0);
   });
@@ -100,23 +100,23 @@ void main() {
         ..email = "$i@a.com"
         ..name = "joe";
 
-      var req = new Query<TestModel>()..values = m;
+      var req = new Query<TestModel>(context)..values = m;
 
       await req.insert();
     }
 
-    var req = new Query<TestModel>();
+    var req = new Query<TestModel>(context);
     var result = await req.fetch();
     expect(result.length, 10);
 
     try {
-      req = new Query<TestModel>();
+      req = new Query<TestModel>(context);
       await req.delete();
     } on StateError catch (e) {
       expect(e.toString(), contains("'canModifyAllInstances'"));
     }
 
-    req = new Query<TestModel>();
+    req = new Query<TestModel>(context);
     result = await req.fetch();
     expect(result.length, 10);
   });
@@ -125,18 +125,18 @@ void main() {
     context = await contextWithModels([TestModel, RefModel]);
 
     var testModelObject = new TestModel()..name = "a";
-    var testModelReq = new Query<TestModel>()..values = testModelObject;
+    var testModelReq = new Query<TestModel>(context)..values = testModelObject;
     var testObj = await testModelReq.insert();
 
     var refModelObject = new RefModel()..test = testObj;
-    var refModelReq = new Query<RefModel>()..values = refModelObject;
+    var refModelReq = new Query<RefModel>(context)..values = refModelObject;
     var refObj = await refModelReq.insert();
 
-    testModelReq = new Query<TestModel>()..canModifyAllInstances = true;
+    testModelReq = new Query<TestModel>(context)..canModifyAllInstances = true;
     var count = await testModelReq.delete();
     expect(count, 1);
 
-    refModelReq = new Query<RefModel>()
+    refModelReq = new Query<RefModel>(context)
       ..returningProperties((r) => [r.id, r.test]);
     refObj = await refModelReq.fetchOne();
     expect(refObj.test, null);
@@ -146,16 +146,16 @@ void main() {
     context = await contextWithModels([GRestrict, GRestrictInverse]);
 
     var griObject = new GRestrictInverse()..name = "a";
-    var griReq = new Query<GRestrictInverse>()..values = griObject;
+    var griReq = new Query<GRestrictInverse>(context)..values = griObject;
     var testObj = await griReq.insert();
 
     var grObject = new GRestrict()..test = testObj;
-    var grReq = new Query<GRestrict>()..values = grObject;
+    var grReq = new Query<GRestrict>(context)..values = grObject;
     await grReq.insert();
 
     var successful = false;
     try {
-      griReq = new Query<GRestrictInverse>()..canModifyAllInstances = true;
+      griReq = new Query<GRestrictInverse>(context)..canModifyAllInstances = true;
       await griReq.delete();
       successful = true;
     } on QueryException catch (e) {
@@ -169,18 +169,18 @@ void main() {
     context = await contextWithModels([GCascade, GCascadeInverse]);
 
     var obj = new GCascadeInverse()..name = "a";
-    var req = new Query<GCascadeInverse>()..values = obj;
+    var req = new Query<GCascadeInverse>(context)..values = obj;
     var testObj = await req.insert();
 
     var cascadeObj = new GCascade()..test = testObj;
-    var cascadeReq = new Query<GCascade>()..values = cascadeObj;
+    var cascadeReq = new Query<GCascade>(context)..values = cascadeObj;
     await cascadeReq.insert();
 
-    req = new Query<GCascadeInverse>()..canModifyAllInstances = true;
+    req = new Query<GCascadeInverse>(context)..canModifyAllInstances = true;
     var count = await req.delete();
     expect(count, 1);
 
-    cascadeReq = new Query<GCascade>();
+    cascadeReq = new Query<GCascade>(context);
     var res = await cascadeReq.fetch();
     expect(res.length, 0);
   });

--- a/test/db/postgresql/delete_test.dart
+++ b/test/db/postgresql/delete_test.dart
@@ -7,7 +7,7 @@ void main() {
   ManagedContext context;
 
   tearDown(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 

--- a/test/db/postgresql/document_test.dart
+++ b/test/db/postgresql/document_test.dart
@@ -17,7 +17,7 @@ void main() {
 
   group("Basic queries", () {
     test("Can insert document object", () async {
-      final q = new Query<Obj>()
+      final q = new Query<Obj>(context)
         ..values.id = 1
         ..values.document = new Document({"k": "v"});
       final o = await q.insert();
@@ -25,7 +25,7 @@ void main() {
     });
 
     test("Can insert document array", () async {
-      final q = new Query<Obj>()
+      final q = new Query<Obj>(context)
         ..values.id = 1
         ..values.document = new Document([{"k": "v"}, 1]);
       final o = await q.insert();
@@ -33,32 +33,32 @@ void main() {
     });
 
     test("Can fetch document object", () async {
-      final q = new Query<Obj>()
+      final q = new Query<Obj>(context)
         ..values.id = 1
         ..values.document = new Document({"k": "v"});
       await q.insert();
 
-      final o = await (new Query<Obj>()).fetch();
+      final o = await (new Query<Obj>(context)).fetch();
       expect(o.first.document.data, {"k":"v"});
     });
 
     test("Can fetch array object", () async {
-      final q = new Query<Obj>()
+      final q = new Query<Obj>(context)
         ..values.id = 1
         ..values.document = new Document([{"k": "v"}, 1]);
       await q.insert();
 
-      final o = await (new Query<Obj>()).fetch();
+      final o = await (new Query<Obj>(context)).fetch();
       expect(o.first.document.data, [{"k":"v"}, 1]);
     });
 
     test("Can update value of document property", () async {
-      final q = new Query<Obj>()
+      final q = new Query<Obj>(context)
         ..values.id = 1
         ..values.document = new Document({"k": "v"});
       final o = await q.insert();
 
-      final u = new Query<Obj>()
+      final u = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(o.id)
         ..values.document = new Document(["a"]);
       final updated = await u.updateOne();
@@ -80,7 +80,7 @@ void main() {
 
       var counter = 1;
       await Future.forEach(testData, (data) async {
-        final q = new Query<Obj>()
+        final q = new Query<Obj>(context)
           ..values.id = counter
           ..values.document = new Document(data);
         await q.insert();
@@ -90,13 +90,13 @@ void main() {
 
     test("Can subscript top-level object and return primitive", () async {
       // {"key": "value"}
-      var q = new Query<Obj>()
+      var q = new Query<Obj>(context)
           ..where((o) => o.id).equalTo(1)
           ..returningProperties((obj) => [obj.id, obj.document["key"]]);
       var o = await q.fetchOne();
       expect(o.document.data, "value");
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(1)
         ..returningProperties((obj) => [obj.id, obj.document["unknownKey"]]);
       o = await q.fetchOne();
@@ -105,7 +105,7 @@ void main() {
 
     test("Can subscript top-level object and return array", () async {
       // {"key": [1, 2]},
-      var q = new Query<Obj>()
+      var q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(2)
         ..returningProperties((obj) => [obj.id, obj.document["key"]]);
       var o = await q.fetchOne();
@@ -114,7 +114,7 @@ void main() {
 
     test("Can subscript top-level object and return object", () async {
       // {"key": {"innerKey": "value"}}
-      final q = new Query<Obj>()
+      final q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(3)
         ..returningProperties((obj) => [obj.id, obj.document["key"]]);
       final o = await q.fetchOne();
@@ -123,25 +123,25 @@ void main() {
 
     test("Can subscript top-level array and return indexed primitive", () async {
       // [1, 2],
-      var q = new Query<Obj>()
+      var q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(4)
         ..returningProperties((obj) => [obj.id, obj.document[0]]);
       var o = await q.fetchOne();
       expect(o.document.data, 1);
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(4)
         ..returningProperties((obj) => [obj.id, obj.document[1]]);
       o = await q.fetchOne();
       expect(o.document.data, 2);
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(4)
         ..returningProperties((obj) => [obj.id, obj.document[-1]]);
       o = await q.fetchOne();
       expect(o.document.data, 2);
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(4)
         ..returningProperties((obj) => [obj.id, obj.document[3]]);
       o = await q.fetchOne();
@@ -150,19 +150,19 @@ void main() {
 
     test("Can subscript object and inner array", () async {
       // {"key": [1, 2]},
-      var q = new Query<Obj>()
+      var q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(2)
         ..returningProperties((obj) => [obj.id, obj.document["key"][0]]);
       var o = await q.fetchOne();
       expect(o.document.data, 1);
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(2)
         ..returningProperties((obj) => [obj.id, obj.document["foo"][0]]);
       o = await q.fetchOne();
       expect(o.document, null);
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(2)
         ..returningProperties((obj) => [obj.id, obj.document["key"][3]]);
       o = await q.fetchOne();
@@ -171,25 +171,25 @@ void main() {
 
     test("Can subscript array and inner object", () async {
       // [{"1": "v1"}, {"2": "v2"}]
-      var q = new Query<Obj>()
+      var q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(5)
         ..returningProperties((obj) => [obj.id, obj.document[0]["1"]]);
       var o = await q.fetchOne();
       expect(o.document.data, "v1");
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(5)
         ..returningProperties((obj) => [obj.id, obj.document[1]["2"]]);
       o = await q.fetchOne();
       expect(o.document.data, "v2");
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(5)
         ..returningProperties((obj) => [obj.id, obj.document[3]["2"]]);
       o = await q.fetchOne();
       expect(o.document, null);
 
-      q = new Query<Obj>()
+      q = new Query<Obj>(context)
         ..where((o) => o.id).equalTo(5)
         ..returningProperties((obj) => [obj.id, obj.document[0]["foo"]]);
       o = await q.fetchOne();

--- a/test/db/postgresql/document_test.dart
+++ b/test/db/postgresql/document_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   tearDown(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -13,10 +13,10 @@ void main() {
     context = await contextWithModels([TestModel]);
 
     var m = new TestModel(name: "Joe", email: "a@a.com");
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
     var item = await req.insert();
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("id = @id", {"id": item.id});
     item = await req.fetchOne();
 
@@ -40,12 +40,12 @@ void main() {
     context = await contextWithModels([TestModel]);
 
     var m = new TestModel(name: "Joe", email: "b@a.com");
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
 
     var item = await req.insert();
     var id = item.id;
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("id = @id", {"id": item.id})
       ..returningProperties((t) => [t.id, t.name]);
 
@@ -60,12 +60,12 @@ void main() {
     context = await contextWithModels([TestModel]);
 
     var m = new TestModel(name: "Joe", email: "b@a.com");
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
 
     await req.insert();
 
     try {
-      req = new Query<TestModel>()
+      req = new Query<TestModel>(context)
         ..returningProperties((t) => [t.id, t["foobar"]]);
       fail("unreachable");
     } on ArgumentError catch (e) {
@@ -81,11 +81,11 @@ void main() {
 
     for (int i = 0; i < 10; i++) {
       var m = new TestModel(name: "Joe$i", email: "asc$i@a.com");
-      var req = new Query<TestModel>()..values = m;
+      var req = new Query<TestModel>(context)..values = m;
       await req.insert();
     }
 
-    var req = new Query<TestModel>()
+    var req = new Query<TestModel>(context)
       ..sortBy((t) => t.email, QuerySortOrder.ascending)
       ..predicate = new QueryPredicate("email like @key", {"key": "asc%"});
 
@@ -95,7 +95,7 @@ void main() {
       expect(result[i].email, "asc$i@a.com");
     }
 
-    req = new Query<TestModel>()..sortBy((t) => t.id, QuerySortOrder.ascending);
+    req = new Query<TestModel>(context)..sortBy((t) => t.id, QuerySortOrder.ascending);
     result = await req.fetch();
 
     int idIndex = 0;
@@ -112,12 +112,12 @@ void main() {
     for (int i = 0; i < 10; i++) {
       var m = new TestModel(name: "Joe$i", email: "desc$i@a.com");
 
-      var req = new Query<TestModel>()..values = m;
+      var req = new Query<TestModel>(context)..values = m;
 
       await req.insert();
     }
 
-    var req = new Query<TestModel>()
+    var req = new Query<TestModel>(context)
       ..sortBy((t) => t.email, QuerySortOrder.descending)
       ..predicate = new QueryPredicate("email like @key", {"key": "desc%"});
     var result = await req.fetch();
@@ -131,7 +131,7 @@ void main() {
   test("Cannot sort by property that doesn't exist", () async {
     context = await contextWithModels([TestModel]);
     try {
-      new Query<TestModel>()
+      new Query<TestModel>(context)
         ..sortBy((u) => u["nonexisting"], QuerySortOrder.ascending);
       expect(true, false);
     } on ArgumentError catch (e) {
@@ -146,7 +146,7 @@ void main() {
   test("Cannot sort by relationship property", () async {
     context = await contextWithModels([GenUser, GenPost]);
     try {
-      new Query<GenUser>()
+      new Query<GenUser>(context)
           ..sortBy((u) => u.posts, QuerySortOrder.ascending);
       expect(true, false);
     } on ArgumentError catch (e) {
@@ -164,12 +164,12 @@ void main() {
     for (int i = 0; i < 10; i++) {
       var m = new TestModel(name: "Joe${i%2}", email: "multi$i@a.com");
 
-      var req = new Query<TestModel>()..values = m;
+      var req = new Query<TestModel>(context)..values = m;
 
       await req.insert();
     }
 
-    var req = new Query<TestModel>()
+    var req = new Query<TestModel>(context)
       ..sortBy((t) => t.name, QuerySortOrder.ascending)
       ..sortBy((t) => t.email, QuerySortOrder.descending)
       ..predicate = new QueryPredicate("email like @key", {"key": "multi%"});
@@ -212,12 +212,12 @@ void main() {
 
     var m = new TestModel(name: "invkey", email: "invkey@a.com");
 
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
     await req.insert();
 
 
     try {
-      req = new Query<TestModel>()
+      req = new Query<TestModel>(context)
         ..returningProperties((t) => [t.id, t["badkey"]]);
 
       fail("unreachable");
@@ -231,20 +231,20 @@ void main() {
 
     var u1 = new GenUser()..name = "Joe";
     var u2 = new GenUser()..name = "Fred";
-    u1 = await (new Query<GenUser>()..values = u1).insert();
-    u2 = await (new Query<GenUser>()..values = u2).insert();
+    u1 = await (new Query<GenUser>(context)..values = u1).insert();
+    u2 = await (new Query<GenUser>(context)..values = u2).insert();
 
     for (int i = 0; i < 5; i++) {
       var p1 = new GenPost()..text = "${2 * i}";
       p1.owner = u1;
-      await (new Query<GenPost>()..values = p1).insert();
+      await (new Query<GenPost>(context)..values = p1).insert();
 
       var p2 = new GenPost()..text = "${2 * i + 1}";
       p2.owner = u2;
-      await (new Query<GenPost>()..values = p2).insert();
+      await (new Query<GenPost>(context)..values = p2).insert();
     }
 
-    var req = new Query<GenPost>()
+    var req = new Query<GenPost>(context)
       ..predicate = new QueryPredicate("owner_id = @id", {"id": u1.id});
     var res = await req.fetch();
     expect(res.length, 5);
@@ -256,7 +256,7 @@ void main() {
             .length,
         5);
 
-    var query = new Query<GenPost>();
+    var query = new Query<GenPost>(context);
     query.where((o) => o.owner).identifiedBy(u1.id);
     res = await query.fetch();
 
@@ -274,10 +274,10 @@ void main() {
 
   test("Fetch object with null reference", () async {
     context = await contextWithModels([GenUser, GenPost]);
-    var p1 = await (new Query<GenPost>()..values = (new GenPost()..text = "1"))
+    var p1 = await (new Query<GenPost>(context)..values = (new GenPost()..text = "1"))
         .insert();
 
-    var req = new Query<GenPost>();
+    var req = new Query<GenPost>(context);
     p1 = await req.fetchOne();
 
     expect(p1.owner, isNull);
@@ -286,13 +286,13 @@ void main() {
   test("Omits specific keys", () async {
     context = await contextWithModels([Omit]);
 
-    var iq = new Query<Omit>()..values = (new Omit()..text = "foobar");
+    var iq = new Query<Omit>(context)..values = (new Omit()..text = "foobar");
 
     var result = await iq.insert();
     expect(result.id, greaterThan(0));
     expect(result.backing.contents["text"], isNull);
 
-    var fq = new Query<Omit>()
+    var fq = new Query<Omit>(context)
       ..predicate = new QueryPredicate("id=@id", {"id": result.id});
 
     var fResult = await fq.fetchOne();
@@ -308,12 +308,12 @@ void main() {
     var objects = [new GenUser()..name = "Joe", new GenUser()..name = "Bob"];
 
     for (var o in objects) {
-      var req = new Query<GenUser>()..values = o;
+      var req = new Query<GenUser>(context)..values = o;
       await req.insert();
     }
 
     try {
-      var q = new Query<GenUser>()..join(set: (u) => u.posts);
+      var q = new Query<GenUser>(context)..join(set: (u) => u.posts);
       await q.fetchOne();
 
       expect(true, false);
@@ -329,14 +329,14 @@ void main() {
       () async {
     context = await contextWithModels([GenUser, GenPost]);
 
-    var u1 = await (new Query<GenUser>()..values.name = "Joe").insert();
+    var u1 = await (new Query<GenUser>(context)..values.name = "Joe").insert();
 
-    await (new Query<GenPost>()
+    await (new Query<GenPost>(context)
           ..values.text = "text"
           ..values.owner = u1)
         .insert();
 
-    var q = new Query<GenPost>()..returningProperties((p) => [p.id, p.owner]);
+    var q = new Query<GenPost>(context)..returningProperties((p) => [p.id, p.owner]);
 
     var result = await q.fetchOne();
     expect(result.owner.id, 1);
@@ -344,7 +344,7 @@ void main() {
 
 
     try {
-      q = new Query<GenPost>()..returningProperties((p) => [p.id, p["owner_id"]]);
+      q = new Query<GenPost>(context)..returningProperties((p) => [p.id, p["owner_id"]]);
       expect(true, false);
     } on ArgumentError catch (e) {
       expect(e.toString(),
@@ -355,8 +355,8 @@ void main() {
   test("Can use public accessor to private property", () async {
     context = await contextWithModels([PrivateField]);
 
-    await (new Query<PrivateField>()).insert();
-    var q = new Query<PrivateField>();
+    await (new Query<PrivateField>(context)).insert();
+    var q = new Query<PrivateField>(context);
     var result = await q.fetchOne();
     expect(result.public, "x");
   });
@@ -364,22 +364,22 @@ void main() {
   test("When fetching valid enum value from db, is available as enum value and in where", () async {
     context = await contextWithModels([EnumObject]);
 
-    var q = new Query<EnumObject>()
+    var q = new Query<EnumObject>(context)
       ..values.enumValues = EnumValues.abcd;
 
     await q.insert();
 
-    q = new Query<EnumObject>();
+    q = new Query<EnumObject>(context);
     var result = await q.fetchOne();
     expect(result.enumValues, EnumValues.abcd);
     expect(result.asMap()["enumValues"], "abcd");
 
-    q = new Query<EnumObject>()
+    q = new Query<EnumObject>(context)
       ..where((o) => o.enumValues).equalTo(EnumValues.abcd);
     result = await q.fetchOne();
     expect(result, isNotNull);
 
-    q = new Query<EnumObject>()
+    q = new Query<EnumObject>(context)
       ..where((o) => o.enumValues).equalTo(EnumValues.efgh);
     result = await q.fetchOne();
     expect(result, isNull);
@@ -391,7 +391,7 @@ void main() {
     await context.persistentStore.execute("INSERT INTO _enumobject (enumValues) VALUES ('foobar')");
 
     try {
-      var q = new Query<EnumObject>();
+      var q = new Query<EnumObject>(context);
       await q.fetch();
       expect(true, false);
     } on StateError catch (e) {

--- a/test/db/postgresql/fetch_test.dart
+++ b/test/db/postgresql/fetch_test.dart
@@ -5,7 +5,7 @@ import '../../helpers.dart';
 void main() {
   ManagedContext context;
   tearDown(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 
@@ -27,7 +27,7 @@ void main() {
   test("Query with dynamic entity and mis-matched context throws exception", () async {
     context = await contextWithModels([TestModel]);
 
-    var someOtherContext = new ManagedContext.standalone(new ManagedDataModel([]), null);
+    var someOtherContext = new ManagedContext(new ManagedDataModel([]), null);
     try {
       new Query.forEntity(context.dataModel.entityForType(TestModel), someOtherContext);
       expect(true, false);

--- a/test/db/postgresql/has_many_fetch_test.dart
+++ b/test/db/postgresql/has_many_fetch_test.dart
@@ -23,7 +23,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await context?.persistentStore?.close();
+      await context?.close();
     });
 
     test("Fetch has-many relationship that has none returns empty OrderedSet",
@@ -229,7 +229,7 @@ void main() {
     });
 
     tearDownAll(() {
-      context?.persistentStore?.close();
+      context?.close();
     });
 
     test("Predicate impacts top-level objects when fetching object graph",
@@ -345,7 +345,7 @@ void main() {
     });
 
     tearDownAll(() {
-      context?.persistentStore?.close();
+      context?.close();
     });
 
     test(
@@ -398,7 +398,7 @@ void main() {
     });
 
     tearDownAll(() {
-      context?.persistentStore?.close();
+      context?.close();
     });
 
     test("Objects returned in join are not the same instance", () async {
@@ -422,7 +422,7 @@ void main() {
     });
 
     tearDownAll(() {
-      context?.persistentStore?.close();
+      context?.close();
     });
 
     test("Trying to fetch hasMany relationship through resultProperties fails",

--- a/test/db/postgresql/has_many_fetch_test.dart
+++ b/test/db/postgresql/has_many_fetch_test.dart
@@ -19,7 +19,7 @@ void main() {
     List<Parent> truth;
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      truth = await populate();
+      truth = await populate(context);
     });
 
     tearDownAll(() async {
@@ -28,7 +28,7 @@ void main() {
 
     test("Fetch has-many relationship that has none returns empty OrderedSet",
         () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..join(set: (p) => p.children)
         ..where((o) => o.name).equalTo("D");
 
@@ -44,7 +44,7 @@ void main() {
     test(
         "Fetch has-many relationship that is empty returns empty, and deeper nested relationships are ignored even when included",
         () async {
-      var q = new Query<Parent>()..where((o) => o.name).equalTo("D");
+      var q = new Query<Parent>(context)..where((o) => o.name).equalTo("D");
 
       q.join(set: (p) => p.children)
         ..join(object: (c) => c.toy)
@@ -62,7 +62,7 @@ void main() {
     test(
         "Fetch has-many relationship that is non-empty returns values for scalar properties in subobjects only",
         () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..join(set: (p) => p.children)
         ..where((o) => o.name).equalTo("C");
 
@@ -81,7 +81,7 @@ void main() {
     test(
         "Fetch has-many relationship, include has-one and has-many in that has-many, where bottom of graph has valid object for hasmany but not for hasone",
         () async {
-      var q = new Query<Parent>()..where((o) => o.name).equalTo("B");
+      var q = new Query<Parent>(context)..where((o) => o.name).equalTo("B");
 
       q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
@@ -113,7 +113,7 @@ void main() {
     test(
         "Fetch has-many relationship, include has-one and has-many in that has-many, where bottom of graph has valid object for hasone but not for hasmany",
         () async {
-      var q = new Query<Parent>()..where((o) => o.name).equalTo("A");
+      var q = new Query<Parent>(context)..where((o) => o.name).equalTo("A");
 
       q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
@@ -148,7 +148,7 @@ void main() {
     test(
         "Fetching multiple top-level instances and including one level of subobjects",
         () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..sortBy((p) => p.pid, QuerySortOrder.ascending)
         ..join(set: (p) => p.children)
         ..where((o) => o.name).oneOf(["A", "C", "D"]);
@@ -182,7 +182,7 @@ void main() {
     });
 
     test("Fetch entire graph", () async {
-      var q = new Query<Parent>();
+      var q = new Query<Parent>(context);
       q.join(set: (p) => p.children)
         ..join(object: (c) => c.toy)
         ..join(set: (c) => c.vaccinations);
@@ -225,7 +225,7 @@ void main() {
 
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      await populate();
+      await populate(context);
     });
 
     tearDownAll(() {
@@ -234,7 +234,7 @@ void main() {
 
     test("Predicate impacts top-level objects when fetching object graph",
         () async {
-      var q = new Query<Parent>()..where((o) => o.name).equalTo("A");
+      var q = new Query<Parent>(context)..where((o) => o.name).equalTo("A");
 
       q.join(set: (p) => p.children)
         ..sortBy((c) => c.cid, QuerySortOrder.ascending)
@@ -260,7 +260,7 @@ void main() {
 
     test("Predicate impacts 2nd level objects when fetching object graph",
         () async {
-      var q = new Query<Parent>();
+      var q = new Query<Parent>(context);
 
       q.join(set: (p) => p.children)
         ..where((o) => o.name).equalTo("C1")
@@ -287,7 +287,7 @@ void main() {
 
     test("Predicate impacts 3rd level objects when fetching object graph",
         () async {
-      var q = new Query<Parent>();
+      var q = new Query<Parent>(context);
 
       var childJoin = q.join(set: (p) => p.children)..join(object: (c) => c.toy);
       childJoin.join(set: (c) => c.vaccinations)..where((o) => o.kind).equalTo("V1");
@@ -325,7 +325,7 @@ void main() {
     test(
         "Predicate that omits top-level objects but would include lower level object return no results",
         () async {
-      var q = new Query<Parent>()..where((o) => o.pid).equalTo(5);
+      var q = new Query<Parent>(context)..where((o) => o.pid).equalTo(5);
 
       var childJoin = q.join(set: (p) => p.children)..join(object: (c) => c.toy);
       childJoin.join(set: (c) => c.vaccinations)..where((o) => o.kind).equalTo("V1");
@@ -341,7 +341,7 @@ void main() {
 
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      truth = await populate();
+      truth = await populate(context);
     });
 
     tearDownAll(() {
@@ -351,7 +351,7 @@ void main() {
     test(
         "Sort descriptor on top-level object doesn't impact lower level objects",
         () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..sortBy((p) => p.name, QuerySortOrder.descending);
 
       q.join(set: (p) => p.children)
@@ -394,7 +394,7 @@ void main() {
 
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      await populate();
+      await populate(context);
     });
 
     tearDownAll(() {
@@ -402,7 +402,7 @@ void main() {
     });
 
     test("Objects returned in join are not the same instance", () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..where((o) => o.pid).equalTo(1)
         ..join(set: (p) => p.children);
 
@@ -418,7 +418,7 @@ void main() {
 
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      await populate();
+      await populate(context);
     });
 
     tearDownAll(() {
@@ -428,7 +428,7 @@ void main() {
     test("Trying to fetch hasMany relationship through resultProperties fails",
         () async {
       try {
-        new Query<Parent>()
+        new Query<Parent>(context)
           ..returningProperties((p) => [p.pid, p.children]);
       } on ArgumentError catch (e) {
         expect(
@@ -442,7 +442,7 @@ void main() {
         () async {
 
       try {
-        final q = new Query<Parent>();
+        final q = new Query<Parent>(context);
         q.join(set: (p) => p.children)
           ..returningProperties((p) => [p.cid, p.vaccinations]);
 
@@ -505,7 +505,7 @@ class _Vaccine {
   Child child;
 }
 
-Future<List<Parent>> populate() async {
+Future<List<Parent>> populate(ManagedContext context) async {
   var modelGraph = <Parent>[];
   var parents = [
     new Parent()
@@ -538,19 +538,19 @@ Future<List<Parent>> populate() async {
   ];
 
   for (var p in parents) {
-    var q = new Query<Parent>()..values.name = p.name;
+    var q = new Query<Parent>(context)..values.name = p.name;
     var insertedParent = await q.insert();
     modelGraph.add(insertedParent);
 
     insertedParent.children = new ManagedSet<Child>();
     for (var child in p.children ?? <Child>[]) {
-      var childQ = new Query<Child>()
+      var childQ = new Query<Child>(context)
         ..values.name = child.name
         ..values.parent = insertedParent;
       insertedParent.children.add(await childQ.insert());
 
       if (child.toy != null) {
-        var toyQ = new Query<Toy>()
+        var toyQ = new Query<Toy>(context)
           ..values.name = child.toy.name
           ..values.child = insertedParent.children.last;
         insertedParent.children.last.toy = await toyQ.insert();
@@ -560,7 +560,7 @@ Future<List<Parent>> populate() async {
         insertedParent.children.last.vaccinations =
             new ManagedSet<Vaccine>.from(
                 await Future.wait(child.vaccinations.map((v) {
-          var vQ = new Query<Vaccine>()
+          var vQ = new Query<Vaccine>(context)
             ..values.kind = v.kind
             ..values.child = insertedParent.children.last;
           return vQ.insert();

--- a/test/db/postgresql/has_one_fetch_test.dart
+++ b/test/db/postgresql/has_one_fetch_test.dart
@@ -23,7 +23,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await context?.persistentStore?.close();
+      await context?.close();
     });
 
     test("Fetch has-one relationship that is null returns null for property",
@@ -195,7 +195,7 @@ void main() {
     });
 
     tearDownAll(() {
-      context?.persistentStore?.close();
+      context?.close();
     });
 
     test("Predicate impacts top-level objects when fetching object graph",
@@ -287,7 +287,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await context?.persistentStore?.close();
+      await context?.close();
     });
 
     test("Can fetch graph when omitting foreign or primary keys from query",
@@ -354,7 +354,7 @@ void main() {
     });
 
     tearDownAll(() {
-      context?.persistentStore?.close();
+      context?.close();
     });
 
     test("Objects returned in join are not the same instance", () async {
@@ -376,7 +376,7 @@ void main() {
     });
 
     tearDownAll(() {
-      context?.persistentStore?.close();
+      context?.close();
     });
 
     test("Trying to fetch hasOne relationship through resultProperties fails",

--- a/test/db/postgresql/has_one_fetch_test.dart
+++ b/test/db/postgresql/has_one_fetch_test.dart
@@ -19,7 +19,7 @@ void main() {
     List<Parent> truth;
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      truth = await populate();
+      truth = await populate(context);
     });
 
     tearDownAll(() async {
@@ -28,7 +28,7 @@ void main() {
 
     test("Fetch has-one relationship that is null returns null for property",
         () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..join(object: (p) => p.child)
         ..where((o) => o.name).equalTo("D");
 
@@ -45,7 +45,7 @@ void main() {
     test(
         "Fetch has-one relationship that is null returns null for property, and more nested has relationships are ignored",
         () async {
-      var q = new Query<Parent>()..where((o) => o.name).equalTo("D");
+      var q = new Query<Parent>(context)..where((o) => o.name).equalTo("D");
 
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
@@ -60,7 +60,7 @@ void main() {
       verifier(await q.fetchOne());
       verifier((await q.fetch()).first);
 
-      var dynQuery = new Query.forEntity(context.dataModel.entityForType(Parent))
+      var dynQuery = new Query.forEntity(context.dataModel.entityForType(Parent), context)
         ..where((o) => o["name"]).equalTo("D");
 
       dynQuery.join<ManagedObject>(object: (p) => p["child"])
@@ -73,7 +73,7 @@ void main() {
     test(
         "Fetch has-one relationship that is non-null returns value for property with scalar values only",
         () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..join(object: (p) => p.child)
         ..where((o) => o.name).equalTo("C");
 
@@ -92,7 +92,7 @@ void main() {
     test(
         "Fetch has-one relationship, include has-one and has-many in that has-one, where bottom of graph has valid object for hasmany but not for hasone",
         () async {
-      var q = new Query<Parent>()..where((o) => o.name).equalTo("B");
+      var q = new Query<Parent>(context)..where((o) => o.name).equalTo("B");
 
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
@@ -117,7 +117,7 @@ void main() {
     test(
         "Fetch has-one relationship, include has-one and has-many in that has-one, where bottom of graph is all null/empty",
         () async {
-      var q = new Query<Parent>()..where((o) => o.name).equalTo("C");
+      var q = new Query<Parent>(context)..where((o) => o.name).equalTo("C");
 
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
@@ -140,7 +140,7 @@ void main() {
     test(
         "Fetching multiple top-level instances and including next-level hasOne",
         () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..join(object: (p) => p.child)
         ..where((o) => o.name).oneOf(["C", "D"]);
 
@@ -156,7 +156,7 @@ void main() {
     });
 
     test("Fetch entire graph", () async {
-      var q = new Query<Parent>();
+      var q = new Query<Parent>(context);
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
         ..join(set: (c) => c.vaccinations);
@@ -191,7 +191,7 @@ void main() {
 
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      await populate();
+      await populate(context);
     });
 
     tearDownAll(() {
@@ -200,7 +200,7 @@ void main() {
 
     test("Predicate impacts top-level objects when fetching object graph",
         () async {
-      var q = new Query<Parent>()..where((o) => o.name).equalTo("A");
+      var q = new Query<Parent>(context)..where((o) => o.name).equalTo("A");
       q.join(object: (p) => p.child)
         ..join(object: (c) => c.toy)
         ..join(set: (c) => c.vaccinations)
@@ -220,7 +220,7 @@ void main() {
 
     test("Predicate impacts 2nd level objects when fetching object graph",
         () async {
-      var q = new Query<Parent>();
+      var q = new Query<Parent>(context);
       q.join(object: (p) => p.child)
         ..where((o) => o.name).equalTo("C1")
         ..join(object: (c) => c.toy)
@@ -246,7 +246,7 @@ void main() {
 
     test("Predicate impacts 3rd level objects when fetching object graph",
         () async {
-      var q = new Query<Parent>();
+      var q = new Query<Parent>(context);
       var childJoin = q.join(object: (p) => p.child)..join(object: (c) => c.toy);
       childJoin.join(set: (c) => c.vaccinations)..where((o) => o.kind).equalTo("V1");
 
@@ -269,7 +269,7 @@ void main() {
     test(
         "Predicate that omits top-level objects but would include lower level object return no results",
         () async {
-      var q = new Query<Parent>()..where((o) => o.pid).equalTo(5);
+      var q = new Query<Parent>(context)..where((o) => o.pid).equalTo(5);
 
       var childJoin = q.join(object: (p) => p.child)..join(object: (c) => c.toy);
       childJoin.join(set: (c) => c.vaccinations)..where((o) => o.kind).equalTo("V1");
@@ -283,7 +283,7 @@ void main() {
 
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      await populate();
+      await populate(context);
     });
 
     tearDownAll(() async {
@@ -292,7 +292,7 @@ void main() {
 
     test("Can fetch graph when omitting foreign or primary keys from query",
         () async {
-      var q = new Query<Parent>()..returningProperties((p) => [p.name]);
+      var q = new Query<Parent>(context)..returningProperties((p) => [p.name]);
 
       var childQuery = q.join(object: (p) => p.child)
         ..returningProperties((c) => [c.name]);
@@ -319,7 +319,7 @@ void main() {
     });
 
     test("Can specify result keys for all joined objects", () async {
-      var q = new Query<Parent>()..returningProperties((p) => [p.pid]);
+      var q = new Query<Parent>(context)..returningProperties((p) => [p.pid]);
 
       var childQuery = q.join(object: (p) => p.child)
         ..returningProperties((c) => [c.cid]);
@@ -350,7 +350,7 @@ void main() {
 
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      await populate();
+      await populate(context);
     });
 
     tearDownAll(() {
@@ -358,7 +358,7 @@ void main() {
     });
 
     test("Objects returned in join are not the same instance", () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..where((o) => o.pid).equalTo(1)
         ..join(object: (p) => p.child);
 
@@ -372,7 +372,7 @@ void main() {
 
     setUpAll(() async {
       context = await contextWithModels([Child, Parent, Toy, Vaccine]);
-      await populate();
+      await populate(context);
     });
 
     tearDownAll(() {
@@ -382,7 +382,7 @@ void main() {
     test("Trying to fetch hasOne relationship through resultProperties fails",
         () async {
       try {
-        new Query<Parent>()..returningProperties((p) => [p.pid, p.child]);
+        new Query<Parent>(context)..returningProperties((p) => [p.pid, p.child]);
         expect(true, false);
       } on ArgumentError catch (e) {
         expect(
@@ -392,7 +392,7 @@ void main() {
       }
 
       try {
-        var q = new Query<Parent>();
+        var q = new Query<Parent>(context);
         q.join(object: (p) => p.child)..returningProperties((c) => [c.cid, c.toy]);
         expect(true, false);
       } on ArgumentError catch (e) {
@@ -404,7 +404,7 @@ void main() {
     });
 
     test("Including paging on a join fails", () async {
-      var q = new Query<Parent>()
+      var q = new Query<Parent>(context)
         ..join(object: (p) => p.child)
         ..pageBy((p) => p.pid, QuerySortOrder.ascending);
 
@@ -469,7 +469,7 @@ class _Vaccine {
   Child child;
 }
 
-Future<List<Parent>> populate() async {
+Future<List<Parent>> populate(ManagedContext context) async {
   var modelGraph = <Parent>[];
   var parents = [
     new Parent()
@@ -494,18 +494,18 @@ Future<List<Parent>> populate() async {
   ];
 
   for (var p in parents) {
-    var q = new Query<Parent>()..values.name = p.name;
+    var q = new Query<Parent>(context)..values.name = p.name;
     var insertedParent = await q.insert();
     modelGraph.add(insertedParent);
 
     if (p.child != null) {
-      var childQ = new Query<Child>()
+      var childQ = new Query<Child>(context)
         ..values.name = p.child.name
         ..values.parent = insertedParent;
       insertedParent.child = await childQ.insert();
 
       if (p.child.toy != null) {
-        var toyQ = new Query<Toy>()
+        var toyQ = new Query<Toy>(context)
           ..values.name = p.child.toy.name
           ..values.child = insertedParent.child;
         insertedParent.child.toy = await toyQ.insert();
@@ -514,7 +514,7 @@ Future<List<Parent>> populate() async {
       if (p.child.vaccinations != null) {
         insertedParent.child.vaccinations = new ManagedSet<Vaccine>.from(
             await Future.wait(p.child.vaccinations.map((v) {
-          var vQ = new Query<Vaccine>()
+          var vQ = new Query<Vaccine>(context)
             ..values.kind = v.kind
             ..values.child = insertedParent.child;
           return vQ.insert();

--- a/test/db/postgresql/insert_test.dart
+++ b/test/db/postgresql/insert_test.dart
@@ -11,7 +11,7 @@ void main() {
   ManagedContext context;
 
   tearDown(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 

--- a/test/db/postgresql/insert_test.dart
+++ b/test/db/postgresql/insert_test.dart
@@ -19,7 +19,7 @@ void main() {
       () async {
     context = await contextWithModels([TestModel]);
 
-    var q = new Query<TestModel>()..values.id = 1;
+    var q = new Query<TestModel>(context)..values.id = 1;
 
     expect(q.values.id, 1);
   });
@@ -27,7 +27,7 @@ void main() {
   test("Insert Bad Key", () async {
     context = await contextWithModels([TestModel]);
 
-    var insertReq = new Query<TestModel>()
+    var insertReq = new Query<TestModel>(context)
       ..valueMap = {
         "name": "bob",
         "emailAddress": "bk@a.com",
@@ -50,10 +50,10 @@ void main() {
       ..name = "bob"
       ..emailAddress = "dup@a.com";
 
-    var insertReq = new Query<TestModel>()..values = m;
+    var insertReq = new Query<TestModel>(context)..values = m;
     await insertReq.insert();
 
-    var insertReqDup = new Query<TestModel>()..values = m;
+    var insertReqDup = new Query<TestModel>(context)..values = m;
 
     var successful = false;
     try {
@@ -66,7 +66,7 @@ void main() {
     expect(successful, false);
 
     m.emailAddress = "dup1@a.com";
-    var insertReqFollowup = new Query<TestModel>()..values = m;
+    var insertReqFollowup = new Query<TestModel>(context)..values = m;
 
     var result = await insertReqFollowup.insert();
 
@@ -76,19 +76,19 @@ void main() {
   test("Insert an object that violates a unique set constraint fails with conflict", () async {
     context = await contextWithModels([MultiUnique]);
 
-    var q = new Query<MultiUnique>()
+    var q = new Query<MultiUnique>(context)
       ..values.a = "a"
       ..values.b = "b";
 
     await q.insert();
 
-    q = new Query<MultiUnique>()
+    q = new Query<MultiUnique>(context)
       ..values.a = "a"
       ..values.b = "a";
 
     await q.insert();
 
-    q = new Query<MultiUnique>()
+    q = new Query<MultiUnique>(context)
       ..values.a = "a"
       ..values.b = "b";
     try {
@@ -106,7 +106,7 @@ void main() {
       ..name = "bob"
       ..emailAddress = "1@a.com";
 
-    var insertReq = new Query<TestModel>()..values = m;
+    var insertReq = new Query<TestModel>(context)..values = m;
 
     var result = await insertReq.insert();
 
@@ -123,11 +123,11 @@ void main() {
       ..name = "bob"
       ..emailAddress = "2@a.com";
 
-    var insertReq = new Query<TestModel>()..values = m;
+    var insertReq = new Query<TestModel>(context)..values = m;
 
     var result = await insertReq.insert();
 
-    var readReq = new Query<TestModel>()
+    var readReq = new Query<TestModel>(context)
       ..predicate =
           new QueryPredicate("emailAddress = @email", {"email": "2@a.com"});
 
@@ -140,7 +140,7 @@ void main() {
 
     var m = new TestModel()..emailAddress = "required@a.com";
 
-    var insertReq = new Query<TestModel>()..values = m;
+    var insertReq = new Query<TestModel>(context)..values = m;
 
     var successful = false;
     try {
@@ -158,7 +158,7 @@ void main() {
       () async {
     context = await contextWithModels([TestModel]);
 
-    var insertReq = new Query<TestModel>()
+    var insertReq = new Query<TestModel>(context)
       ..valueMap = {"id": 20, "name": "Bob"}
       ..returningProperties((t) => [t.id, t.name]);
 
@@ -167,7 +167,7 @@ void main() {
     expect(value.name, "Bob");
     expect(value.asMap().containsKey("emailAddress"), false);
 
-    insertReq = new Query<TestModel>()
+    insertReq = new Query<TestModel>(context)
       ..valueMap = {"id": 21, "name": "Bob"}
       ..returningProperties((t) => [t.id, t.name, t.emailAddress]);
 
@@ -183,13 +183,13 @@ void main() {
     context = await contextWithModels([GenUser, GenPost]);
 
     var u = new GenUser()..name = "Joe";
-    var q = new Query<GenUser>()..values = u;
+    var q = new Query<GenUser>(context)..values = u;
     u = await q.insert();
 
     var p = new GenPost()
       ..owner = u
       ..text = "1";
-    var pq = new Query<GenPost>()..values = p;
+    var pq = new Query<GenPost>(context)..values = p;
     p = await pq.insert();
 
     expect(p.id, greaterThan(0));
@@ -201,7 +201,7 @@ void main() {
 
     var t = new GenTime()..text = "hey";
 
-    var q = new Query<GenTime>()..values = t;
+    var q = new Query<GenTime>(context)..values = t;
 
     var result = await q.insert();
 
@@ -218,7 +218,7 @@ void main() {
       ..dateCreated = dt
       ..text = "hey";
 
-    var q = new Query<GenTime>()..values = t;
+    var q = new Query<GenTime>(context)..values = t;
 
     var result = await q.insert();
 
@@ -232,7 +232,7 @@ void main() {
 
     var t = new TransientModel()..value = "foo";
 
-    var q = new Query<TransientModel>()..values = t;
+    var q = new Query<TransientModel>(context)..values = t;
     var result = await q.insert();
     expect(result.transientValue, null);
   });
@@ -249,21 +249,21 @@ void main() {
 
     var u = new GenUser()..readFromMap(json);
 
-    var q = new Query<GenUser>()..values = u;
+    var q = new Query<GenUser>(context)..values = u;
 
     var result = await q.insert();
     expect(result.id, greaterThan(0));
     expect(result.name, "Bob");
     expect(result.posts, isNull);
 
-    var pq = new Query<GenPost>();
+    var pq = new Query<GenPost>(context);
     expect(await pq.fetch(), hasLength(0));
   });
 
   test("Insert object with no keys", () async {
     context = await contextWithModels([BoringObject]);
 
-    var q = new Query<BoringObject>();
+    var q = new Query<BoringObject>(context);
     var result = await q.insert();
     expect(result.id, greaterThan(0));
   });
@@ -271,8 +271,8 @@ void main() {
   test("Can use insert private properties", () async {
     context = await contextWithModels([PrivateField]);
 
-    await (new Query<PrivateField>()..values.public = "abc").insert();
-    var q = new Query<PrivateField>();
+    await (new Query<PrivateField>(context)..values.public = "abc").insert();
+    var q = new Query<PrivateField>(context);
     var result = await q.fetch();
     expect(result.first.public, "abc");
   });
@@ -280,7 +280,7 @@ void main() {
   test("Can use enum to set property to be stored in db", () async {
     context = await contextWithModels([EnumObject]);
 
-    var q = new Query<EnumObject>()
+    var q = new Query<EnumObject>(context)
       ..values.enumValues = EnumValues.efgh;
 
     var result = await q.insert();

--- a/test/db/postgresql/many_to_many_fetch_test.dart
+++ b/test/db/postgresql/many_to_many_fetch_test.dart
@@ -27,7 +27,7 @@ void main() {
   });
 
   tearDownAll(() async {
-    await ctx.persistentStore.close();
+    await ctx.close();
   });
 
   group("Explicit joins", () {

--- a/test/db/postgresql/many_to_many_fetch_test.dart
+++ b/test/db/postgresql/many_to_many_fetch_test.dart
@@ -23,7 +23,7 @@ void main() {
       Game
     ]);
     var _ = await populateModelGraph(ctx);
-    await populateGameSchedule();
+    await populateGameSchedule(ctx);
   });
 
   tearDownAll(() async {
@@ -32,7 +32,7 @@ void main() {
 
   group("Explicit joins", () {
     test("Can join across many to many relationship, from one side", () async {
-      var q = new Query<RootObject>()
+      var q = new Query<RootObject>(ctx)
         ..sortBy((r) => r.rid, QuerySortOrder.ascending);
 
       q.join(set: (r) => r.join)..join(object: (r) => r.other);
@@ -71,7 +71,7 @@ void main() {
 
     test("Can join across many to many relationship, from other side",
         () async {
-      var q = new Query<OtherRootObject>()
+      var q = new Query<OtherRootObject>(ctx)
         ..sortBy((o) => o.id, QuerySortOrder.ascending);
 
       q.join(set: (r) => r.join)..join(object: (r) => r.root);
@@ -110,7 +110,7 @@ void main() {
     });
 
     test("Can join from join table", () async {
-      var q = new Query<RootJoinObject>()
+      var q = new Query<RootJoinObject>(ctx)
         ..sortBy((r) => r.id, QuerySortOrder.ascending)
         ..join(object: (r) => r.other)
         ..join(object: (r) => r.root);
@@ -128,7 +128,7 @@ void main() {
 
   group("Implicit joins", () {
     test("Can use implicit matcher across many to many table", () async {
-      var q = new Query<RootObject>()
+      var q = new Query<RootObject>(ctx)
         ..sortBy((r) => r.rid, QuerySortOrder.ascending)
         ..where((o) => o.join.haveAtLeastOneWhere.other.value1).lessThan(4);
 
@@ -143,7 +143,7 @@ void main() {
     });
 
     test("Can use implicit join with join table to one side", () async {
-      var q = new Query<RootJoinObject>()..where((o) => o.root.value1).equalTo(1);
+      var q = new Query<RootJoinObject>(ctx)..where((o) => o.root.value1).equalTo(1);
       var results = await q.fetch();
       expect(
           results.map((r) => r.asMap()).toList(),
@@ -162,7 +162,7 @@ void main() {
     });
 
     test("Can use implicit join with join table to both sides", () async {
-      var q = new Query<RootJoinObject>()
+      var q = new Query<RootJoinObject>(ctx)
         ..where((o) => o.root.value1).equalTo(1)
         ..where((o) => o.other.value1).equalTo(1);
       var results = await q.fetch();
@@ -176,7 +176,7 @@ void main() {
             },
           ]));
 
-      q = new Query<RootJoinObject>()
+      q = new Query<RootJoinObject>(ctx)
         ..where((o) => o.root.value1).equalTo(1)
         ..where((o) => o.other.value1).equalTo(2);
       results = await q.fetch();
@@ -190,7 +190,7 @@ void main() {
             },
           ]));
 
-      q = new Query<RootJoinObject>()
+      q = new Query<RootJoinObject>(ctx)
         ..where((o) => o.root.value1).equalTo(2)
         ..where((o) => o.other.value1).equalTo(2);
       results = await q.fetch();
@@ -200,7 +200,7 @@ void main() {
 
   group("Self joins - standard", () {
     test("Can join by one relationship", () async {
-      var q = new Query<Team>()..sortBy((t) => t.id, QuerySortOrder.ascending);
+      var q = new Query<Team>(ctx)..sortBy((t) => t.id, QuerySortOrder.ascending);
 
       q.join(set: (t) => t.awayGames)..join(object: (g) => g.homeTeam);
 
@@ -246,7 +246,7 @@ void main() {
     });
 
     test("Can join by other relationship", () async {
-      var q = new Query<Team>()..sortBy((t) => t.id, QuerySortOrder.ascending);
+      var q = new Query<Team>(ctx)..sortBy((t) => t.id, QuerySortOrder.ascending);
 
       q.join(set: (t) => t.homeGames)..join(object: (g) => g.awayTeam);
       var results = await q.fetch();
@@ -292,7 +292,7 @@ void main() {
     });
 
     test("Can join from join table", () async {
-      var q = new Query<Game>()
+      var q = new Query<Game>(ctx)
         ..join(object: (g) => g.awayTeam)
         ..join(object: (g) => g.homeTeam)
         ..sortBy((g) => g.id, QuerySortOrder.ascending);
@@ -329,7 +329,7 @@ void main() {
         "Attempt to join many to many relationship on the same property throws an exception before executing",
         () async {
       try {
-        var q = new Query<Team>();
+        var q = new Query<Team>(ctx);
 
         q.join(set: (t) => t.homeGames)..join(object: (g) => g.homeTeam);
         expect(true, false);
@@ -342,7 +342,7 @@ void main() {
   group("Self joins - implicit", () {
     test("Can implicit join through join table", () async {
       // 'Teams that have played at Minnesota'
-      var q = new Query<Team>()
+      var q = new Query<Team>(ctx)
         ..sortBy((t) => t.id, QuerySortOrder.ascending)
         ..where((o) => o.awayGames.haveAtLeastOneWhere.homeTeam.name).contains("Minn");
       var results = await q.fetch();
@@ -353,7 +353,7 @@ void main() {
           ]));
 
       // 'Teams that have played at Iowa'
-      q = new Query<Team>()
+      q = new Query<Team>(ctx)
         ..sortBy((t) => t.id, QuerySortOrder.ascending)
         ..where((o) => o.awayGames.haveAtLeastOneWhere.homeTeam.name).contains("Iowa");
       results = await q.fetch();
@@ -362,7 +362,7 @@ void main() {
 
     test("Can implicit join from join table - one side", () async {
       // 'Games where Iowa was away'
-      var q = new Query<Game>()..where((o) => o.awayTeam.name).contains("Iowa");
+      var q = new Query<Game>(ctx)..where((o) => o.awayTeam.name).contains("Iowa");
       var results = await q.fetch();
       expect(
           results.map((g) => g.asMap()).toList(),
@@ -386,7 +386,7 @@ void main() {
 
     test("Can implicit join from join table - both sides", () async {
       // 'Games where Iowa played Wisconsin at home'
-      var q = new Query<Game>()
+      var q = new Query<Game>(ctx)
         ..where((o) => o.homeTeam.name).contains("Wisco")
         ..where((o) => o.awayTeam.name).contains("Iowa");
       var results = await q.fetch();
@@ -407,7 +407,7 @@ void main() {
         "Attempt to implicitly join many to many relationships on the same property throws an exception when executing",
         () async {
       try {
-        var q = new Query<Team>();
+        var q = new Query<Team>(ctx);
         q.join(set: (t) => t.awayGames)
           ..where((o) => o.awayTeam.name).contains("Minn");
         await q.fetch();
@@ -422,7 +422,7 @@ void main() {
   group("Self joins - standard + filter", () {
     test("Can filter returned nested objects by their values", () async {
       // 'All teams and the games they've played at Minnesota'
-      var q = new Query<Team>();
+      var q = new Query<Team>(ctx);
       q.join(set: (t) => t.awayGames)
         ..where((o) => o.homeTeam.name).contains("Minn");
       var results = await q.fetch();
@@ -478,7 +478,7 @@ class _Team {
   ManagedSet<Game> awayGames;
 }
 
-Future populateGameSchedule() async {
+Future populateGameSchedule(ManagedContext ctx) async {
   var teams = [
     new Team()..name = "Wisconsin",
     new Team()..name = "Minnesota",
@@ -486,7 +486,7 @@ Future populateGameSchedule() async {
   ];
 
   for (var t in teams) {
-    var q = new Query<Team>()..values = t;
+    var q = new Query<Team>(ctx)..values = t;
     t.id = (await q.insert()).id;
   }
 
@@ -509,7 +509,7 @@ Future populateGameSchedule() async {
   ];
 
   for (var g in games) {
-    var q = new Query<Game>()..values = g;
+    var q = new Query<Game>(ctx)..values = g;
     await q.insert();
   }
 }

--- a/test/db/postgresql/matcher_test.dart
+++ b/test/db/postgresql/matcher_test.dart
@@ -10,7 +10,7 @@ void main() {
     var counter = 0;
     var names = ["Bob", "Fred", "Tim", "Sally", "Kanye", "Lisa"];
     for (var name in names) {
-      var q = new Query<TestModel>()
+      var q = new Query<TestModel>(context)
         ..values.name = name
         ..values.email = "$counter@a.com";
       await q.insert();
@@ -18,12 +18,12 @@ void main() {
       counter++;
     }
 
-    var q = new Query<InnerModel>()
+    var q = new Query<InnerModel>(context)
       ..values.name = "Bob's"
       ..values.owner = (new TestModel()..id = 1);
     await q.insert();
 
-    q = new Query<InnerModel>()..values.name = "No one's";
+    q = new Query<InnerModel>(context)..values.name = "No one's";
     await q.insert();
   });
 
@@ -34,12 +34,12 @@ void main() {
 
   group("Equals matcher", () {
     test("Non-string value", () async {
-      var q = new Query<TestModel>()..where((p) => p.id).equalTo(1);
+      var q = new Query<TestModel>(context)..where((p) => p.id).equalTo(1);
       var results = await q.fetch();
       expect(results.length, 1);
       expect(results.first.id, 1);
 
-      q = new Query<TestModel>()..where((p) => p.id).not.equalTo(1);
+      q = new Query<TestModel>(context)..where((p) => p.id).not.equalTo(1);
 
       results = await q.fetch();
       expect(results.length, 5);
@@ -47,32 +47,32 @@ void main() {
     });
 
     test("String value, case sensitive default", () async {
-      var q = new Query<TestModel>()..where((o) => o.email).equalTo("0@a.com");
+      var q = new Query<TestModel>(context)..where((o) => o.email).equalTo("0@a.com");
       var results = await q.fetch();
       expect(results.length, 1);
       expect(results.first.id, 1);
 
-      q = new Query<TestModel>()..where((o) => o.email).not.equalTo("0@a.com");
+      q = new Query<TestModel>(context)..where((o) => o.email).not.equalTo("0@a.com");
       results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((tm) => tm.id == 1), false);
 
-      q = new Query<TestModel>()..where((o) => o.email).equalTo("0@A.com");
+      q = new Query<TestModel>(context)..where((o) => o.email).equalTo("0@A.com");
       results = await q.fetch();
       expect(results.length, 0);
 
-      q = new Query<TestModel>()..where((o) => o.email).not.equalTo("0@A.com");
+      q = new Query<TestModel>(context)..where((o) => o.email).not.equalTo("0@A.com");
       results = await q.fetch();
       expect(results.length, 6);
     });
 
     test("String value, case sensitive default", () async {
-      var q = new Query<TestModel>()..where((o) => o.email).equalTo("0@A.com", caseSensitive: false);
+      var q = new Query<TestModel>(context)..where((o) => o.email).equalTo("0@A.com", caseSensitive: false);
       var results = await q.fetch();
       expect(results.length, 1);
       expect(results.first.id, 1);
 
-      q = new Query<TestModel>()..where((o) => o.email).not.equalTo("0@A.com", caseSensitive: false);
+      q = new Query<TestModel>(context)..where((o) => o.email).not.equalTo("0@A.com", caseSensitive: false);
       results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((tm) => tm.email == "0@a.com"), false);
@@ -80,54 +80,54 @@ void main() {
   });
 
   test("Less than matcher", () async {
-    var q = new Query<TestModel>()..where((o) => o.id).lessThan(3);
+    var q = new Query<TestModel>(context)..where((o) => o.id).lessThan(3);
     var results = await q.fetch();
     expect(results.length, 2);
     expect(results.first.id, 1);
     expect(results.last.id, 2);
 
-    q = new Query<TestModel>()..where((o) => o.id).not.lessThan(3);
+    q = new Query<TestModel>(context)..where((o) => o.id).not.lessThan(3);
     results = await q.fetch();
     expect(results.length, 4);
     expect(results.every((tm) => tm.id >= 3), true);
   });
 
   test("Less than equal to matcher", () async {
-    var q = new Query<TestModel>()..where((o) => o.id).lessThanEqualTo(3);
+    var q = new Query<TestModel>(context)..where((o) => o.id).lessThanEqualTo(3);
     var results = await q.fetch();
     expect(results.length, 3);
     expect(results[0].id, 1);
     expect(results[1].id, 2);
     expect(results[2].id, 3);
 
-    q = new Query<TestModel>()..where((o) => o.id).not.lessThanEqualTo(3);
+    q = new Query<TestModel>(context)..where((o) => o.id).not.lessThanEqualTo(3);
     results = await q.fetch();
     expect(results.length, 3);
     expect(results.every((tm) => tm.id > 3), true);
   });
 
   test("Greater than matcher", () async {
-    var q = new Query<TestModel>()..where((o) => o.id).greaterThan(4);
+    var q = new Query<TestModel>(context)..where((o) => o.id).greaterThan(4);
     var results = await q.fetch();
     expect(results.length, 2);
     expect(results[0].id, 5);
     expect(results[1].id, 6);
 
-    q = new Query<TestModel>()..where((o) => o.id).not.greaterThan(4);
+    q = new Query<TestModel>(context)..where((o) => o.id).not.greaterThan(4);
     results = await q.fetch();
     expect(results.length, 4);
     expect(results.every((tm) => tm.id <= 4), true);
   });
 
   test("Greater than equal to matcher", () async {
-    var q = new Query<TestModel>()..where((o) => o.id).greaterThanEqualTo(4);
+    var q = new Query<TestModel>(context)..where((o) => o.id).greaterThanEqualTo(4);
     var results = await q.fetch();
     expect(results.length, 3);
     expect(results[0].id, 4);
     expect(results[1].id, 5);
     expect(results[2].id, 6);
 
-    q = new Query<TestModel>()..where((o) => o.id).not.greaterThanEqualTo(4);
+    q = new Query<TestModel>(context)..where((o) => o.id).not.greaterThanEqualTo(4);
     results = await q.fetch();
     expect(results.length, 3);
     expect(results.every((tm) => tm.id < 4), true);
@@ -135,44 +135,44 @@ void main() {
 
   group("Not equal matcher", () {
     test("Non-string value", () async {
-      var q = new Query<TestModel>()..where((o) => o.id).notEqualTo(1);
+      var q = new Query<TestModel>(context)..where((o) => o.id).notEqualTo(1);
       var results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((t) => t.id == 1), false);
 
-      q = new Query<TestModel>()..where((o) => o.id).not.notEqualTo(1);
+      q = new Query<TestModel>(context)..where((o) => o.id).not.notEqualTo(1);
       results = await q.fetch();
       expect(results.length, 1);
       expect(results.any((t) => t.id == 1), true);
     });
 
     test("String value, case sensitive default", () async {
-      var q = new Query<TestModel>()..where((o) => o.email).notEqualTo("0@a.com");
+      var q = new Query<TestModel>(context)..where((o) => o.email).notEqualTo("0@a.com");
       var results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((t) => t.id == 1), false);
 
-      q = new Query<TestModel>()..where((o) => o.email).not.notEqualTo("0@a.com");
+      q = new Query<TestModel>(context)..where((o) => o.email).not.notEqualTo("0@a.com");
       results = await q.fetch();
       expect(results.length, 1);
       expect(results.any((t) => t.id == 1), true);
 
-      q = new Query<TestModel>()..where((o) => o.email).notEqualTo("0@A.com");
+      q = new Query<TestModel>(context)..where((o) => o.email).notEqualTo("0@A.com");
       results = await q.fetch();
       expect(results.length, 6);
 
-      q = new Query<TestModel>()..where((o) => o.email).not.notEqualTo("0@A.com");
+      q = new Query<TestModel>(context)..where((o) => o.email).not.notEqualTo("0@A.com");
       results = await q.fetch();
       expect(results.length, 0);
     });
 
     test("String value, case sensitive default", () async {
-      var q = new Query<TestModel>()..where((o) => o.email).notEqualTo("0@A.com", caseSensitive: false);
+      var q = new Query<TestModel>(context)..where((o) => o.email).notEqualTo("0@A.com", caseSensitive: false);
       var results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((t) => t.id == 1), false);
 
-      q = new Query<TestModel>()..where((o) => o.email).not.notEqualTo("0@A.com", caseSensitive: false);
+      q = new Query<TestModel>(context)..where((o) => o.email).not.notEqualTo("0@A.com", caseSensitive: false);
       results = await q.fetch();
       expect(results.length, 1);
       expect(results.any((t) => t.id == 1), true);
@@ -180,13 +180,13 @@ void main() {
   });
 
   test("whereIn matcher", () async {
-    var q = new Query<TestModel>()..where((o) => o.id).oneOf([1, 2]);
+    var q = new Query<TestModel>(context)..where((o) => o.id).oneOf([1, 2]);
     var results = await q.fetch();
     expect(results.length, 2);
     expect(results[0].id, 1);
     expect(results[1].id, 2);
 
-    q = new Query<TestModel>()..where((o) => o.id).not.oneOf([1, 2]);
+    q = new Query<TestModel>(context)..where((o) => o.id).not.oneOf([1, 2]);
     results = await q.fetch();
     expect(results.length, 4);
     expect(results.any((t) => t.id == 1), false);
@@ -194,14 +194,14 @@ void main() {
   });
 
   test("whereBetween matcher", () async {
-    var q = new Query<TestModel>()..where((o) => o.id).between(2, 4);
+    var q = new Query<TestModel>(context)..where((o) => o.id).between(2, 4);
     var results = await q.fetch();
     expect(results.length, 3);
     expect(results[0].id, 2);
     expect(results[1].id, 3);
     expect(results[2].id, 4);
 
-    q = new Query<TestModel>()..where((o) => o.id).not.between(2, 4);
+    q = new Query<TestModel>(context)..where((o) => o.id).not.between(2, 4);
     results = await q.fetch();
     expect(results.length, 3);
 
@@ -212,14 +212,14 @@ void main() {
   });
 
   test("whereOutsideOf matcher", () async {
-    var q = new Query<TestModel>()..where((o) => o.id).outsideOf(2, 4);
+    var q = new Query<TestModel>(context)..where((o) => o.id).outsideOf(2, 4);
     var results = await q.fetch();
     expect(results.length, 3);
     expect(results[0].id, 1);
     expect(results[1].id, 5);
     expect(results[2].id, 6);
 
-    q = new Query<TestModel>()..where((o) => o.id).not.outsideOf(2, 4);
+    q = new Query<TestModel>(context)..where((o) => o.id).not.outsideOf(2, 4);
     results = await q.fetch();
     expect(results.length, 3);
 
@@ -230,36 +230,36 @@ void main() {
   });
 
   test("identifiedBy matcher", () async {
-    var q = new Query<InnerModel>()..where((o) => o.owner).identifiedBy(1);
+    var q = new Query<InnerModel>(context)..where((o) => o.owner).identifiedBy(1);
     var results = await q.fetch();
     expect(results.length, 1);
     expect(results.first.owner.id, 1);
 
     // Does not include null values; this is intentional.
-    q = new Query<InnerModel>()..where((o) => o.owner).not.identifiedBy(1);
+    q = new Query<InnerModel>(context)..where((o) => o.owner).not.identifiedBy(1);
     results = await q.fetch();
     expect(results.length, 0);
   });
 
   test("whereNull matcher", () async {
-    var q = new Query<InnerModel>()..where((o) => o.owner).isNull();
+    var q = new Query<InnerModel>(context)..where((o) => o.owner).isNull();
     var results = await q.fetch();
     expect(results.length, 1);
     expect(results.first.name, "No one's");
 
-    q = new Query<InnerModel>()..where((o) => o.owner).not.isNull();
+    q = new Query<InnerModel>(context)..where((o) => o.owner).not.isNull();
     results = await q.fetch();
     expect(results.length, 1);
     expect(results.first.name, "Bob's");
   });
 
   test("whereNotNull matcher", () async {
-    var q = new Query<InnerModel>()..where((o) => o.owner).isNotNull();
+    var q = new Query<InnerModel>(context)..where((o) => o.owner).isNotNull();
     var results = await q.fetch();
     expect(results.length, 1);
     expect(results.first.name, "Bob's");
 
-    q = new Query<InnerModel>()..where((o) => o.owner).not.isNotNull();
+    q = new Query<InnerModel>(context)..where((o) => o.owner).not.isNotNull();
     results = await q.fetch();
     expect(results.length, 1);
     expect(results.first.name, "No one's");
@@ -267,13 +267,13 @@ void main() {
 
   group("whereContains matcher", () {
     test("Case sensitive, default", () async {
-      var q = new Query<TestModel>()..where((o) => o.name).contains("y");
+      var q = new Query<TestModel>(context)..where((o) => o.name).contains("y");
       var results = await q.fetch();
       expect(results.length, 2);
       expect(results.first.name, "Sally");
       expect(results.last.name, "Kanye");
 
-      q = new Query<TestModel>()..where((o) => o.name).not.contains("y");
+      q = new Query<TestModel>(context)..where((o) => o.name).not.contains("y");
       results = await q.fetch();
       expect(results.length, 4);
       expect(results.any((tm) => tm.name == "Sally"), false);
@@ -281,13 +281,13 @@ void main() {
     });
 
     test("Case insensitive", () async {
-      var q = new Query<TestModel>()..where((o) => o.name).contains("Y", caseSensitive: false);
+      var q = new Query<TestModel>(context)..where((o) => o.name).contains("Y", caseSensitive: false);
       var results = await q.fetch();
       expect(results.length, 2);
       expect(results.first.name, "Sally");
       expect(results.last.name, "Kanye");
 
-      q = new Query<TestModel>()..where((o) => o.name).not.contains("Y", caseSensitive: false);
+      q = new Query<TestModel>(context)..where((o) => o.name).not.contains("Y", caseSensitive: false);
       results = await q.fetch();
       expect(results.length, 4);
       expect(results.any((tm) => tm.name == "Sally"), false);
@@ -297,24 +297,24 @@ void main() {
 
   group("whereBeginsWith matcher", () {
     test("Case sensitive, default", () async {
-      var q = new Query<TestModel>()..where((o) => o.name).beginsWith("B");
+      var q = new Query<TestModel>(context)..where((o) => o.name).beginsWith("B");
       var results = await q.fetch();
       expect(results.length, 1);
       expect(results.first.name, "Bob");
 
-      q = new Query<TestModel>()..where((o) => o.name).not.beginsWith("B");
+      q = new Query<TestModel>(context)..where((o) => o.name).not.beginsWith("B");
       results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((tm) => tm.name == "Bob"), false);
     });
 
     test("Case insensitive", () async {
-      var q = new Query<TestModel>()..where((o) => o.name).beginsWith("b", caseSensitive: false);
+      var q = new Query<TestModel>(context)..where((o) => o.name).beginsWith("b", caseSensitive: false);
       var results = await q.fetch();
       expect(results.length, 1);
       expect(results.first.name, "Bob");
 
-      q = new Query<TestModel>()..where((o) => o.name).not.beginsWith("b", caseSensitive: false);
+      q = new Query<TestModel>(context)..where((o) => o.name).not.beginsWith("b", caseSensitive: false);
       results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((tm) => tm.name == "Bob"), false);
@@ -323,24 +323,24 @@ void main() {
 
   group("whereEndsWith matcher", () {
     test("Case sensitive, default", () async {
-      var q = new Query<TestModel>()..where((o) => o.name).endsWith("m");
+      var q = new Query<TestModel>(context)..where((o) => o.name).endsWith("m");
       var results = await q.fetch();
       expect(results.length, 1);
       expect(results.first.name, "Tim");
 
-      q = new Query<TestModel>()..where((o) => o.name).not.endsWith("m");
+      q = new Query<TestModel>(context)..where((o) => o.name).not.endsWith("m");
       results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((tm) => tm.name == "Tim"), false);
     });
 
     test("Case insensitive", () async {
-      var q = new Query<TestModel>()..where((o) => o.name).endsWith("M", caseSensitive: false);
+      var q = new Query<TestModel>(context)..where((o) => o.name).endsWith("M", caseSensitive: false);
       var results = await q.fetch();
       expect(results.length, 1);
       expect(results.first.name, "Tim");
 
-      q = new Query<TestModel>()..where((o) => o.name).not.endsWith("M", caseSensitive: false);
+      q = new Query<TestModel>(context)..where((o) => o.name).not.endsWith("M", caseSensitive: false);
       results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((tm) => tm.name == "Tim"), false);

--- a/test/db/postgresql/matcher_test.dart
+++ b/test/db/postgresql/matcher_test.dart
@@ -28,7 +28,7 @@ void main() {
   });
 
   tearDownAll(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 

--- a/test/db/postgresql/paging_test.dart
+++ b/test/db/postgresql/paging_test.dart
@@ -15,7 +15,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await context?.persistentStore?.close();
+      await context?.close();
       context = null;
     });
 
@@ -71,7 +71,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await context?.persistentStore?.close();
+      await context?.close();
       context = null;
     });
 
@@ -289,7 +289,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await context?.persistentStore?.close();
+      await context?.close();
       context = null;
     });
 

--- a/test/db/postgresql/paging_test.dart
+++ b/test/db/postgresql/paging_test.dart
@@ -10,7 +10,7 @@ void main() {
       context = await contextWithModels([PageableTestModel]);
       for (int i = 0; i < 10; i++) {
         var p = new PageableTestModel()..value = "$i";
-        await (new Query<PageableTestModel>()..values = p).insert();
+        await (new Query<PageableTestModel>(context)..values = p).insert();
       }
     });
 
@@ -20,7 +20,7 @@ void main() {
     });
 
     test("Fetch limit and offset specify a particular row", () async {
-      var q = new Query<PageableTestModel>()
+      var q = new Query<PageableTestModel>(context)
         ..fetchLimit = 1
         ..offset = 2;
 
@@ -30,7 +30,7 @@ void main() {
     });
 
     test("Offset out of bounds returns no results", () async {
-      var q = new Query<PageableTestModel>()
+      var q = new Query<PageableTestModel>(context)
         ..fetchLimit = 1
         ..offset = 10;
 
@@ -39,7 +39,7 @@ void main() {
     });
 
     test("Offset respects ordering specified by sort descriptors", () async {
-      var q = new Query<PageableTestModel>()
+      var q = new Query<PageableTestModel>(context)
         ..fetchLimit = 2
         ..offset = 2
         ..sortBy((p) => p.id, QuerySortOrder.descending);
@@ -66,7 +66,7 @@ void main() {
       context = await contextWithModels([PageableTestModel]);
       for (int i = 0; i < 10; i++) {
         var p = new PageableTestModel()..value = "$i";
-        await (new Query<PageableTestModel>()..values = p).insert();
+        await (new Query<PageableTestModel>(context)..values = p).insert();
       }
     });
 
@@ -104,7 +104,7 @@ void main() {
     test("Ascending from known data set edge, limited to inside data set",
         () async {
       // select * from t where id > 0 order by id asc limit 5;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 0)
         ..fetchLimit = 5;
       var res = await req.fetch();
@@ -113,7 +113,7 @@ void main() {
 
     test("Ascending from first element, limited to inside data set", () async {
       // select * from t where id > 1 order by id asc limit 5;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 1)
         ..fetchLimit = 5;
       var res = await req.fetch();
@@ -122,7 +122,7 @@ void main() {
 
     test("Ascending from first element, extended past data set", () async {
       // select * from t where id > 0 order by id asc limit 15;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 0)
         ..fetchLimit = 15;
       var res = await req.fetch();
@@ -131,7 +131,7 @@ void main() {
 
     test("Ascending from inside data set to known edge", () async {
       // select * from t where id > 6 order by id asc limit 4;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 6)
         ..fetchLimit = 4;
       var res = await req.fetch();
@@ -140,7 +140,7 @@ void main() {
 
     test("Ascending from inside data set to past edge", () async {
       // select * from t where id > 6 order by id asc limit 5
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 6)
         ..fetchLimit = 5;
       var res = await req.fetch();
@@ -149,7 +149,7 @@ void main() {
 
     test("Ascending from edge of data set into outside data set", () async {
       // select * from t where id > 10 order by id asc limit 5
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 10)
         ..fetchLimit = 5;
       var res = await req.fetch();
@@ -158,7 +158,7 @@ void main() {
 
     test("Ascending from outside the data set and onward", () async {
       // select * from t where id > 11 order by id asc limit 10
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending, boundingValue: 11)
         ..fetchLimit = 10;
       var res = await req.fetch();
@@ -167,7 +167,7 @@ void main() {
 
     test("Ascending from null to all the way outside the data set", () async {
       // select * from t order by id asc limit 15
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending)
         ..fetchLimit = 15;
       var res = await req.fetch();
@@ -176,7 +176,7 @@ void main() {
 
     test("Ascending from null to halfway into the data set", () async {
       // select * from t order by id asc limit 5;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.ascending)
         ..fetchLimit = 5;
       var res = await req.fetch();
@@ -185,7 +185,7 @@ void main() {
 
     test("Descending from beginning of data set to before data set", () async {
       // select * from t where id < 0 order by id desc limit 10
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 0)
         ..fetchLimit = 10;
       var res = await req.fetch();
@@ -195,7 +195,7 @@ void main() {
     test("Descending from first element in data set to before data set",
         () async {
       // select * from t where id < 1 order by id desc limit 10;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 1)
         ..fetchLimit = 10;
       var res = await req.fetch();
@@ -204,7 +204,7 @@ void main() {
 
     test("Descending from middle of data set to before data set", () async {
       // select * from t where id < 4 order by id desc limit 10;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 4)
         ..fetchLimit = 10;
       var res = await req.fetch();
@@ -213,7 +213,7 @@ void main() {
 
     test("Descending from middle of data set to edge of data set", () async {
       // select * from t where id < 5 order by id desc limit 4;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 5)
         ..fetchLimit = 4;
       var res = await req.fetch();
@@ -224,7 +224,7 @@ void main() {
         "Descending from outside end of data set to beginning edge of data set",
         () async {
       // select * from t where id < 11 order by id desc limit 10;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 11)
         ..fetchLimit = 10;
       var res = await req.fetch();
@@ -234,7 +234,7 @@ void main() {
     test("Descending from last element in data set to middle of data set",
         () async {
       // select * from t where id < 10 order by id desc limit 5;
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 10)
         ..fetchLimit = 5;
       var res = await req.fetch();
@@ -244,7 +244,7 @@ void main() {
     test("Descending from outside end of data set to middle of data set",
         () async {
       // select * from t where id < 11 order by id desc limit 5
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending, boundingValue: 11)
         ..fetchLimit = 5;
       var res = await req.fetch();
@@ -253,7 +253,7 @@ void main() {
 
     test("Descending from null to beginning of data set", () async {
       // select * from t order by id desc limit 10
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending)
         ..fetchLimit = 10;
       var res = await req.fetch();
@@ -262,7 +262,7 @@ void main() {
 
     test("Descending from null to middle of data set", () async {
       // select * from t order by id desc limit 5
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.id, QuerySortOrder.descending)
         ..fetchLimit = 5;
       var res = await req.fetch();
@@ -284,7 +284,7 @@ void main() {
       context = await contextWithModels([PageableTestModel, HasMany, BelongsTo]);
       for (int i = 0; i < 10; i++) {
         var p = new PageableTestModel()..value = "$i";
-        await (new Query<PageableTestModel>()..values = p).insert();
+        await (new Query<PageableTestModel>(context)..values = p).insert();
       }
     });
 
@@ -294,7 +294,7 @@ void main() {
     });
 
     test("Incorrect type for boundingValue", () async {
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.value, QuerySortOrder.ascending, boundingValue: 0);
 
       try {
@@ -308,7 +308,7 @@ void main() {
 
     test("Page property doesn't exist throws error", () async {
       try {
-        var _ = new Query<PageableTestModel>()
+        var _ = new Query<PageableTestModel>(context)
           ..pageBy((p) => p["foobar"], QuerySortOrder.ascending,
               boundingValue: "0");
 
@@ -319,7 +319,7 @@ void main() {
     });
 
     test("Query when not fetching paging property still succeeds", () async {
-      var req = new Query<PageableTestModel>()
+      var req = new Query<PageableTestModel>(context)
         ..pageBy((p) => p.value, QuerySortOrder.ascending, boundingValue: "0")
         ..returningProperties((p) => [p.id])
         ..fetchLimit = 5;
@@ -329,7 +329,7 @@ void main() {
 
     test("Page by relationship fails", () async {
       try {
-        new Query<HasMany>()
+        new Query<HasMany>(context)
           ..pageBy((p) => p.objects, QuerySortOrder.ascending);
         expect(true, false);
       } on ArgumentError catch (e) {

--- a/test/db/postgresql/tiered_where_test.dart
+++ b/test/db/postgresql/tiered_where_test.dart
@@ -26,7 +26,7 @@ void main() {
   });
 
   tearDownAll(() async {
-    await ctx.persistentStore.close();
+    await ctx.close();
   });
 
   group("Joins return appropriate properties", () {

--- a/test/db/postgresql/tiered_where_test.dart
+++ b/test/db/postgresql/tiered_where_test.dart
@@ -33,7 +33,7 @@ void main() {
     // This group ensures that the right fields are returned and turned into objects,
     // not whether or not the right objects are returned.
     test("Values are not returned from implicitly joined tables", () async {
-      var q = new Query<RootObject>()..where((o) => o.child.cid).greaterThan(1);
+      var q = new Query<RootObject>(ctx)..where((o) => o.child.cid).greaterThan(1);
       var results = await q.fetch();
 
       for (var r in results) {
@@ -46,7 +46,7 @@ void main() {
     });
 
     test("Objects have default values when explicitly joined", () async {
-      var q = new Query<RootObject>()..join(object: (r) => r.child);
+      var q = new Query<RootObject>(ctx)..join(object: (r) => r.child);
       var results = await q.fetch();
 
       for (var r in results) {
@@ -73,7 +73,7 @@ void main() {
     test(
         "Query with both explicit and implicit join only returns values for explicit join",
         () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
 
       q.join(object: (r) => r.child)..where((o) => o.grandChild.gid).greaterThan(1);
       var results = await q.fetch();
@@ -101,7 +101,7 @@ void main() {
     });
 
     test("Nested explicit joins return values for all tables", () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
 
       q.join(object: (r) => r.child)..join(object: (c) => c.grandChild);
 
@@ -141,7 +141,7 @@ void main() {
 
     test("Query can specify resultProperties values when explicitly joined",
         () async {
-      var q = new Query<RootObject>()..returningProperties((r) => [r.rid]);
+      var q = new Query<RootObject>(ctx)..returningProperties((r) => [r.rid]);
 
       q.join(object: (r) => r.child)..returningProperties((c) => [c.cid]);
 
@@ -161,7 +161,7 @@ void main() {
     test(
         "Query with nested explicit joins can specify resultProperties for all objects",
         () async {
-      var q = new Query<RootObject>()..returningProperties((r) => [r.rid]);
+      var q = new Query<RootObject>(ctx)..returningProperties((r) => [r.rid]);
 
       var cq = q.join(object: (r) => r.child)..returningProperties((c) => [c.cid]);
 
@@ -190,7 +190,7 @@ void main() {
 
   group("With where clauses on root object", () {
     test("Implicity joining related object", () async {
-      var q = new Query<RootObject>()..where((o) => o.child.cid).equalTo(1);
+      var q = new Query<RootObject>(ctx)..where((o) => o.child.cid).equalTo(1);
       var results = await q.fetch();
 
       var inMemoryMatch = rootObjects.firstWhere((r) => r.child?.cid == 1);
@@ -199,7 +199,7 @@ void main() {
     });
 
     test("Explicitly joining related object", () async {
-      var q = new Query<RootObject>()..where((o) => o.rid).greaterThan(1);
+      var q = new Query<RootObject>(ctx)..where((o) => o.rid).greaterThan(1);
 
       q.join(set: (r) => r.children)..where((o) => o.cid).greaterThan(5);
 
@@ -217,7 +217,7 @@ void main() {
     });
 
     test("Explicitly joining related objects, nested implicit join", () async {
-      var q = new Query<RootObject>()..where((o) => o.rid).equalTo(1);
+      var q = new Query<RootObject>(ctx)..where((o) => o.rid).equalTo(1);
       q.join(set: (r) => r.children)
         ..where((o) => o.grandChildren.haveAtLeastOneWhere.gid).equalTo(5);
 
@@ -230,7 +230,7 @@ void main() {
 
     test("Explicitly joining related objects and nested related objects",
         () async {
-      var q = new Query<RootObject>()..where((o) => o.rid).equalTo(1);
+      var q = new Query<RootObject>(ctx)..where((o) => o.rid).equalTo(1);
 
       var cq = q.join(set: (r) => r.children);
 
@@ -255,7 +255,7 @@ void main() {
     });
 
     test("Nested implicit joins are combined", () async {
-      var q = new Query<RootObject>()
+      var q = new Query<RootObject>(ctx)
         ..where((o) => o.children.haveAtLeastOneWhere.cid).equalTo(2)
         ..where
             ((o) => o.children
@@ -269,7 +269,7 @@ void main() {
       expect(results.first.rid, 1);
       expect(results.first.backing.contents.containsKey("children"), false);
 
-      q = new Query<RootObject>()
+      q = new Query<RootObject>(ctx)
         ..where((o) => o.children.haveAtLeastOneWhere.cid).equalTo(2)
         ..where
           ((o) => o.children
@@ -284,7 +284,7 @@ void main() {
 
   group("With where clauses on child object", () {
     test("Explicit joins do not impact returned root objects", () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
       q.join(object: (r) => r.child)..where((o) => o.cid).equalTo(1);
       var results = await q.fetch();
 
@@ -299,7 +299,7 @@ void main() {
     test(
         "Implicit join on child affects child object returned, but not root objects",
         () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
       q.join(set: (r) => r.children)..where((o) => o.grandChild.gid).equalTo(4);
       var results = await q.fetch();
 
@@ -314,7 +314,7 @@ void main() {
     test(
         "Where clause on child + implicit join to granchild can find overly identified object",
         () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
       q.join(set: (r) => r.children)
         ..where((o) => o.cid).equalTo(2)
         ..where((o) => o.grandChildren.haveAtLeastOneWhere.gid).equalTo(6);
@@ -332,7 +332,7 @@ void main() {
     test(
         "Where clause on child + implicit join to grandchild returns empty if conditions conflict",
         () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
       q.join(set: (r) => r.children)
         ..where((o) => o.cid).equalTo(4)
         ..where((o) => o.grandChildren.haveAtLeastOneWhere.gid).equalTo(6);
@@ -345,7 +345,7 @@ void main() {
     test(
         "Where clause on child + implicit join to grandchild returns appropriate matches",
         () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
       q.join(set: (r) => r.children)
         ..where((o) => o.cid).lessThanEqualTo(5)
         ..where((o) => o.grandChildren.haveAtLeastOneWhere.gid).greaterThan(5);
@@ -368,7 +368,7 @@ void main() {
     test(
         "Explicit join on child and grandchild, retains all root objects and child objects",
         () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
       var cq = q.join(set: (r) => r.children);
       cq.join(set: (c) => c.grandChildren)..where((o) => o.gid).equalTo(5);
 
@@ -412,7 +412,7 @@ void main() {
     test(
         "An explicit and implicit join on the same table return the keys of the explicit join",
         () async {
-      var q = new Query<RootObject>()..where((o) => o.child.value1).greaterThan(0);
+      var q = new Query<RootObject>(ctx)..where((o) => o.child.value1).greaterThan(0);
 
       q.join(object: (r) => r.child)..returningProperties((c) => [c.cid]);
 
@@ -431,7 +431,7 @@ void main() {
     test(
         "An explicit and implicit join on same table combine predicates and have appropriate impact on root objects",
         () async {
-      var q = new Query<RootObject>()
+      var q = new Query<RootObject>(ctx)
         ..where((o) => o.children.haveAtLeastOneWhere.cid).greaterThan(5);
 
       q.join(set: (r) => r.children)..where((o) => o.cid).lessThan(10);
@@ -452,7 +452,7 @@ void main() {
 
   group("Filtering by existence", () {
     test("WhereNotNull on hasMany", () async {
-      var q = new Query<RootObject>()..where((o) => o.children).isNotNull();
+      var q = new Query<RootObject>(ctx)..where((o) => o.children).isNotNull();
       var results = await q.fetch();
 
       expect(results.length, 3);
@@ -463,7 +463,7 @@ void main() {
     });
 
     test("WhereNull on hasMany", () async {
-      var q = new Query<RootObject>()..where((o) => o.children).isNull();
+      var q = new Query<RootObject>(ctx)..where((o) => o.children).isNull();
       var results = await q.fetch();
 
       expect(results.length, 2);
@@ -473,7 +473,7 @@ void main() {
     });
 
     test("WhereNotNull on hasOne", () async {
-      var q = new Query<RootObject>()..where((o) => o.child).isNotNull();
+      var q = new Query<RootObject>(ctx)..where((o) => o.child).isNotNull();
       var results = await q.fetch();
 
       expect(results.length, 3);
@@ -484,7 +484,7 @@ void main() {
     });
 
     test("WhereNull on hasOne", () async {
-      var q = new Query<RootObject>()..where((o) => o.child).isNull();
+      var q = new Query<RootObject>(ctx)..where((o) => o.child).isNull();
       var results = await q.fetch();
 
       expect(results.length, 2);
@@ -497,7 +497,7 @@ void main() {
   group("Same entity, different relationship property", () {
     test("Where clause on root object for two properties with same entity type",
         () async {
-      var q = new Query<RootObject>()
+      var q = new Query<RootObject>(ctx)
         ..where((o) => o.children.haveAtLeastOneWhere.cid).greaterThan(3)
         ..where((o) => o.child.cid).equalTo(1);
       var results = await q.fetch();
@@ -507,7 +507,7 @@ void main() {
       expect(results.first.child, isNull);
       expect(results.first.children, isNull);
 
-      q = new Query<RootObject>()
+      q = new Query<RootObject>(ctx)
         ..where((o) => o.children.haveAtLeastOneWhere.cid).greaterThan(10)
         ..where((o) => o.child.cid).equalTo(1);
       results = await q.fetch();
@@ -516,7 +516,7 @@ void main() {
     });
 
     test("Join on on two properties with same entity type", () async {
-      var q = new Query<RootObject>();
+      var q = new Query<RootObject>(ctx);
 
       q.join(set: (r) => r.children)..where((o) => o.cid).greaterThan(3);
 
@@ -536,7 +536,7 @@ void main() {
 
   group("Can use deeply nested property when building where", () {
     test("From has-one", () async {
-      var q = new Query<RootObject>()
+      var q = new Query<RootObject>(ctx)
           ..where((o) => o.child.grandChild.gid)
           .equalTo(1);
       final result = await q.fetch();
@@ -546,7 +546,7 @@ void main() {
     });
 
     test("From belongs-to-one", () async {
-      var q = new Query<GrandChildObject>()
+      var q = new Query<GrandChildObject>(ctx)
         ..where((o) => o.parent.parent.rid)
             .equalTo(1);
       final result = await q.fetch();
@@ -556,7 +556,7 @@ void main() {
     });
 
     test("From belongs-to-many", () async {
-      var q = new Query<GrandChildObject>()
+      var q = new Query<GrandChildObject>(ctx)
         ..sortBy((o) => o.gid, QuerySortOrder.ascending)
         ..where((o) => o.parents.parents.rid)
             .equalTo(1);

--- a/test/db/postgresql/typing_test.dart
+++ b/test/db/postgresql/typing_test.dart
@@ -18,7 +18,7 @@ void main() {
   test("Values get typed when used in predicate", () async {
     context = await contextWithModels([TestModel]);
 
-    final q = new Query<TestModel>()
+    final q = new Query<TestModel>(context)
       ..where((o) => o.id).equalTo(1)
       ..where((o) => o.n).equalTo("a")
       ..where((o) => o.t).equalTo(new DateTime.now())
@@ -40,7 +40,7 @@ void main() {
   test("Values get typed when used as insertion values", () async {
     context = await contextWithModels([TestModel]);
 
-    final q = new Query<TestModel>()
+    final q = new Query<TestModel>(context)
       ..values.id = 1
       ..values.n = "a"
       ..values.t = new DateTime.now()

--- a/test/db/postgresql/typing_test.dart
+++ b/test/db/postgresql/typing_test.dart
@@ -11,7 +11,7 @@ import '../../helpers.dart';
 void main() {
   ManagedContext context;
   tearDown(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 

--- a/test/db/postgresql/update_test.dart
+++ b/test/db/postgresql/update_test.dart
@@ -17,14 +17,14 @@ void main() {
       ..name = "Bob"
       ..emailAddress = "1@a.com";
 
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
     await req.insert();
 
     m
       ..name = "Fred"
       ..emailAddress = "2@a.com";
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("name = @name", {"name": "Bob"})
       ..values = m;
 
@@ -38,20 +38,20 @@ void main() {
   test("Setting relationship to a new value succeeds", () async {
     context = await contextWithModels([Child, Parent]);
 
-    var q = new Query<Parent>()..values.name = "Bob";
+    var q = new Query<Parent>(context)..values.name = "Bob";
     var parent = await q.insert();
 
-    var childQuery = new Query<Child>()
+    var childQuery = new Query<Child>(context)
       ..values.name = "Fred"
       ..values.parent = parent;
 
     var child = await childQuery.insert();
     expect(child.parent.id, parent.id);
 
-    q = new Query<Parent>()..values.name = "Sally";
+    q = new Query<Parent>(context)..values.name = "Sally";
     var newParent = await q.insert();
 
-    childQuery = new Query<Child>()
+    childQuery = new Query<Child>(context)
       ..where((o) => o.id).equalTo(child.id)
       ..values.parent = newParent;
     child = (await childQuery.update()).first;
@@ -62,17 +62,17 @@ void main() {
     context = await contextWithModels([Child, Parent]);
 
     var parent = new Parent()..name = "Bob";
-    var q = new Query<Parent>()..values = parent;
+    var q = new Query<Parent>(context)..values = parent;
     parent = await q.insert();
 
     var child = new Child()
       ..name = "Fred"
       ..parent = parent;
-    var childQuery = new Query<Child>()..values = child;
+    var childQuery = new Query<Child>(context)..values = child;
     child = await childQuery.insert();
     expect(child.parent.id, parent.id);
 
-    childQuery = new Query<Child>()
+    childQuery = new Query<Child>(context)
       ..where((o) => o.id).equalTo(child.id)
       ..values = (new Child()..parent = null);
     child = (await childQuery.update()).first;
@@ -86,21 +86,21 @@ void main() {
       ..name = "Bob"
       ..emailAddress = "1@a.com";
 
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
     await req.insert();
 
     m
       ..name = "Fred"
       ..emailAddress = "2@a.com";
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("name = @name", {"name": "John"})
       ..values = m;
 
     var response = await req.update();
     expect(response.length, 0);
 
-    req = new Query<TestModel>();
+    req = new Query<TestModel>(context);
     var fetchResponse = await req.fetchOne();
     expect(fetchResponse.name, "Bob");
     expect(fetchResponse.emailAddress, "1@a.com");
@@ -113,17 +113,17 @@ void main() {
       ..name = "Bob"
       ..emailAddress = "1@a.com";
 
-    var req = new Query<TestModel>()..values = m1;
+    var req = new Query<TestModel>(context)..values = m1;
     m1 = await req.insert();
 
     var m2 = new TestModel()
       ..name = "Fred"
       ..emailAddress = "2@a.com";
 
-    req = new Query<TestModel>()..values = m2;
+    req = new Query<TestModel>(context)..values = m2;
     await req.insert();
 
-    var q = new Query<TestModel>()
+    var q = new Query<TestModel>(context)
       ..where((o) => o.name).equalTo("Bob")
       ..values = (new TestModel()..emailAddress = "3@a.com");
 
@@ -140,22 +140,22 @@ void main() {
       ..name = "Bob"
       ..emailAddress = "1@a.com";
 
-    m1 = await (new Query<TestModel>()..values = m1).insert();
+    m1 = await (new Query<TestModel>(context)..values = m1).insert();
 
-    await (new Query<TestModel>()
+    await (new Query<TestModel>(context)
           ..values = (new TestModel()
             ..name = "Fred"
             ..emailAddress = "2@a.com"))
         .insert();
 
-    var updateQuery = new Query<TestModel>()
+    var updateQuery = new Query<TestModel>(context)
       ..where((o) => o.emailAddress).equalTo("1@a.com")
       ..values.emailAddress = "3@a.com";
     var updatedObject = (await updateQuery.update()).first;
 
     expect(updatedObject.emailAddress, "3@a.com");
 
-    var allUsers = await (new Query<TestModel>()).fetch();
+    var allUsers = await (new Query<TestModel>(context)).fetch();
     expect(allUsers.length, 2);
     expect(allUsers.firstWhere((m) => m.id == m1.id).emailAddress, "3@a.com");
     expect(allUsers.firstWhere((m) => m.id != m1.id).emailAddress, "2@a.com");
@@ -168,10 +168,10 @@ void main() {
       ..name = "Bob"
       ..emailAddress = "1@a.com";
 
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
     await req.insert();
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("name = @name", {"name": "Bob"})
       ..values.name = "John";
 
@@ -179,7 +179,7 @@ void main() {
     expect(response.name, "John");
     expect(response.emailAddress, "1@a.com");
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("name = @name", {"name": "Bob"})
       ..values.name = "John";
 
@@ -198,12 +198,12 @@ void main() {
       ..name = "Fred"
       ..emailAddress = "2@a.com";
 
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
     await req.insert();
-    req = new Query<TestModel>()..values = fred;
+    req = new Query<TestModel>(context)..values = fred;
     await req.insert();
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..predicate = new QueryPredicate("name is not null", null)
       ..values.name = "Joe";
 
@@ -226,12 +226,12 @@ void main() {
       ..name = "Fred"
       ..emailAddress = "2@a.com";
 
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
     await req.insert();
-    req = new Query<TestModel>()..values = fred;
+    req = new Query<TestModel>(context)..values = fred;
     await req.insert();
 
-    req = new Query<TestModel>()..values.name = "Joe";
+    req = new Query<TestModel>(context)..values.name = "Joe";
 
     try {
       var _ = await req.update();
@@ -251,12 +251,12 @@ void main() {
       ..name = "Fred"
       ..emailAddress = "2@a.com";
 
-    var req = new Query<TestModel>()..values = m;
+    var req = new Query<TestModel>(context)..values = m;
     await req.insert();
-    req = new Query<TestModel>()..values = fred;
+    req = new Query<TestModel>(context)..values = fred;
     await req.insert();
 
-    req = new Query<TestModel>()
+    req = new Query<TestModel>(context)
       ..canModifyAllInstances = true
       ..values.name = "Fred";
 
@@ -278,12 +278,12 @@ void main() {
         ..emailAddress = "2@a.com"
     ];
     for (var o in objects) {
-      var req = new Query<TestModel>()..values = o;
+      var req = new Query<TestModel>(context)..values = o;
       await req.insert();
     }
 
     try {
-      var q = new Query<TestModel>()
+      var q = new Query<TestModel>(context)
         ..where((o) => o.emailAddress).equalTo("2@a.com")
         ..values.emailAddress = "1@a.com";
       await q.updateOne();
@@ -296,17 +296,17 @@ void main() {
   test("Can use enum to set property to be stored in db", () async {
     context = await contextWithModels([EnumObject]);
 
-    var q = new Query<EnumObject>()
+    var q = new Query<EnumObject>(context)
       ..values.enumValues = EnumValues.efgh;
 
     await q.insert();
 
-    q = new Query<EnumObject>()
+    q = new Query<EnumObject>(context)
       ..values.enumValues = EnumValues.abcd;
 
     await q.insert();
 
-    q = new Query<EnumObject>()
+    q = new Query<EnumObject>(context)
       ..values.enumValues = EnumValues.other18Letters
       ..where((o) => o.enumValues).equalTo(EnumValues.efgh);
 

--- a/test/db/postgresql/update_test.dart
+++ b/test/db/postgresql/update_test.dart
@@ -6,7 +6,7 @@ void main() {
   ManagedContext context;
 
   tearDown(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 

--- a/test/db/postgresql/validation_test.dart
+++ b/test/db/postgresql/validation_test.dart
@@ -9,7 +9,7 @@ void main() {
   });
 
   tearDownAll(() async {
-    await ctx.persistentStore.close();
+    await ctx.close();
   });
 
   test("update runs update validations", () async {

--- a/test/db/postgresql/validation_test.dart
+++ b/test/db/postgresql/validation_test.dart
@@ -13,18 +13,18 @@ void main() {
   });
 
   test("update runs update validations", () async {
-    var q = new Query<T>()
+    var q = new Query<T>(ctx)
       ..values.aOrb = "a";
     var objectID = (await q.insert()).id;
 
-    q = new Query<T>()
+    q = new Query<T>(ctx)
       ..where((o) => o.id).equalTo(objectID)
       ..values.equalTo2OnUpdate = 2;
     var o = (await q.update()).first;
     expect(o.aOrb, "a");
     expect(o.equalTo2OnUpdate, 2);
 
-    q = new Query<T>()
+    q = new Query<T>(ctx)
       ..where((o) => o.id).equalTo(objectID)
       ..values.aOrb = "c"
       ..values.equalTo2OnUpdate = 2;
@@ -35,7 +35,7 @@ void main() {
       expect(e.toString(), contains("Must be one of: 'a','b'"));
     }
 
-    q = new Query<T>()
+    q = new Query<T>(ctx)
       ..where((o) => o.id).equalTo(objectID)
       ..values.aOrb = "b"
       ..values.equalTo2OnUpdate = 1;
@@ -46,7 +46,7 @@ void main() {
       expect(e.toString(), contains("Must be equal to '2'"));
     }
 
-    q = new Query<T>()
+    q = new Query<T>(ctx)
       ..where((o) => o.id).equalTo(objectID)
       ..values.aOrb = "b"
       ..values.equalTo1OnInsert = 2
@@ -58,7 +58,7 @@ void main() {
   });
 
   test("updateOne runs update validations", () async {
-    var q = new Query<T>()
+    var q = new Query<T>(ctx)
       ..where((o) => o.id).equalTo(1)
       ..values.equalTo2OnUpdate = 3;
     try {
@@ -70,14 +70,14 @@ void main() {
   });
 
   test("insert runs insert validations", () async {
-    var q = new Query<T>()
+    var q = new Query<T>(ctx)
       ..values.aOrb = "a"
       ..values.equalTo1OnInsert = 1;
     var o = await q.insert();
     expect(o.aOrb, "a");
     expect(o.equalTo1OnInsert, 1);
 
-    q = new Query<T>()
+    q = new Query<T>(ctx)
       ..values.aOrb = "c"
       ..values.equalTo1OnInsert = 1;
     try {
@@ -87,7 +87,7 @@ void main() {
       expect(e.toString(), contains("Must be one of"));
     }
 
-    q = new Query<T>()
+    q = new Query<T>(ctx)
       ..values.aOrb = "b"
       ..values.equalTo1OnInsert = 2;
     try {
@@ -97,7 +97,7 @@ void main() {
       expect(e.toString(), contains("Must be equal to"));
     }
 
-    q = new Query<T>()
+    q = new Query<T>(ctx)
       ..values.aOrb = "b"
       ..values.equalTo1OnInsert = 1
       ..values.equalTo2OnUpdate = 1;
@@ -108,7 +108,7 @@ void main() {
   });
 
   test("valueMap ignores validations", () async {
-    var q = new Query<T>()
+    var q = new Query<T>(ctx)
       ..valueMap = {
         "aOrb": "c",
         "equalTo1OnInsert": 10
@@ -119,15 +119,15 @@ void main() {
   });
 
   test("willUpdate runs prior to update", () async {
-    var q = new Query<U>();
+    var q = new Query<U>(ctx);
     var o = await q.insert();
-    q = new Query<U>()..where((o) => o.id).equalTo(o.id);
+    q = new Query<U>(ctx)..where((o) => o.id).equalTo(o.id);
     o = (await q.update()).first;
     expect(o.q, "willUpdate");
   });
 
   test("willInsert runs prior to insert", () async {
-    var q = new Query<U>();
+    var q = new Query<U>(ctx);
     var o = await q.insert();
     expect(o.id, isNotNull);
     expect(o.q, "willInsert");
@@ -135,10 +135,10 @@ void main() {
   });
 
   test("ManagedObject onUpdate is subject to all validations", () async {
-    var q = new Query<V>();
+    var q = new Query<V>(ctx);
     var o = await q.insert();
 
-    q = new Query<V>()..where((o) => o.id).equalTo(o.id);
+    q = new Query<V>(ctx)..where((o) => o.id).equalTo(o.id);
     try {
       await q.update();
       expect(true, false);
@@ -149,7 +149,7 @@ void main() {
   });
 
   test("ManagedObject onInsert is subject to all validations", () async {
-    var q = new Query<W>();
+    var q = new Query<W>(ctx);
     try {
       await q.insert();
       expect(true, false);

--- a/test/db/query_test.dart
+++ b/test/db/query_test.dart
@@ -12,6 +12,15 @@ void main() {
     await ctx.close();
   });
 
+  test("If context does not contian data model with query type, throw exception", () async {
+    try {
+      new Query<Missing>(ctx);
+      fail('unreachable');
+    } on ArgumentError catch (e) {
+      expect(e.toString(), contains("Invalid context"));
+    }
+  });
+  
   test("Can immediately access primary key of belongs-to relationship when building Query.values", () {
     final q = new Query<Child>(ctx);
     q.values.parent.id = 1;
@@ -23,7 +32,7 @@ void main() {
     expect(q.values.name, "Bob");
   });
 
-//todo: Deferring these until next PR
+//todo: Deferring these until later
 //  test("Can immediately access document property when building Query.values", () {
 //    final q = new Query<Root>();
 //    q.values.document["id"] = 1;
@@ -214,4 +223,10 @@ class Constructor extends ManagedObject<_Constructor> implements _Constructor {
   Constructor() {
     name = "Bob";
   }
+}
+
+class Missing extends ManagedObject<_Missing> {}
+class _Missing {
+  @primaryKey
+  int id;
 }

--- a/test/db/query_value_test.dart
+++ b/test/db/query_value_test.dart
@@ -13,13 +13,13 @@ void main() {
   });
 
   test("Can immediately access primary key of belongs-to relationship when building Query.values", () {
-    final q = new Query<Child>();
+    final q = new Query<Child>(ctx);
     q.values.parent.id = 1;
     expect(q.values.parent.id, 1);
   });
 
   test("Values set in constructor are replicated in Query.values", () async {
-    final q = new Query<Constructor>();
+    final q = new Query<Constructor>(ctx);
     expect(q.values.name, "Bob");
   });
 
@@ -47,7 +47,7 @@ void main() {
 //  });
 
   test("Access ManagedSet property of Query.values throws error", () {
-    final q = new Query<Root>();
+    final q = new Query<Root>(ctx);
     try {
       q.values.children = new ManagedSet<Child>();
       fail('unreachable');
@@ -57,7 +57,7 @@ void main() {
   });
 
   test("Accessing non-primary key of ManagedObject property in Query.values throws error", () {
-    final q = new Query<Child>();
+    final q = new Query<Child>(ctx);
     try {
       q.values.parent.name = "ok";
       fail('unreachable');
@@ -67,7 +67,7 @@ void main() {
   });
 
   test("Accessing primary key of has-one property in Query.values throws error", () {
-    final q = new Query<Root>();
+    final q = new Query<Root>(ctx);
     try {
       q.values.child.id = 1;
       fail('unreachable');
@@ -77,21 +77,21 @@ void main() {
   });
 
   test("Can set belongs-to relationship with default constructed object if it is empty", () {
-    final q = new Query<Child>();
+    final q = new Query<Child>(ctx);
     q.values.parent = new Root();
     q.values.parent.id = 1;
     expect(q.values.parent.id, 1);
   });
 
   test("Can set belongs-to relationship with default constructed object if it only contains primary key", () {
-    final q = new Query<Child>();
+    final q = new Query<Child>(ctx);
     q.values.parent = new Root()..id = 1;
     expect(q.values.parent.id, 1);
 
   });
 
   test("Setting belongs-to relationship with default constructed object removes non-primary key values", () {
-    final q = new Query<Child>();
+    final q = new Query<Child>(ctx);
     q.values.parent = new Root()
       ..id = 1
       ..name = "bob";
@@ -111,14 +111,14 @@ void main() {
 
   group("Query.values assigned to instance created by default constroct", () {
     test("Can still create subobjects", () {
-      final q = new Query<Child>();
+      final q = new Query<Child>(ctx);
       q.values = new Child();
       q.values.parent.id = 1;
       expect(q.values.parent.id, 1);
     });
 
     test("Replaced object retains all property values", () {
-      final q = new Query<Child>();
+      final q = new Query<Child>(ctx);
       final r = new Child()
         ..name = "bob";
 
@@ -129,7 +129,7 @@ void main() {
     });
 
     test("If default instance holds ManagedSet, remove it", () {
-      final q = new Query<Root>();
+      final q = new Query<Root>(ctx);
       q.values = new Root()
         ..children = new ManagedSet();
 
@@ -137,14 +137,14 @@ void main() {
     });
 
     test("If default instance holds has-one ManagedObject, remove it", () {
-      final q = new Query<Root>();
+      final q = new Query<Root>(ctx);
       q.values = new Root()
         ..child = new Child();
       expect(q.values.backing.contents, {});
     });
 
     test("If default instance holds belongs-to ManagedObject with more than primary key, remove inner key", () {
-      final q = new Query<Child>();
+      final q = new Query<Child>(ctx);
       q.values = new Child()
         ..parent = (new Root()..name = "fred");
       expect(q.values.backing.contents.keys, ["parent"]);
@@ -152,7 +152,7 @@ void main() {
     });
 
     test("If default instance holds belongs-to ManagedObject with only primary key, retain value", () {
-      final q = new Query<Child>();
+      final q = new Query<Child>(ctx);
       final r = new Child()
         ..parent = (new Root()..id = 1);
 
@@ -162,7 +162,7 @@ void main() {
     });
 
     test("If multiple values are set on assigned object, only remove those that need to be removed", () {
-      final q = new Query<Child>();
+      final q = new Query<Child>(ctx);
       q.values = new Child()
         ..parent = (new Root()..id = 1..name = "fred")
         ..name = "fred";

--- a/test/db/query_value_test.dart
+++ b/test/db/query_value_test.dart
@@ -9,7 +9,7 @@ void main() {
     ctx = await contextWithModels([Root, Child, Constructor]);
   });
   tearDownAll(() async {
-    await ctx.persistentStore.close();
+    await ctx.close();
   });
 
   test("Can immediately access primary key of belongs-to relationship when building Query.values", () {

--- a/test/db/tracking_test.dart
+++ b/test/db/tracking_test.dart
@@ -12,7 +12,7 @@ void main() {
   });
 
   tearDown(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 

--- a/test/db/validate_value_test.dart
+++ b/test/db/validate_value_test.dart
@@ -1,9 +1,14 @@
 import 'package:test/test.dart';
 import 'package:aqueduct/aqueduct.dart';
 
+import '../helpers.dart';
+
 void main() {
-  var dataModel = new ManagedDataModel([T, U, V, EnumObject]);
-  ManagedContext.defaultContext = new ManagedContext(dataModel, null);
+  final ctx = new ManagedContext(new ManagedDataModel([T, U, V, EnumObject]), new DefaultPersistentStore());
+
+  tearDownAll(() async {
+    await ctx.close();
+  });
 
   group("Validate.matches", () {
     test("Valid regex reports match", () {

--- a/test/http/default_resource_controller_test.dart
+++ b/test/http/default_resource_controller_test.dart
@@ -20,7 +20,7 @@ void main() {
 
       var now = new DateTime.now().toUtc();
       for (var i = 0; i < 5; i++) {
-        var q = new Query<TestModel>()
+        var q = new Query<TestModel>(app.channel.context)
           ..values.createdAt = now
           ..values.name = "$i";
         allObjects.add(await q.insert());
@@ -166,7 +166,7 @@ void main() {
 
       var now = new DateTime.now().toUtc();
       for (var i = 0; i < 10; i++) {
-        var q = new Query<TestModel>()
+        var q = new Query<TestModel>(app.channel.context)
           ..values.createdAt = now
           ..values.name = "${9 - i}";
         allObjects.add(await q.insert());
@@ -362,7 +362,7 @@ void main() {
 
       var now = new DateTime.now().toUtc();
       for (var i = 0; i < 10; i++) {
-        var q = new Query<TestModel>()
+        var q = new Query<TestModel>(app.channel.context)
           ..values.createdAt = now
           ..values.name = "${9 - i}";
         allObjects.add(await q.insert());

--- a/test/http/default_resource_controller_test.dart
+++ b/test/http/default_resource_controller_test.dart
@@ -30,7 +30,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await app.channel.context.persistentStore.close();
+      await app.channel.context.close();
       await app.stop();
     });
 
@@ -96,7 +96,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await app.channel.context.persistentStore.close();
+      await app.channel.context.close();
       await app.stop();
     });
 
@@ -129,7 +129,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await app.channel.context.persistentStore.close();
+      await app.channel.context.close();
       await app.stop();
     });
 
@@ -176,7 +176,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await app.channel.context.persistentStore.close();
+      await app.channel.context.close();
       await app.stop();
     });
 
@@ -277,15 +277,14 @@ void main() {
         ..components = new APIComponents());
 
       var dataModel = new ManagedDataModel([TestModel]);
-      ManagedContext.defaultContext =
-      new ManagedContext(dataModel, new DefaultPersistentStore());
-      final c = new ManagedObjectController<TestModel>();
+      final ctx = new ManagedContext(dataModel, new DefaultPersistentStore());
+      final c = new ManagedObjectController<TestModel>(ctx);
       c.prepare();
 
       collectionOperations = c.documentOperations(context, "/", new APIPath());
       idOperations = c.documentOperations(context, "/", new APIPath(parameters: [new APIParameter.path("id")]));
 
-      ManagedContext.defaultContext.documentComponents(context);
+      ctx.documentComponents(context);
 
       await context.finalize();
     });
@@ -372,7 +371,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await app.channel.context.persistentStore.close();
+      await app.channel.context.close();
       await app.stop();
     });
 
@@ -399,7 +398,6 @@ class TestChannel extends ApplicationChannel {
     var persistentStore = new PostgreSQLPersistentStore(
         "dart", "dart", "localhost", 5432, "dart_test");
     context = new ManagedContext(dataModel, persistentStore);
-    ManagedContext.defaultContext = context;
 
     var targetSchema = new Schema.fromDataModel(context.dataModel);
     var schemaBuilder = new SchemaBuilder.toSchema(
@@ -417,11 +415,11 @@ class TestChannel extends ApplicationChannel {
     final router = new Router();
     router
         .route("/controller/[:id]")
-        .link(() => new ManagedObjectController<TestModel>());
+        .link(() => new ManagedObjectController<TestModel>(context));
 
     router
       .route("/dynamic/[:id]")
-      .link(() => new ManagedObjectController.forEntity(context.dataModel.entityForType(TestModel)));
+      .link(() => new ManagedObjectController.forEntity(context.dataModel.entityForType(TestModel), context));
     return router;
   }
 }

--- a/test/http/subclass_managed_object_controller_test.dart
+++ b/test/http/subclass_managed_object_controller_test.dart
@@ -27,7 +27,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      await app.channel.context.persistentStore.close();
+      await app.channel.context.close();
       await app.stop();
     });
 
@@ -109,7 +109,6 @@ class TestChannel extends ApplicationChannel {
     var persistentStore = new PostgreSQLPersistentStore(
         "dart", "dart", "localhost", 5432, "dart_test");
     context = new ManagedContext(dataModel, persistentStore);
-    ManagedContext.defaultContext = context;
 
     var targetSchema = new Schema.fromDataModel(context.dataModel);
     var schemaBuilder = new SchemaBuilder.toSchema(
@@ -127,7 +126,7 @@ class TestChannel extends ApplicationChannel {
     final router = new Router();
     router
         .route("/controller/[:id]")
-        .link(() => new Subclass());
+        .link(() => new Subclass(context));
     return router;
   }
 }
@@ -143,6 +142,8 @@ class _TestModel {
 }
 
 class Subclass extends ManagedObjectController<TestModel> {
+  Subclass(ManagedContext context) : super(context);
+
   @override
   Future<Query<TestModel>> willFindObjectWithQuery(
       Query<TestModel> query) async {

--- a/test/http/subclass_managed_object_controller_test.dart
+++ b/test/http/subclass_managed_object_controller_test.dart
@@ -17,7 +17,7 @@ void main() {
 
       var now = new DateTime.now().toUtc();
       for (var i = 0; i < 5; i++) {
-        var q = new Query<TestModel>()
+        var q = new Query<TestModel>(app.channel.context)
           ..values.createdAt = now
           ..values.name = "$i";
         allObjects.add(await q.insert());

--- a/test/managed_auth/managed_auth_role_storage_test.dart
+++ b/test/managed_auth/managed_auth_role_storage_test.dart
@@ -44,7 +44,7 @@ void main() {
   });
 
   tearDownAll(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 

--- a/test/managed_auth/managed_auth_role_storage_test.dart
+++ b/test/managed_auth/managed_auth_role_storage_test.dart
@@ -18,7 +18,7 @@ void main() {
     context = await contextWithModels([User, ManagedAuthClient, ManagedAuthToken]);
     storage = new RoleBasedAuthStorage(context);
     auth = new AuthServer(storage);
-    createdUsers = await createUsers(5);
+    createdUsers = await createUsers(context, 5);
 
     var salt = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345";
 
@@ -38,7 +38,7 @@ void main() {
       ..hashedSecret = ac.hashedSecret
       ..redirectURI = ac.redirectURI)
         .map((mc) {
-      var q = new Query<ManagedAuthClient>()..values = mc;
+      var q = new Query<ManagedAuthClient>(context)..values = mc;
       return q.insert();
     }));
   });
@@ -262,7 +262,7 @@ class _User extends ManagedAuthenticatable {
   String role;
 }
 
-Future<List<User>> createUsers(int count) async {
+Future<List<User>> createUsers(ManagedContext ctx, int count) async {
   var list = <User>[];
   for (int i = 0; i < count; i++) {
     var salt = AuthUtility.generateRandomSalt();
@@ -284,7 +284,7 @@ Future<List<User>> createUsers(int count) async {
       u.role = "invalid";
     }
 
-    var q = new Query<User>()..values = u;
+    var q = new Query<User>(ctx)..values = u;
 
     list.add(await q.insert());
   }

--- a/test/managed_auth/managed_auth_storage_test.dart
+++ b/test/managed_auth/managed_auth_storage_test.dart
@@ -43,7 +43,7 @@ void main() {
           ..hashedSecret = ac.hashedSecret
           ..redirectURI = ac.redirectURI)
         .map((mc) {
-      var q = new Query<ManagedAuthClient>()..values = mc;
+      var q = new Query<ManagedAuthClient>(context)..values = mc;
       return q.insert();
     }));
 
@@ -80,13 +80,13 @@ void main() {
         expect(true, false);
       } on AuthServerException {}
 
-      var q = new Query<ManagedAuthClient>();
+      var q = new Query<ManagedAuthClient>(context);
       expect(await q.fetch(), hasLength(5));
     });
 
     test("Revoking unknown client has no impact", () async {
       await auth.revokeClientID("nonsense");
-      var q = new Query<ManagedAuthClient>();
+      var q = new Query<ManagedAuthClient>(context);
       expect(await q.fetch(), hasLength(5));
     });
   });
@@ -96,7 +96,7 @@ void main() {
     User createdUser;
     setUp(() async {
       auth = new AuthServer(storage);
-      createdUser = (await createUsers(1)).first;
+      createdUser = (await createUsers(context, 1)).first;
     });
 
     test(
@@ -253,7 +253,7 @@ void main() {
 
     setUp(() async {
       auth = new AuthServer(storage);
-      createdUser = (await createUsers(1)).first;
+      createdUser = (await createUsers(context, 1)).first;
       initialToken = await auth.authenticate(createdUser.username,
           User.DefaultPassword, "com.stablekernel.app1", "kilimanjaro");
     });
@@ -305,7 +305,7 @@ void main() {
       }
 
       // Make sure we don't have duplicates in the db
-      var q = new Query<ManagedAuthToken>();
+      var q = new Query<ManagedAuthToken>(context);
       expect(await q.fetch(), hasLength(1));
     });
 
@@ -374,7 +374,7 @@ void main() {
 
     setUp(() async {
       auth = new AuthServer(storage);
-      createdUser = (await createUsers(1)).first;
+      createdUser = (await createUsers(context, 1)).first;
     });
 
     test("Can create an auth code that can be exchanged for a token", () async {
@@ -481,7 +481,7 @@ void main() {
 
     setUp(() async {
       auth = new AuthServer(storage);
-      createdUser = (await createUsers(1)).first;
+      createdUser = (await createUsers(context, 1)).first;
       code = await auth.authenticateForCode(createdUser.username,
           User.DefaultPassword, "com.stablekernel.redirect");
     });
@@ -527,7 +527,7 @@ void main() {
         expect(true, false);
       } on AuthServerException {}
 
-      var q = new Query<ManagedAuthToken>()..where((o) => o.code).equalTo(code.code);
+      var q = new Query<ManagedAuthToken>(context)..where((o) => o.code).equalTo(code.code);
       expect(await q.fetch(), isEmpty);
     });
 
@@ -551,7 +551,7 @@ void main() {
       }
 
       // Ensure that the associated auth code is also destroyed
-      var authCodeQuery = new Query<ManagedAuthToken>();
+      var authCodeQuery = new Query<ManagedAuthToken>(context);
       expect(await authCodeQuery.fetch(), isEmpty);
     });
 
@@ -586,7 +586,7 @@ void main() {
       }
 
       // Ensure that the associated auth code is also destroyed
-      var authCodeQuery = new Query<ManagedAuthToken>();
+      var authCodeQuery = new Query<ManagedAuthToken>(context);
       expect(await authCodeQuery.fetch(), isEmpty);
     });
 
@@ -640,7 +640,7 @@ void main() {
 
     setUp(() async {
       auth = new AuthServer(storage);
-      createdUsers = await createUsers(3);
+      createdUsers = await createUsers(context, 3);
     });
 
     test("Revoking a client revokes all of its tokens and auth codes",
@@ -680,7 +680,7 @@ void main() {
         expect(e.reason, AuthRequestError.invalidGrant);
       }
 
-      var tokenQuery = new Query<ManagedAuthToken>();
+      var tokenQuery = new Query<ManagedAuthToken>(context);
       expect(await tokenQuery.fetch(), isEmpty);
     });
 
@@ -722,7 +722,7 @@ void main() {
       expect(await auth.verify(issuedTokenKeep.accessToken),
           new isInstanceOf<Authorization>());
 
-      var tokenQuery = new Query<ManagedAuthToken>();
+      var tokenQuery = new Query<ManagedAuthToken>(context);
       expect(await tokenQuery.fetch(), hasLength(3));
     });
 
@@ -757,7 +757,7 @@ void main() {
 
     setUp(() async {
       auth = new AuthServer(storage);
-      createdUsers = await createUsers(3);
+      createdUsers = await createUsers(context, 3);
     });
 
     test(
@@ -801,7 +801,7 @@ void main() {
         expect(e.reason, AuthRequestError.invalidGrant);
       }
 
-      var tokenQuery = new Query<ManagedAuthToken>();
+      var tokenQuery = new Query<ManagedAuthToken>(context);
       expect(await tokenQuery.fetch(), isEmpty);
     });
   });
@@ -814,7 +814,7 @@ void main() {
     setUp(() async {
       var limitedStorage = new ManagedAuthDelegate<User>(context, tokenLimit: 3);
       auth = new AuthServer(limitedStorage);
-      createdUsers = await createUsers(3);
+      createdUsers = await createUsers(context, 3);
     });
 
     test("Revoking a token automatically deletes the code that generated it",
@@ -826,11 +826,11 @@ void main() {
       var exchangedToken = await auth.exchange(
           exchangedCode.code, "com.stablekernel.redirect", "mckinley");
 
-      var codeQuery = new Query<ManagedAuthToken>()
+      var codeQuery = new Query<ManagedAuthToken>(context)
         ..where((o) => o.code).equalTo(exchangedCode.code);
       expect(await codeQuery.fetch(), hasLength(1));
 
-      var tokenQuery = new Query<ManagedAuthToken>()
+      var tokenQuery = new Query<ManagedAuthToken>(context)
         ..where((o) => o.accessToken).equalTo(exchangedToken.accessToken);
       await tokenQuery.delete();
 
@@ -865,14 +865,14 @@ void main() {
       }
 
       // Insert the 'race condition' code
-      var manualInsertQuery = new Query<ManagedAuthToken>()..values = manualCode;
+      var manualInsertQuery = new Query<ManagedAuthToken>(context)..values = manualCode;
       manualCode = await manualInsertQuery.insert();
 
       // Make a new code, should kill the race condition code and the first generated code in the loop.
       // Other user codes remain
       var newCode = await auth.authenticateForCode(createdUsers.first.username,
           User.DefaultPassword, "com.stablekernel.redirect");
-      var codeQuery = new Query<ManagedAuthToken>();
+      var codeQuery = new Query<ManagedAuthToken>(context);
       var codesInDB = (await codeQuery.fetch()).map((ac) => ac.code).toList();
 
       // These codes are in chronological order
@@ -907,7 +907,7 @@ void main() {
     setUp(() async {
       var limitedStorage = new ManagedAuthDelegate<User>(context, tokenLimit: 3);
       auth = new AuthServer(limitedStorage);
-      createdUsers = await createUsers(10);
+      createdUsers = await createUsers(context, 10);
     });
 
     test(
@@ -937,14 +937,14 @@ void main() {
       }
 
       // Insert the 'race condition' token
-      var manualInsertQuery = new Query<ManagedAuthToken>()..values = manualToken;
+      var manualInsertQuery = new Query<ManagedAuthToken>(context)..values = manualToken;
       manualToken = await manualInsertQuery.insert();
 
       // Make a new token, should kill the race condition token and the first generated token in the loop.
       // Other user token remain
       var newToken = await auth.authenticate(createdUsers.first.username,
           User.DefaultPassword, "com.stablekernel.app1", "kilimanjaro");
-      var tokenQuery = new Query<ManagedAuthToken>();
+      var tokenQuery = new Query<ManagedAuthToken>(context);
       var tokensInDB =
           (await tokenQuery.fetch()).map((ac) => ac.accessToken).toList();
 
@@ -1012,7 +1012,7 @@ void main() {
     User createdUser;
     setUp(() async {
       auth = new AuthServer(storage);
-      createdUser = (await createUsers(1)).first;
+      createdUser = (await createUsers(context, 1)).first;
 
       var salt = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345";
 
@@ -1051,7 +1051,7 @@ void main() {
             ..hashedSecret = ac.hashedSecret
             ..redirectURI = ac.redirectURI)
           .map((mc) {
-        var q = new Query<ManagedAuthClient>()..values = mc;
+        var q = new Query<ManagedAuthClient>(context)..values = mc;
         return q.insert();
       }));
     });
@@ -1274,7 +1274,7 @@ void main() {
             new AuthScope("location:add")
           ]);
 
-      var q = new Query<ManagedAuthClient>()
+      var q = new Query<ManagedAuthClient>(context)
         ..where((o) => o.id).equalTo("all.redirect")
         ..values.allowedScope = "user location:add.readonly";
       await q.updateOne();
@@ -1411,7 +1411,7 @@ class User extends ManagedObject<_User>
 
 class _User extends ManagedAuthenticatable {}
 
-Future<List<User>> createUsers(int count) async {
+Future<List<User>> createUsers(ManagedContext ctx, int count) async {
   var list = <User>[];
   for (int i = 0; i < count; i++) {
     var salt = AuthUtility.generateRandomSalt();
@@ -1421,7 +1421,7 @@ Future<List<User>> createUsers(int count) async {
       ..hashedPassword =
           AuthUtility.generatePasswordHash(User.DefaultPassword, salt);
 
-    var q = new Query<User>()..values = u;
+    var q = new Query<User>(ctx)..values = u;
 
     list.add(await q.insert());
   }

--- a/test/managed_auth/managed_auth_storage_test.dart
+++ b/test/managed_auth/managed_auth_storage_test.dart
@@ -51,7 +51,7 @@ void main() {
   });
 
   tearDown(() async {
-    await context?.persistentStore?.close();
+    await context?.close();
     context = null;
   });
 


### PR DESCRIPTION
This work sets the stage for #35.

ManagedDataModels are now reference counted in a static ManagedDataModelManager. A context can take/release ownership of data models.