### PR TITLE
updating git clone link

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -19,7 +19,7 @@ brew upgrade dart --devel
 Once you have Dart 2.0, clone Aqueduct locally, switch to the 3.0 branch, and install the CLI from your local repository.
 
 ```bash
-git clone git@github.com:stablekernel/aqueduct.git
+git clone https://github.com/stablekernel/aqueduct.git
 cd aqueduct
 git checkout 3.0
 


### PR DESCRIPTION
when using ssh+git users will get permission denied, so switched to https