### PR TITLE
Adds Query.insertObject static method

### DIFF
--- a/lib/src/db/query/query.dart
+++ b/lib/src/db/query/query.dart
@@ -48,6 +48,14 @@ abstract class Query<InstanceType extends ManagedObject> {
     return context.persistentStore.newQuery<InstanceType>(context, entity);
   }
 
+  /// Inserts [object] into the database managed by [context].
+  ///
+  /// This is equivalent to creating a [Query], assigning [object] to [values], and invoking [insert].
+  static Future<T> insertObject<T extends ManagedObject>(ManagedContext context, T object) {
+    final query = new Query.forEntity(object.entity, context)..values = object;
+    return query.insert();
+  }
+
   /// Configures this instance to fetch a relationship property identified by [object] or [set].
   ///
   /// By default, objects returned by [Query.fetch] do not have their relationship properties populated. (In other words,

--- a/test/db/postgresql/insert_test.dart
+++ b/test/db/postgresql/insert_test.dart
@@ -7,7 +7,6 @@ import '../../helpers.dart';
 import 'package:postgres/postgres.dart';
 
 void main() {
-  justLogEverything();
   ManagedContext context;
 
   tearDown(() async {
@@ -41,6 +40,13 @@ void main() {
       expect(
           e.toString(), contains("Column 'bad_key' does not exist for table 'simple'"));
     }
+  });
+
+  test("Insert from static method", () async {
+    context = await contextWithModels([TestModel]);
+    final o = await Query.insertObject(context, new TestModel()..name = "Bob");
+    expect(o.id, isNotNull);
+    expect(o.name, "Bob");
   });
 
   test("Inserting an object that violated a unique constraint fails", () async {


### PR DESCRIPTION
Convenience to avoid having to create an a query just to insert an object.