### PR TITLE
Improves QueryPredicate.and (renamed from andPredicates)

### DIFF
--- a/lib/src/db/postgresql/mappers/row.dart
+++ b/lib/src/db/postgresql/mappers/row.dart
@@ -113,7 +113,7 @@ class RowMapper extends PostgresMapper with PredicateBuilder, EntityTableMapper 
       if (predicate != null) {
         filterPredicates.add(predicate);
       }
-      _joinCondition = QueryPredicate.andPredicates(filterPredicates);
+      _joinCondition = QueryPredicate.and(filterPredicates);
     }
 
     return _joinCondition;
@@ -174,7 +174,7 @@ class RowMapper extends PostgresMapper with PredicateBuilder, EntityTableMapper 
     var columnsWithoutNamespace = flattenedColumns.map((p) => p.columnName()).join(",");
 
     var outerWhere = QueryPredicate
-        .andPredicates(matcherExpressions.where((expr) => !identical(expr.table, this)).map((expr) => expr.predicate));
+        .and(matcherExpressions.where((expr) => !identical(expr.table, this)).map((expr) => expr.predicate));
     var outerWhereString = "";
     if (outerWhere != null) {
       outerWhereString = " WHERE ${outerWhere.format}";

--- a/lib/src/db/postgresql/query_builder.dart
+++ b/lib/src/db/postgresql/query_builder.dart
@@ -80,7 +80,15 @@ class PostgresQueryBuilder extends Object with PredicateBuilder, RowInstantiator
 
   bool get containsJoins => returningOrderedMappers.reversed.any((p) => p is RowMapper);
 
-  String get whereClause => finalizedPredicate?.format;
+  String get whereClause {
+    if (finalizedPredicate?.format == null) {
+      return null;
+    }
+    if (finalizedPredicate.format.isEmpty) {
+      return null;
+    }
+    return finalizedPredicate.format;
+  }
 
   Map<String, dynamic> get substitutionValueMap {
     var m = <String, dynamic>{};
@@ -176,7 +184,7 @@ class PostgresQueryBuilder extends Object with PredicateBuilder, RowInstantiator
     var matchers = propertyExpressionsFromObject(expressions, createdImplicitRowMappers);
     var allPredicates = matchers.expand((p) => [p.predicate]).toList();
     allPredicates.addAll(predicates.where((p) => p != null));
-    return QueryPredicate.andPredicates(allPredicates);
+    return QueryPredicate.and(allPredicates);
   }
 
   int aliasCounter = 0;

--- a/lib/src/db/query/predicate.dart
+++ b/lib/src/db/query/predicate.dart
@@ -28,38 +28,69 @@ class QueryPredicate {
   /// Default constructor
   ///
   /// The [format] and [parameters] of this predicate. [parameters] may be null.
-  QueryPredicate(this.format, this.parameters);
+  QueryPredicate(this.format, this.parameters) {
+    format ??= "";
+    parameters ??= {};
+  }
 
-  /// Joins together a list of predicates by the 'and' token.
+  QueryPredicate.empty() : format = "", parameters = {};
+
+  /// Combines [predicates] with 'AND' keyword.
   ///
-  /// For combining multiple predicate together.
-  static QueryPredicate andPredicates(Iterable<QueryPredicate> predicates) {
-    var predicateList = predicates.toList();
+  /// The [format] of the return value is produced by joining together each [predicates]
+  /// [format] string with 'AND'. Each [parameters] from individual [predicates] is combined
+  /// into the returned [parameters].
+  ///
+  /// If there are duplicate parameter names in [predicates], they will be disambiguated by suffixing
+  /// the parameter name in both [format] and [parameters] with a unique integer.
+  ///
+  /// If [predicates] is null or empty, an empty predicate is returned. If [predicates] contains only
+  /// one predicate, that predicate is returned.
+  static QueryPredicate and(Iterable<QueryPredicate> predicates) {
+    var predicateList = predicates
+        ?.where((p) => p?.format != null && p.format.isNotEmpty)
+        ?.toList();
     if (predicateList == null) {
-      return null;
+      return new QueryPredicate.empty();
     }
 
     if (predicateList.length == 0) {
-      return null;
+      return new QueryPredicate.empty();
     }
 
     if (predicateList.length == 1) {
       return predicateList.first;
     }
 
-    var predicateFormat =
-        "(" + predicateList.map((pred) => "${pred.format}").join(" AND ") + ")";
+    // If we have duplicate keys anywhere, we need to disambiguate them.
+    int dupeCounter = 0;
+    final allFormatStrings = [];
+    final valueMap = <String, dynamic>{};
+    for (var predicate in predicateList) {
+      final duplicateKeys = predicate.parameters?.keys?.where((k) => valueMap.keys.contains(k))?.toList() ?? [];
 
-    var valueMap = <String, dynamic>{};
-    predicateList.forEach((p) {
-      p.parameters?.forEach((k, v) {
-        if (valueMap.containsKey(k)) {
-          throw new ArgumentError("Invalid query predicate when creating 'andPredicate'. "
-              "Substitution key '$k' appears in multiple predicates and cannot be disambiguated.");
-        }
-        valueMap[k] = v;
-      });
-    });
+      if (duplicateKeys.length > 0) {
+        var fmt = predicate.format;
+        Map<String, String> dupeMap = {};
+        duplicateKeys.forEach((key) {
+          final replacementKey = "${key}$dupeCounter";;
+          fmt = fmt.replaceAll("@$key", "@$replacementKey");
+          dupeMap[key] = replacementKey;
+          dupeCounter ++;
+        });
+
+        allFormatStrings.add(fmt);
+        predicate?.parameters?.forEach((key, value) {
+          valueMap[dupeMap[key] ?? key] = value;
+        });
+      } else {
+        allFormatStrings.add(predicate.format);
+        valueMap.addAll(predicate?.parameters ?? {});
+      }
+    }
+
+    var predicateFormat =
+        "(" + allFormatStrings.join(" AND ") + ")";
 
     return new QueryPredicate(predicateFormat, valueMap);
   }

--- a/test/db/predicate_test.dart
+++ b/test/db/predicate_test.dart
@@ -2,14 +2,67 @@ import 'package:aqueduct/aqueduct.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("QueryPredicate throws error if 'and' predicates have duplicate keys", () {
-    var p1 = new QueryPredicate("p=@p", {"p": 1});
-    var p2 = new QueryPredicate("p=@p", {"p": 2});
-    try {
-      QueryPredicate.andPredicates([p1, p2]);
-      fail("should fail");
-    } on ArgumentError catch (e) {
-      expect(e.message, contains("Substitution key 'p' appears in multiple predicates and cannot be disambiguated."));
-    }
+  group("QueryPredicate.and", () {
+    test("Duplicate keys are replaced", () {
+      var p1 = new QueryPredicate("p=@p", {"p": 1});
+      var p2 = new QueryPredicate("p=@p", {"p": 2});
+      final combined = QueryPredicate.and([p1, p2]);
+      expect(combined.format, "(p=@p AND p=@p0)");
+      expect(combined.parameters, {
+        "p": 1,
+        "p0": 2
+      });
+    });
+
+    test("Multiple duplicate keys are replaced", () {
+      var p1 = new QueryPredicate("p=@p", {"p": 1});
+      var p2 = new QueryPredicate("p=@p", {"p": 2});
+      var p3 = new QueryPredicate("p=@p", {"p": 3});
+      final combined = QueryPredicate.and([p1, p2, p3]);
+      expect(combined.format, "(p=@p AND p=@p0 AND p=@p1)");
+      expect(combined.parameters, {
+        "p": 1,
+        "p0": 2,
+        "p1": 3
+      });
+    });
+    
+    test("If empty list, return empty predicate", () {
+      expect(QueryPredicate.and([]).format, "");
+      expect(QueryPredicate.and([]).parameters, {});
+    });
+
+    test("If null, return empty predicate", () {
+      expect(QueryPredicate.and(null).format, "");
+      expect(QueryPredicate.and(null).parameters, {});
+    });
+
+    test("If only one element in list, return that element", () {
+      final valid = new QueryPredicate("x=@a", {"a": 0});
+      final p = QueryPredicate.and([valid]);
+      expect(p.format, valid.format);
+      expect(p.parameters, valid.parameters);
+    });
+
+    test("If and'ing empty predicate, ignore it", () {
+      final valid = new QueryPredicate("x=@a", {"a": 0});
+      final p = QueryPredicate.and([valid, new QueryPredicate.empty()]);
+      expect(p.format, valid.format);
+      expect(p.parameters, valid.parameters);
+    });
+
+    test("If and'ing null predicate, ignore it", () {
+      final valid = new QueryPredicate("x=@a", {"a": 0});
+      final p = QueryPredicate.and([valid, null]);
+      expect(p.format, valid.format);
+      expect(p.parameters, valid.parameters);
+    });
+
+    test("And'ing predicate with no parameters", () {
+      final valid = new QueryPredicate("x=y", null);
+      final p = QueryPredicate.and([valid]);
+      expect(p.format, valid.format);
+      expect(p.parameters, {});
+    });
   });
 }


### PR DESCRIPTION
- returns an empty predicate instead of null 
- allows for duplicate parameter names