### PR TITLE
Adds database transactions to ORM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.0
 
+- Adds `ManagedContext.transaction` to enable queries to be run in a database transaction. 
 - Removes `ManagedContext.defaultContext`; context usage must be explicit.
 - Adds 'Scope' annotation to add granular scoping to `ResourceController` methods.
 - Adds support for storing PostgreSQL JSONB data with `Document` data type.

--- a/lib/src/db/managed/context.dart
+++ b/lib/src/db/managed/context.dart
@@ -51,11 +51,20 @@ class ManagedContext implements APIComponentDocumenter {
     ApplicationServiceRegistry.defaultInstance.register<ManagedContext>(this, (o) => o.close());
   }
 
+  /// Creates a child context from [parentContext].
+  ManagedContext.childOf(ManagedContext parentContext) :
+    persistentStore = parentContext.persistentStore,
+    dataModel = parentContext.dataModel;
+
   /// The persistent store that [Query]s on this context are executed through.
-  final PersistentStore persistentStore;
+  PersistentStore persistentStore;
 
   /// The data model containing the [ManagedEntity]s that describe the [ManagedObject]s this instance works with.
   final ManagedDataModel dataModel;
+
+  Future<dynamic> transaction(Future queries(ManagedContext transaction)) {
+    return persistentStore.transaction(new ManagedContext.childOf(this), queries);
+  }
 
   /// Closes this context and release its underlying resources.
   ///
@@ -75,4 +84,10 @@ class ManagedContext implements APIComponentDocumenter {
 
   @override
   void documentComponents(APIDocumentContext context) => dataModel.documentComponents(context);
+}
+
+class Rollback {
+  Rollback(this.reason);
+
+  final dynamic reason;
 }

--- a/lib/src/db/persistent_store/persistent_store.dart
+++ b/lib/src/db/persistent_store/persistent_store.dart
@@ -26,6 +26,7 @@ abstract class PersistentStore {
   Future<dynamic> executeQuery(String formatString, Map<String, dynamic> values, int timeoutInSeconds,
       {PersistentStoreQueryReturnType returnType});
 
+  Future<dynamic> transaction(ManagedContext transactionContext, Future queries(ManagedContext transaction));
 
   /// Closes the underlying database connection.
   Future close();

--- a/lib/src/db/persistent_store/persistent_store.dart
+++ b/lib/src/db/persistent_store/persistent_store.dart
@@ -26,7 +26,7 @@ abstract class PersistentStore {
   Future<dynamic> executeQuery(String formatString, Map<String, dynamic> values, int timeoutInSeconds,
       {PersistentStoreQueryReturnType returnType});
 
-  Future<dynamic> transaction(ManagedContext transactionContext, Future queries(ManagedContext transaction));
+  Future<dynamic> transaction(ManagedContext transactionContext, Future transactionBlock(ManagedContext transaction));
 
   /// Closes the underlying database connection.
   Future close();

--- a/test/db/postgresql/transaction_test.dart
+++ b/test/db/postgresql/transaction_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:aqueduct/aqueduct.dart';
+
+import '../../context_helpers.dart';
+
+void main() {
+  ManagedContext context;
+  setUp(() async {
+    context = await contextWithModels([Model]);
+  });
+
+  tearDown(() async {
+    await context.close();
+  });
+
+  test("Queries in transaction block are executed in transaction", () async {
+    await context.transaction((t) async {
+      final q1 = new Query<Model>(t)..values.name = "Bob";
+      await q1.insert();
+
+      await Query.insertObject(t, new Model()..name = "Fred");
+    });
+
+    final objects = await (new Query<Model>(context)..sortBy((o) => o.name, QuerySortOrder.ascending)).fetch();
+    expect(objects.length, 2);
+    expect(objects.first.name, "Bob");
+    expect(objects.last.name, "Fred");
+  });
+
+  test("A transaction returns null if it completes successfully", () async {
+    final result = await context.transaction((t) async {
+      await Query.insertObject(t, new Model()..name = "Bob");
+    });
+
+    expect(result, isNull);
+  });
+
+  test(
+      "Queries outside of transaction block while transaction block is running are queued until transaction is complete",
+      () async {
+    context.transaction((t) async {
+      await Query.insertObject(t, new Model()..name = "1");
+      await Query.insertObject(t, new Model()..name = "2");
+      await Query.insertObject(t, new Model()..name = "3");
+    });
+
+    final results = await (new Query<Model>(context)).fetch();
+    expect(results.length, 3);
+  });
+
+  test("Error thrown from query rolls back transaction and is thrown by transaction method", () async {
+    try {
+      await context.transaction((t) async {
+        await Query.insertObject(t, new Model()..name = "1");
+        // This query will fail because name is null
+        await Query.insertObject(t, new Model());
+        fail('unreachable');
+      });
+      fail('unreachable');
+    } on QueryException catch (e) {
+      expect(e.toString(), contains("not-null"));
+    }
+
+    expect((await (new Query<Model>(context).fetch())).length, 0);
+  });
+
+  test("Error thrown from non-query code in transaction rolls back transaction and thrown by transaction method",
+      () async {
+    try {
+      await context.transaction((t) async {
+        await Query.insertObject(t, new Model()..name = "1");
+        throw new StateError("hello");
+      });
+      fail('unreachable');
+    } on StateError catch (e) {
+      expect(e.toString(), contains("hello"));
+    }
+
+    expect((await (new Query<Model>(context).fetch())).length, 0);
+  });
+
+  test("A thrown rollback rolls back transaction and returns rollback reason", () async {
+    final res = await context.transaction((t) async {
+      final res = await Query.insertObject(t, new Model()..name = "1");
+
+      if (res.name == "1") {
+        throw new Rollback("hello");
+      }
+
+      await Query.insertObject(t, new Model()..name = "2");
+    });
+
+    expect(res, "hello");
+    expect((await (new Query<Model>(context).fetch())).length, 0);
+  });
+
+  test("Queries executed through persistentStore.execute use transaction context", () async {
+    await context.transaction((t) async {
+      await Query.insertObject(t, new Model()..name = "1");
+      await t.persistentStore.execute("INSERT INTO _Model (name) VALUES ('2')");
+      await Query.insertObject(t, new Model()..name = "3");
+    });
+
+    expect((await (new Query<Model>(context).fetch())).length, 3);
+  });
+}
+
+class _Model {
+  @primaryKey
+  int id;
+
+  String name;
+}
+
+class Model extends ManagedObject<_Model> implements _Model {}

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -279,6 +279,10 @@ class DefaultPersistentStore extends PersistentStore {
   @override
   Future close() async {}
 
+
+  @override
+  Future<dynamic> transaction(ManagedContext transactionContext, Future queries(ManagedContext transaction)) async => throw new Exception("Transaciton not supported on mock");
+
   @override
   List<String> createTable(SchemaTable t, {bool isTemporary: false}) => [];
   @override


### PR DESCRIPTION
Adds `ManagedContext.transaction` that takes a closure of queries that will run in the same transaction.

Finishes #35 