### PR TITLE
Adds BodyDecoder.decode, BodyDecoder.as

### DIFF
--- a/aqueduct/CHANGELOG.md
+++ b/aqueduct/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.0
 
-- Adds `BodyDecoder.asDynamic`.
+- Adds `BodyDecoder.decode<T>` and `BodyDecoder.as<T>`. This replaces existing `decodeAs*` and `as*` methods.
 - `package:aqueduct/test` moved to `package:aqueduct_test/aqueduct_test`, which is a separate dependency than `aqueduct`.
 - Renames methods in `AuthDelegate` to provide consistency.
 - Adds `AuthDelegate.addClient` and `AuthServer.addClient`.

--- a/aqueduct/lib/src/http/body_decoder.dart
+++ b/aqueduct/lib/src/http/body_decoder.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:convert';
 import 'dart:mirrors';
 import 'package:aqueduct/src/utilities/mirror_helpers.dart';
 
@@ -32,9 +33,9 @@ abstract class BodyDecoder {
 
   /// Whether or not [bytes] are available as a list after decoding has occurred.
   ///
-  /// By default, invoking [decode] (or one of the methods that invokes it) will discard
-  /// the initial bytes and only keep the decoded value. Setting this flag to false
-  /// will keep a copy of the original bytes, accessible through [asBytes].
+  /// By default, invoking [decode] will discard
+  /// the initial bytes and only keep the decoded value. Setting this flag to true
+  /// will keep a copy of the original bytes in [originalBytes].
   bool retainOriginalBytes = false;
 
   /// Whether or not [bytes] have been decoded yet.
@@ -53,6 +54,9 @@ abstract class BodyDecoder {
     return (_decodedData as Object).runtimeType;
   }
 
+  /// The raw bytes of this request body.
+  ///
+  /// This value is valid if [retainOriginalBytes] was set to true prior to [decode] being invoked.
   List<int> get originalBytes {
     if (retainOriginalBytes == false) {
       throw StateError("'originalBytes' were not retained. Set 'retainOriginalBytes' to true prior to decoding.");
@@ -64,25 +68,25 @@ abstract class BodyDecoder {
   dynamic _decodedData;
   List<int> _bytes;
 
-  /// Returns decoded data, decoding it if not already decoded.
+  /// Decodes this object's bytes as [T].
   ///
-  /// This is the raw access method to an HTTP body's decoded value. It is preferable
-  /// to use methods such as [decodeAsMap], [decodeAsList], and [decodeAsString], all of which
-  /// invoke this method, but throw the appropriate [Response] if they are not the correct type.
+  /// This method will select the [Codec] for [contentType] from the [HTTPCodecRepository].
+  /// The bytes of this object will be decoded according to that codec. If the codec
+  /// produces a value that is not [T], a bad request error [Response] is thrown.
   ///
-  /// The first time this method is invoked, [bytes] is read in full and decoded according to [contentType].
-  /// The decoded data is stored in this instance so that subsequent access will
-  /// return the cached decoded data instead of decoding it again.
+  /// Performance considerations:
   ///
-  /// If the body is empty, this method will return null and no decoding is attempted.
+  /// The decoded value is retained, and subsequent invocations of this method return the
+  /// retained value to avoid performing the decoding process again.
   ///
-  /// The elements of the return value depend on the codec selected from [HTTPCodecRepository], determined
-  /// by [contentType]. If there is no codec in [HTTPCodecRepository] for the content type of the
-  /// request body being decoded, this method returns the flattened list of bytes directly
-  /// from the request body as [List<int>].
+  /// When [T] is a collection type, specifying type parameters can impact performance.
+  /// For example, if [T] is `List<String>`, each element of the decoded list is verified
+  /// to be an instance of [String]. If [T] is `List<dynamic>`, this check is not performed.
+  /// It is the developer's responsibility to ensure the objects in the list are the
+  /// expected type.
   Future<T> decode<T>() async {
     if (hasBeenDecoded) {
-      return _cast(_decodedData);
+      return _cast<T>(_decodedData);
     }
 
     final codec = HTTPCodecRepository.defaultInstance
@@ -95,7 +99,7 @@ abstract class BodyDecoder {
 
     if (codec == null) {
       _decodedData = originalBytes;
-      return _cast(_decodedData);
+      return _cast<T>(_decodedData);
     }
 
     try {
@@ -106,15 +110,19 @@ abstract class BodyDecoder {
       throw new Response.badRequest(body: {"error": "request entity could not be decoded"});
     }
 
-    return _cast(_decodedData);
+    return _cast<T>(_decodedData);
   }
 
+  /// Returns previously decoded object as [T].
+  ///
+  /// This method is the synchronous version of [decode]. However, [decode] must have been called
+  /// prior to invoking this method.
   T as<T>() {
     if (!hasBeenDecoded) {
       throw StateError("Attempted to access request body without decoding it.");
     }
 
-    return _cast(_decodedData);
+    return _cast<T>(_decodedData);
   }
 
   static T _cast<T>(dynamic body) {

--- a/aqueduct/lib/src/http/managed_object_controller.dart
+++ b/aqueduct/lib/src/http/managed_object_controller.dart
@@ -122,7 +122,7 @@ class ManagedObjectController<InstanceType extends ManagedObject> extends Resour
   @Operation.post()
   Future<Response> createObject() async {
     InstanceType instance = _query.entity.instanceType.newInstance(new Symbol(""), []).reflectee as InstanceType;
-    instance.readFromMap(request.body.asMap());
+    instance.readFromMap(request.body.as());
     _query.values = instance;
 
     _query = await willInsertObjectWithQuery(_query);
@@ -201,7 +201,7 @@ class ManagedObjectController<InstanceType extends ManagedObject> extends Resour
     _query.where((o) => o[primaryKey]).equalTo(parsedIdentifier);
 
     InstanceType instance = _query.entity.instanceType.newInstance(new Symbol(""), []).reflectee as InstanceType;
-    instance.readFromMap(request.body.asMap());
+    instance.readFromMap(request.body.as());
     _query.values = instance;
 
     _query = await willUpdateObjectWithQuery(_query);
@@ -355,8 +355,6 @@ class ManagedObjectController<InstanceType extends ManagedObject> extends Resour
           "404": new APIResponse("No object found."),
           "400": new APIResponse.schema(
               "Invalid request.", new APISchemaObject.object({"error": new APISchemaObject.string()})),
-          "422": new APIResponse.schema(
-              "Entity in unexpected format", new APISchemaObject.object({"error": new APISchemaObject.string()})),
           "409": new APIResponse.schema(
               "Object already exists", new APISchemaObject.object({"error": new APISchemaObject.string()})),
         };
@@ -365,8 +363,6 @@ class ManagedObjectController<InstanceType extends ManagedObject> extends Resour
           "200": new APIResponse.schema("Returns created object.", context.schema.getObjectWithType(InstanceType)),
           "400": new APIResponse.schema(
               "Invalid request.", new APISchemaObject.object({"error": new APISchemaObject.string()})),
-          "422": new APIResponse.schema(
-              "Entity in unexpected format", new APISchemaObject.object({"error": new APISchemaObject.string()})),
           "409": new APIResponse.schema(
               "Object already exists", new APISchemaObject.object({"error": new APISchemaObject.string()}))
         };

--- a/aqueduct/lib/src/http/query_controller.dart
+++ b/aqueduct/lib/src/http/query_controller.dart
@@ -63,7 +63,7 @@ abstract class QueryController<InstanceType extends ManagedObject>
 
   @override
   void didDecodeRequestBody(RequestBody body) {
-    query.values.readFromMap(body.asMap());
+    query.values.readFromMap(body.as());
     query.values.removePropertyFromBackingMap(query.values.entity.primaryKey);
   }
 }

--- a/aqueduct/lib/src/http/request_body.dart
+++ b/aqueduct/lib/src/http/request_body.dart
@@ -3,13 +3,12 @@ import 'dart:io';
 import 'http.dart';
 import 'body_decoder.dart';
 
-/// Instances of this class decode HTTP request bodies according to their content type.
+/// Objects that represent a request body, and can be decoded into Dart objects.
 ///
-/// Every instance of [Request] has a [Request.body] property of this type. [ResourceController]s automatically decode
-/// [Request.body] prior to invoking a operation method. Other [Controller]s should use [decode]
-/// or one of the typed methods ([asList], [asMap], [decodeAsMap], [decodeAsList]) to decode HTTP body data.
+/// Every instance of [Request] has a [Request.body] property of this type. Use
+/// [decode] to convert the contents of this object into a Dart type (e.g, [Map] or [List]).
 ///
-/// Default decoders are available for 'application/json', 'application/x-www-form-urlencoded' and 'text/*' content types.
+/// See also [HTTPCodecRepository] for how decoding occurs.
 class RequestBody extends BodyDecoder {
   /// Creates a new instance of this type.
   ///

--- a/aqueduct/lib/src/http/request_body.dart
+++ b/aqueduct/lib/src/http/request_body.dart
@@ -6,7 +6,7 @@ import 'body_decoder.dart';
 /// Instances of this class decode HTTP request bodies according to their content type.
 ///
 /// Every instance of [Request] has a [Request.body] property of this type. [ResourceController]s automatically decode
-/// [Request.body] prior to invoking a operation method. Other [Controller]s should use [decodedData]
+/// [Request.body] prior to invoking a operation method. Other [Controller]s should use [decode]
 /// or one of the typed methods ([asList], [asMap], [decodeAsMap], [decodeAsList]) to decode HTTP body data.
 ///
 /// Default decoders are available for 'application/json', 'application/x-www-form-urlencoded' and 'text/*' content types.

--- a/aqueduct/lib/src/http/resource_controller_internal/bindings.dart
+++ b/aqueduct/lib/src/http/resource_controller_internal/bindings.dart
@@ -151,7 +151,7 @@ class BoundQueryParameter extends BoundInput {
     dynamic value = queryParameters[externalName];
     if (value == null) {
       if (requestHasFormData(request)) {
-        value = request.body.asMap()[externalName];
+        value = request.body.as<Map<String, dynamic>>()[externalName];
       }
     }
 
@@ -189,7 +189,7 @@ class BoundBody extends BoundInput {
       }
 
       var value = intoType.newInstance(new Symbol(""), []).reflectee as HTTPSerializable;
-      value.readFromMap(request.body.asMap());
+      value.readFromMap(request.body.as());
 
       return value;
     } else if (intoType.isSubtypeOf(reflectType(List))) {
@@ -197,7 +197,7 @@ class BoundBody extends BoundInput {
         throw new Response(422, null, {"error": "unexpected request entity data type"});
       }
 
-      var bodyList = request.body.asList();
+      List<Map<String, dynamic>> bodyList = request.body.as();
       if (bodyList.isEmpty) {
         return [];
       }

--- a/aqueduct/lib/src/http/resource_controller_internal/bindings.dart
+++ b/aqueduct/lib/src/http/resource_controller_internal/bindings.dart
@@ -1,5 +1,6 @@
 import 'dart:mirrors';
 
+import 'package:aqueduct/src/utilities/mirror_helpers.dart';
 import 'package:open_api/v3.dart';
 
 import '../serializable.dart';
@@ -183,39 +184,27 @@ class BoundBody extends BoundInput {
       return null;
     }
 
-    if (intoType.isAssignableTo(reflectType(HTTPSerializable))) {
-      if (!reflectType(request.body.decodedType).isSubtypeOf(reflectType(Map))) {
-        throw new Response(422, null, {"error": "unexpected request entity data type"});
-      }
-
-      var value = intoType.newInstance(new Symbol(""), []).reflectee as HTTPSerializable;
+    if (intoType.isSubtypeOf(reflectType(HTTPSerializable))) {
+      final value = intoType.newInstance(new Symbol(""), []).reflectee as HTTPSerializable;
       value.readFromMap(request.body.as());
 
       return value;
     } else if (intoType.isSubtypeOf(reflectType(List))) {
-      if (!reflectType(request.body.decodedType).isSubtypeOf(reflectType(List))) {
-        throw new Response(422, null, {"error": "unexpected request entity data type"});
-      }
-
-      List<Map<String, dynamic>> bodyList = request.body.as();
+      final bodyList = request.body.as<List<Map<String, dynamic>>>();
       if (bodyList.isEmpty) {
         return [];
       }
 
-      var typeArg = intoType.typeArguments.first as ClassMirror;
+      final typeArg = intoType.typeArguments.first as ClassMirror;
       return bodyList.map((object) {
-        if (!reflectType(object.runtimeType).isSubtypeOf(reflectType(Map))) {
-          throw new Response(422, null, {"error": "unexpected request entity data type"});
-        }
-
-        var value = typeArg.newInstance(new Symbol(""), []).reflectee as HTTPSerializable;
+        final value = typeArg.newInstance(new Symbol(""), []).reflectee as HTTPSerializable;
         value.readFromMap(object);
 
         return value;
       }).toList();
     }
 
-    throw new Response(422, null, {"error": "unexpected request entity data type"});
+    return runtimeCast(request.body.as(), intoType);
   }
 }
 

--- a/aqueduct/lib/src/http/resource_controller_internal/controller.dart
+++ b/aqueduct/lib/src/http/resource_controller_internal/controller.dart
@@ -171,7 +171,7 @@ class BoundController {
 
     if (!request.body.isEmpty) {
       controller.willDecodeRequestBody(request.body);
-      await request.body.decodedData;
+      await request.body.decode();
       controller.didDecodeRequestBody(request.body);
     }
 

--- a/aqueduct/templates/db/test/simple_controller_test.dart
+++ b/aqueduct/templates/db/test/simple_controller_test.dart
@@ -15,7 +15,7 @@ Future main() async {
   test("GET /model/:id returns previously created object", () async {
     var response = await harness.agent.post("/model", body: {"name": "Bob"});
 
-    final createdObject = response.body.asMap();
+    final createdObject = response.body.as();
     response = await harness.agent.request("/model/${createdObject["id"]}").get();
     expect(
         response,

--- a/aqueduct/templates/db_and_auth/test/register_test.dart
+++ b/aqueduct/templates/db_and_auth/test/register_test.dart
@@ -18,7 +18,7 @@ void main() {
     var json = {"username": "bob@stablekernel.com", "password": "foobaraxegrind12%"};
 
     final registerResponse = await harness.publicAgent.post("/register", body: json);
-    final accessToken = registerResponse.body.asMap()["access_token"];
+    final accessToken = registerResponse.body.as()["access_token"];
     final userAgent = new Agent.from(harness.agent)..bearerAuthorization = accessToken;
 
     final identityResponse = await userAgent.get("/me");

--- a/aqueduct/test/auth/auth_code_controller_test.dart
+++ b/aqueduct/test/auth/auth_code_controller_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(res, hasResponse(200, body: null, headers: {"content-type": "text/html; charset=utf-8"}));
 
       // The data is actually JSON for purposes of this test, just makes it easier to validate here.
-      expect(json.decode(res.body.asString()), {
+      expect(json.decode(res.body.as<String>()), {
         "response_type": "code",
         "client_id": "com.stablekernel.redirect",
         "state": null,
@@ -75,7 +75,7 @@ void main() {
       var res = await req.get();
       expect(res, hasStatus(200));
       expect(res, hasHeaders({"content-type": "text/html; charset=utf-8"}));
-      expect(json.decode(res.body.asString()), {
+      expect(json.decode(res.body.as<String>()), {
         "response_type": "code",
         "client_id": "com.stablekernel.redirect",
         "state": "Alaska",

--- a/aqueduct/test/auth/auth_controller_test.dart
+++ b/aqueduct/test/auth/auth_controller_test.dart
@@ -80,7 +80,7 @@ void main() {
           resRefresh,
           hasResponse(200, body: {
             "access_token": isString,
-            "refresh_token": resToken.body.asMap()["refresh_token"],
+            "refresh_token": resToken.body.as<Map<String, dynamic>>()["refresh_token"],
             "expires_in": greaterThan(3500),
             "token_type": "bearer"
           }, headers: {
@@ -107,7 +107,7 @@ void main() {
           resRefresh,
           hasResponse(200, body: {
             "access_token": isString,
-            "refresh_token": resToken.body.asMap()["refresh_token"],
+            "refresh_token": resToken.body.as<Map<String, dynamic>>()["refresh_token"],
             "expires_in": greaterThan(3500),
             "token_type": "bearer",
             "scope": "user"
@@ -136,7 +136,7 @@ void main() {
           resRefresh,
           hasResponse(200, body: {
             "access_token": isString,
-            "refresh_token": resToken.body.asMap()["refresh_token"],
+            "refresh_token": resToken.body.as<Map<String, dynamic>>()["refresh_token"],
             "expires_in": greaterThan(3500),
             "token_type": "bearer",
             "scope": "user"
@@ -368,7 +368,7 @@ void main() {
     });
 
     test("refresh_token appears more than once", () async {
-      final grantMap = (await grant("com.stablekernel.app1", "kilimanjaro", user1)).body.asMap();
+      final Map<String, dynamic> grantMap = (await grant("com.stablekernel.app1", "kilimanjaro", user1)).body.as();
       final refreshToken = Uri.encodeQueryComponent(grantMap["refresh_token"] as String);
 
       var req = client.request("/auth/token")
@@ -701,7 +701,7 @@ Map<String, String> substituteUser(Map<String, String> initial, {String username
 }
 
 Map<String, String> refreshTokenMapFromTokenResponse(TestResponse resp) {
-  return {"refresh_token": resp.body.asMap()["refresh_token"] as String};
+  return {"refresh_token": resp.body.as<Map<String, dynamic>>()["refresh_token"] as String};
 }
 
 Map<String, String> get user1 =>

--- a/aqueduct/test/http/body_decoder_test.dart
+++ b/aqueduct/test/http/body_decoder_test.dart
@@ -120,7 +120,7 @@ void main() {
         "c": ["2/4"]
       });
 
-      expect(utf8.decode(request.body.as<List<int>>()), "a=b&c=2%2F4");
+      expect(utf8.decode(request.body.originalBytes), "a=b&c=2%2F4");
     });
 
     test("Any text decoder works on text with charset", () async {
@@ -142,7 +142,7 @@ void main() {
           .catchError((err) => null);
 
       var request = new Request(await server.first);
-      String body = await request.body.decode();
+      List<int> body = await request.body.decode();
       expect(body, "foobar".codeUnits);
     });
 
@@ -153,7 +153,7 @@ void main() {
       req.close().catchError((err) => null);
 
       var request = new Request(await server.first);
-      String body = await request.body.decode();
+      List<int> body = await request.body.decode();
 
       expect(request.raw.headers.contentType, isNull);
       expect(body, "foobar".codeUnits);
@@ -531,7 +531,7 @@ void main() {
       postJSON({"k": "v"});
       var body = new RequestBody(await server.first);
       try {
-        await body.decode<List<int>>();
+        body.originalBytes;
         expect(true, false);
       } on StateError {}
     });
@@ -542,7 +542,7 @@ void main() {
       var body = new RequestBody(await server.first)..retainOriginalBytes = true;
       await body.decode();
       expect(body.as<Map<String, dynamic>>(), {"k": "v"});
-      expect(body.as<List<int>>(), utf8.encode(json.encode({"k":"v"})));
+      expect(body.originalBytes, utf8.encode(json.encode({"k":"v"})));
     });
 
     test("Retain bytes when no codec is used", () async {

--- a/aqueduct/test/http/body_decoder_test.dart
+++ b/aqueduct/test/http/body_decoder_test.dart
@@ -87,7 +87,7 @@ void main() {
           .catchError((err) => null);
 
       request = new Request(await server.first);
-      var body = await request.body.decodedData;
+      Map<String, dynamic> body = await request.body.decode();
       expect(body, {"a": "val"});
     });
 
@@ -101,7 +101,7 @@ void main() {
       request = new Request(await server.first);
       expect(request.raw.headers.contentType.charset, null);
 
-      var body = await request.body.decodedData;
+      Map<String, dynamic> body = await request.body.decode();
       expect(body, {"a": "val"});
     });
 
@@ -114,13 +114,13 @@ void main() {
           .catchError((err) => null);
       var request = new Request(await server.first);
       request.body.retainOriginalBytes = true;
-      var body = await request.body.decodedData;
+      Map<String, dynamic> body = await request.body.decode();
       expect(body, {
         "a": ["b"],
         "c": ["2/4"]
       });
 
-      expect(utf8.decode(request.body.asBytes()), "a=b&c=2%2F4");
+      expect(utf8.decode(request.body.as<List<int>>()), "a=b&c=2%2F4");
     });
 
     test("Any text decoder works on text with charset", () async {
@@ -130,7 +130,7 @@ void main() {
           .catchError((err) => null);
 
       var request = new Request(await server.first);
-      var body = await request.body.decodedData;
+      String body = await request.body.decode();
       expect(body, "foobar");
     });
 
@@ -142,7 +142,7 @@ void main() {
           .catchError((err) => null);
 
       var request = new Request(await server.first);
-      var body = await request.body.decodedData;
+      String body = await request.body.decode();
       expect(body, "foobar".codeUnits);
     });
 
@@ -153,7 +153,7 @@ void main() {
       req.close().catchError((err) => null);
 
       var request = new Request(await server.first);
-      var body = await request.body.decodedData;
+      String body = await request.body.decode();
 
       expect(request.raw.headers.contentType, isNull);
       expect(body, "foobar".codeUnits);
@@ -167,7 +167,7 @@ void main() {
       var request = new Request(await server.first);
 
       try {
-        await request.body.decodedData;
+        await request.body.decode();
         expect(true, false);
       } on Response catch (e) {
         expect(e.statusCode, 400);
@@ -200,7 +200,7 @@ void main() {
               body: json.encode({"key":"value"}))
           .catchError((err) => null);
       var request = new Request(await server.first);
-      var body = await request.body.decodedData;
+      Map<String, dynamic> body = await request.body.decode();
       expect(body, {"key":"value"});
     });
 
@@ -212,7 +212,7 @@ void main() {
           .catchError((err) => null);
 
       var request = new Request(await server.first);
-      var body = await request.body.decodedData;
+      Map<String, dynamic> body = await request.body.decode();
       expect(body, {"key":"value"});
     });
 
@@ -226,7 +226,7 @@ void main() {
       var request = new Request(await server.first);
       expect(request.raw.headers.contentType.charset, null);
 
-      var body = await request.body.decodedData;
+      Map<String, dynamic> body = await request.body.decode();
       expect(body, {"a": "val"});
     });
 
@@ -244,7 +244,7 @@ void main() {
       // Tests run in checked mode, but coverage runs in unchecked mode.
       var data;
       try {
-        data = await request.body.decodedData;
+        data = await request.body.decode();
       } catch (e) {
         expect(e, isNotNull);
       }
@@ -267,16 +267,16 @@ void main() {
     test("Decode valid decodeAsMap", () async {
       postJSON({"a" : "val"});
       var body = new RequestBody(await server.first);
-      expect(await body.decodeAsMap(), {"a": "val"});
+      expect(await body.decode<Map<String, dynamic>>(), {"a": "val"});
     });
 
     test("Return valid asMap from already decoded body", () async {
       postJSON({"a" : "val"});
       var body = new RequestBody(await server.first);
-      await body.decodedData;
-      expect(body.asMap(), {"a": "val"});
+      await body.decode();
+      expect(body.as<Map<String, dynamic>>(), {"a": "val"});
 
-      expect(body.asDynamic(), {"a": "val"});
+      expect(body.as(), {"a": "val"});
     });
 
     test("Call asMap prior to decode throws error", () async {
@@ -284,20 +284,20 @@ void main() {
       var body = new RequestBody(await server.first);
 
       try {
-        body.asMap();
+        body.as<Map<String, dynamic>>();
         expect(true, false);
       } on StateError {}
     });
 
-    test("decodeAsMap with non-map returns 422", () async {
+    test("decodeAsMap with non-map returns 400", () async {
       postJSON("a");
       var body = new RequestBody(await server.first);
 
       try {
-        await body.decodeAsMap();
+        await body.decode<Map<String, dynamic>>();
         expect(true, false);
       } on Response catch (e) {
-        expect(e.statusCode, 422);
+        expect(e.statusCode, 400);
       }
     });
 
@@ -308,7 +308,7 @@ void main() {
           .catchError((err) => null);
       var body = new RequestBody(await server.first);
 
-      expect(await body.decodeAsMap(), null);
+      expect(await body.decode<Map<String, dynamic>>(), null);
       expect(body.hasBeenDecoded, true);
     });
 
@@ -319,8 +319,8 @@ void main() {
           .catchError((err) => null);
 
       var body = new RequestBody(await server.first);
-      await body.decodedData;
-      expect(body.asMap(), null);
+      await body.decode();
+      expect(body.as<Map<String, dynamic>>(), null);
     });
   });
 
@@ -338,14 +338,14 @@ void main() {
     test("Decode valid decodeAsList", () async {
       postJSON([{"a": "val"}]);
       var body = new RequestBody(await server.first);
-      expect(await body.decodeAsList(), [{"a": "val"}]);
+      expect(await body.decode<List<Map<String, dynamic>>>(), [{"a": "val"}]);
     });
 
     test("Return valid asList from already decoded body", () async {
       postJSON([{"a" : "val"}]);
       var body = new RequestBody(await server.first);
-      await body.decodedData;
-      expect(body.asList(), [{"a": "val"}]);
+      await body.decode();
+      expect(body.as<List<Map<String, dynamic>>>(), [{"a": "val"}]);
     });
 
     test("Call asList prior to decode throws exception", () async {
@@ -353,7 +353,7 @@ void main() {
       var body = new RequestBody(await server.first);
 
       try {
-        body.asList();
+        body.as<List<Map<String, dynamic>>>();
         expect(true, false);
       } on StateError {}
     });
@@ -363,10 +363,10 @@ void main() {
       var body = new RequestBody(await server.first);
 
       try {
-        await body.decodeAsList();
+        await body.decode<List<Map<String, dynamic>>>();
         expect(true, false);
       } on Response catch (response) {
-        expect(response.statusCode, 422);
+        expect(response.statusCode, 400);
       }
     });
 
@@ -377,7 +377,7 @@ void main() {
           .catchError((err) => null);
       var body = new RequestBody(await server.first);
 
-      expect(await body.decodeAsList(), null);
+      expect(await body.decode(), null);
       expect(body.hasBeenDecoded, true);
     });
 
@@ -388,8 +388,8 @@ void main() {
           .catchError((err) => null);
 
       var body = new RequestBody(await server.first);
-      await body.decodedData;
-      expect(body.asList(), null);
+      await body.decode();
+      expect(body.as<List<Map<String, dynamic>>>(), null);
     });
   });
 
@@ -407,7 +407,7 @@ void main() {
     test("Decode valid decodeAsString", () async {
       postString("abcdef");
       var body = new RequestBody(await server.first);
-      expect(await body.decodeAsString(), "abcdef");
+      expect(await body.decode<String>(), "abcdef");
     });
 
     test("Decode large string", () async {
@@ -416,14 +416,14 @@ void main() {
 
       postString(largeString);
       var body = new RequestBody(await server.first);
-      expect(await body.decodeAsString(), largeString);
+      expect(await body.decode<String>(), largeString);
     });
 
     test("Return valid asString from already decoded body", () async {
       postString("abcdef");
       var body = new RequestBody(await server.first);
-      await body.decodedData;
-      expect(body.asString(), "abcdef");
+      await body.decode();
+      expect(body.as<String>(), "abcdef");
     });
 
     test("Call asString prior to decode throws exception", () async {
@@ -431,7 +431,7 @@ void main() {
       var body = new RequestBody(await server.first);
 
       try {
-        body.asString();
+        body.as<String>();
         expect(true, false);
       } on StateError {}
     });
@@ -441,10 +441,10 @@ void main() {
       var body = new RequestBody(await server.first);
 
       try {
-        await body.decodeAsString();
+        await body.decode<String>();
         expect(true, false);
       } on Response catch (response) {
-        expect(response.statusCode, 422);
+        expect(response.statusCode, 400);
       }
     });
 
@@ -455,7 +455,7 @@ void main() {
           .catchError((err) => null);
       var body = new RequestBody(await server.first);
 
-      expect(await body.decodeAsString(), null);
+      expect(await body.decode<String>(), null);
       expect(body.hasBeenDecoded, true);
     });
 
@@ -466,8 +466,8 @@ void main() {
           .catchError((err) => null);
 
       var body = new RequestBody(await server.first);
-      await body.decodedData;
-      expect(body.asString(), null);
+      await body.decode();
+      expect(body.as<String>(), null);
     });
   });
 
@@ -485,14 +485,14 @@ void main() {
     test("Decode valid decodeAsBytes", () async {
       postBytes([1, 2, 3, 4]);
       var body = new RequestBody(await server.first);
-      expect(await body.decodeAsBytes(), [1, 2, 3, 4]);
+      expect(await body.decode<List<int>>(), [1, 2, 3, 4]);
     });
 
     test("Return valid asBytes from already decoded body", () async {
       postBytes([1, 2, 3, 4]);
       var body = new RequestBody(await server.first);
-      await body.decodedData;
-      expect(body.asBytes(), [1, 2, 3, 4]);
+      await body.decode();
+      expect(body.as<List<int>>(), [1, 2, 3, 4]);
     });
 
     test("Call asBytes prior to decode throws error", () async {
@@ -500,7 +500,7 @@ void main() {
 
       var body = new RequestBody(await server.first);
       try {
-        body.asBytes();
+        body.as<List<int>>();
         expect(true, false);
       } on StateError {}
     });
@@ -512,7 +512,7 @@ void main() {
           .catchError((err) => null);
       var body = new RequestBody(await server.first);
 
-      expect(await body.decodeAsBytes(), null);
+      expect(await body.decode<List<int>>(), null);
       expect(body.hasBeenDecoded, true);
     });
 
@@ -523,15 +523,15 @@ void main() {
           .catchError((err) => null);
 
       var body = new RequestBody(await server.first);
-      await body.decodedData;
-      expect(body.asBytes(), null);
+      await body.decode();
+      expect(body.as<List<int>>(), null);
     });
 
     test("Throw exception if not retaining bytes and body was decoded", () async {
       postJSON({"k": "v"});
       var body = new RequestBody(await server.first);
       try {
-        await body.decodeAsBytes();
+        await body.decode<List<int>>();
         expect(true, false);
       } on StateError {}
     });
@@ -540,17 +540,17 @@ void main() {
       postJSON({"k": "v"});
 
       var body = new RequestBody(await server.first)..retainOriginalBytes = true;
-      await body.decodedData;
-      expect(body.asMap(), {"k": "v"});
-      expect(body.asBytes(), utf8.encode(json.encode({"k":"v"})));
+      await body.decode();
+      expect(body.as<Map<String, dynamic>>(), {"k": "v"});
+      expect(body.as<List<int>>(), utf8.encode(json.encode({"k":"v"})));
     });
 
     test("Retain bytes when no codec is used", () async {
       postBytes([1, 2, 3, 4]);
 
       var body = new RequestBody(await server.first)..retainOriginalBytes = true;
-      await body.decodedData;
-      expect(body.asBytes(), [1, 2, 3, 4]);
+      await body.decode();
+      expect(body.as<List<int>>(), [1, 2, 3, 4]);
     });
   });
 
@@ -574,8 +574,8 @@ void main() {
 
       var request = new Request(await server.first);
 
-      var b1 = await request.body.decodedData;
-      var b2 = await request.body.decodedData;
+      var b1 = await request.body.decode();
+      var b2 = await request.body.decode();
 
       expect(b1, isNotNull);
       expect(identical(b1, b2), true);
@@ -588,7 +588,7 @@ void main() {
         var next = new Controller();
         next.linkFunction((req) async {
           // This'll crash
-          var _ = await req.body.decodedData;
+          var _ = await req.body.decode();
 
           return new Response.ok(200);
         });
@@ -638,7 +638,7 @@ void main() {
 
       var controller = new Controller()
         ..linkFunction((req) async {
-          var body = await req.body.decodeAsMap();
+          var body = await req.body.decode<Map<String, dynamic>>();
           return new Response.ok(body);
         });
       server.listen((req) {
@@ -672,7 +672,7 @@ void main() {
 
       var controller = new Controller()
         ..linkFunction((req) async {
-          var body = await req.body.decodedData;
+          var body = await req.body.decode();
           return new Response.ok(body)..contentType = new ContentType("application", "octet-stream");
         });
       server.listen((req) {

--- a/aqueduct/test/http/body_encoder_streaming_test.dart
+++ b/aqueduct/test/http/body_encoder_streaming_test.dart
@@ -314,7 +314,7 @@ void main() {
 
       var controller = new Controller()
         ..linkFunction((req) async {
-          var body = await req.body.decodeAsMap();
+          var body = await req.body.decode<Map<String, dynamic>>();
           return new Response.ok(body);
         });
       server.listen((req) {
@@ -359,7 +359,7 @@ void main() {
 
       var controller = new Controller()
         ..linkFunction((req) async {
-          var body = await req.body.decodedData;
+          var body = await req.body.decode();
           return new Response.ok(body)..contentType = new ContentType("application", "octet-stream");
         });
       server.listen((req) {

--- a/aqueduct/test/http/controller_test.dart
+++ b/aqueduct/test/http/controller_test.dart
@@ -305,12 +305,12 @@ void main() {
       expect(json.decode(resp.body), {"statusCode": 500});
     });
 
-    test("Failure to decode request body as appropriate type is 422", () async {
+    test("Failure to decode request body as appropriate type is 400", () async {
       server = await HttpServer.bind(InternetAddress.loopbackIPv4, 8888);
       server.map((req) => new Request(req)).listen((req) async {
         var next = new Controller();
         next.linkFunction((r) async {
-          await r.body.decodeAsMap();
+          await r.body.decode<Map<String, dynamic>>();
           return new Response.ok(null);
         });
         await next.receive(req);
@@ -319,7 +319,7 @@ void main() {
       var resp = await http.post("http://localhost:8888",
           headers: {"content-type": "application/json"}, body: json.encode(["a"]));
 
-      expect(resp.statusCode, 422);
+      expect(resp.statusCode, 400);
     });
   });
 }

--- a/aqueduct/test/http/default_resource_controller_test.dart
+++ b/aqueduct/test/http/default_resource_controller_test.dart
@@ -341,7 +341,7 @@ void main() {
       var op = collectionOperations["post"];
       expect(op.id, "createTestModel");
 
-      expect(op.responses.length, 4);
+      expect(op.responses.length, 3);
 
       expect(op.responses["409"], isNotNull);
       expect(op.responses["400"], isNotNull);
@@ -353,7 +353,7 @@ void main() {
       var op = idOperations["put"];
       expect(op.id, "updateTestModel");
 
-      expect(op.responses.length, 5);
+      expect(op.responses.length, 4);
 
       expect(op.responses["404"], isNotNull);
       expect(op.responses["409"], isNotNull);

--- a/aqueduct/test/http/default_resource_controller_test.dart
+++ b/aqueduct/test/http/default_resource_controller_test.dart
@@ -344,7 +344,6 @@ void main() {
       expect(op.responses.length, 4);
 
       expect(op.responses["409"], isNotNull);
-      expect(op.responses["422"], isNotNull);
       expect(op.responses["400"], isNotNull);
       expect(op.responses["200"].content["application/json"].schema.referenceURI.path, "/components/schemas/TestModel");
       expect(op.requestBody.content["application/json"].schema.referenceURI.path, "/components/schemas/TestModel");
@@ -358,7 +357,6 @@ void main() {
 
       expect(op.responses["404"], isNotNull);
       expect(op.responses["409"], isNotNull);
-      expect(op.responses["422"], isNotNull);
       expect(op.responses["400"], isNotNull);
       expect(op.responses["200"].content["application/json"].schema.referenceURI.path, "/components/schemas/TestModel");
       expect(op.requestBody.content["application/json"].schema.referenceURI.path, "/components/schemas/TestModel");

--- a/aqueduct/test/http/isolate/message_hub_test.dart
+++ b/aqueduct/test/http/isolate/message_hub_test.dart
@@ -248,7 +248,7 @@ class HubChannel extends ApplicationChannel {
     });
 
     router.route("/send").linkFunction((req) async {
-      var msg = await req.body.decodeAsString();
+      String msg = await req.body.decode();
       if (msg == "garbage") {
         messageHub.add((x) => x);
       } else {

--- a/aqueduct/test/http/resource_controller_body_binding_test.dart
+++ b/aqueduct/test/http/resource_controller_body_binding_test.dart
@@ -133,7 +133,7 @@ void main() {
       }];
       var response = await postJSON(m);
       expect(response.statusCode, 400);
-      expect(json.decode(response.body)["error"], contains("unexpected request entity data type"));
+      expect(json.decode(response.body)["error"], contains("request entity was unexpected type"));
     });
 
     test("Is Map when expecting List returns 400", () async {
@@ -144,7 +144,7 @@ void main() {
       };
       var response = await postJSON(m);
       expect(response.statusCode, 400);
-      expect(json.decode(response.body)["error"], contains("unexpected request entity data type"));
+      expect(json.decode(response.body)["error"], contains("request entity was unexpected type"));
     });
 
     test("If required body and no body included, return 400", () async {
@@ -158,7 +158,7 @@ void main() {
       server = await enableController("/", ListTestController);
       var response = await postJSON(["a", "b"]);
       expect(response.statusCode, 400);
-      expect(json.decode(response.body)["error"], contains("unexpected request entity data type"));
+      expect(json.decode(response.body)["error"], contains("request entity was unexpected type"));
 
     });
   });

--- a/aqueduct/test/http/resource_controller_body_binding_test.dart
+++ b/aqueduct/test/http/resource_controller_body_binding_test.dart
@@ -132,7 +132,7 @@ void main() {
         "name": "Bob"
       }];
       var response = await postJSON(m);
-      expect(response.statusCode, 422);
+      expect(response.statusCode, 400);
       expect(json.decode(response.body)["error"], contains("unexpected request entity data type"));
     });
 
@@ -143,7 +143,7 @@ void main() {
         "name": "Bob"
       };
       var response = await postJSON(m);
-      expect(response.statusCode, 422);
+      expect(response.statusCode, 400);
       expect(json.decode(response.body)["error"], contains("unexpected request entity data type"));
     });
 
@@ -157,7 +157,7 @@ void main() {
     test("Expect list of objects, got list of strings", () async {
       server = await enableController("/", ListTestController);
       var response = await postJSON(["a", "b"]);
-      expect(response.statusCode, 422);
+      expect(response.statusCode, 400);
       expect(json.decode(response.body)["error"], contains("unexpected request entity data type"));
 
     });

--- a/aqueduct/test/http/resource_controller_test.dart
+++ b/aqueduct/test/http/resource_controller_test.dart
@@ -594,7 +594,7 @@ class TController extends ResourceController {
 
   @Operation.post()
   Future<Response> post() async {
-    var body = this.request.body.asMap();
+    Map<String, dynamic> body = this.request.body.as();
 
     return new Response.ok(body);
   }

--- a/aqueduct_test/lib/src/mock_server.dart
+++ b/aqueduct_test/lib/src/mock_server.dart
@@ -143,7 +143,7 @@ class MockHTTPServer extends MockServer<Request> {
     server.map((req) => new Request(req)).listen((req) async {
       add(req);
 
-      await req.body.decodedData;
+      await req.body.decode;
 
       final response = await _dequeue(req);
       if (response != null) {

--- a/aqueduct_test/lib/src/mock_server.dart
+++ b/aqueduct_test/lib/src/mock_server.dart
@@ -143,7 +143,7 @@ class MockHTTPServer extends MockServer<Request> {
     server.map((req) => new Request(req)).listen((req) async {
       add(req);
 
-      await req.body.decode;
+      await req.body.decode();
 
       final response = await _dequeue(req);
       if (response != null) {

--- a/aqueduct_test/lib/src/request.dart
+++ b/aqueduct_test/lib/src/request.dart
@@ -179,7 +179,7 @@ class TestRequest {
     final response = new TestResponse._(rawResponse);
 
     // Trigger body to be decoded
-    await response.body.decodedData;
+    await response.body.decode();
 
     return response;
   }

--- a/aqueduct_test/lib/src/response.dart
+++ b/aqueduct_test/lib/src/response.dart
@@ -17,7 +17,7 @@ class TestResponse {
   /// The HTTP body of the response.
   ///
   /// The body is guaranteed to be decoded prior to accessing it. You do
-  /// not need to invoke [TestResponseBody.decodedData] or any of its asynchronous
+  /// not need to invoke [TestResponseBody.decode] or any of its asynchronous
   /// decoding methods.
   final TestResponseBody body;
 
@@ -84,7 +84,7 @@ class TestResponseBody extends BodyDecoder {
 
   @override
   String toString() {
-    return asDynamic().toString();
+    return as().toString();
   }
 
 

--- a/aqueduct_test/lib/src/response_matcher.dart
+++ b/aqueduct_test/lib/src/response_matcher.dart
@@ -36,7 +36,7 @@ class HTTPResponseMatcher extends Matcher {
     }
 
     if (body != null) {
-      if (!body.matches(response.body.asDynamic(), matchState)) {
+      if (!body.matches(response.body.as(), matchState)) {
         matchState["HTTPResponseMatcher.didFailOnBody"] = true;
         success = false;
       }
@@ -93,7 +93,7 @@ class HTTPResponseMatcher extends Matcher {
     }
 
     if (matchState["HTTPResponseMatcher.didFailOnBody"] == true) {
-      body.describeMismatch(response.body.asDynamic(), mismatchDescription, matchState, verbose);
+      body.describeMismatch(response.body.as(), mismatchDescription, matchState, verbose);
     }
 
     return mismatchDescription;

--- a/aqueduct_test/test/agent_test.dart
+++ b/aqueduct_test/test/agent_test.dart
@@ -122,19 +122,19 @@ void main() {
       msg = await server.next();
       expect(msg.path.string, "/foo");
       expect(msg.method, "POST");
-      expect(msg.body.asMap(), {"foo": "bar"});
+      expect(msg.body.as(), {"foo": "bar"});
 
       expect((await defaultTestClient.execute("PATCH", "/foo", body: {"foo": "bar"})) is TestResponse, true);
       msg = await server.next();
       expect(msg.path.string, "/foo");
       expect(msg.method, "PATCH");
-      expect(msg.body.asMap(), {"foo": "bar"});
+      expect(msg.body.as(), {"foo": "bar"});
 
       expect((await defaultTestClient.put("/foo", body: {"foo": "bar"})) is TestResponse, true);
       msg = await server.next();
       expect(msg.path.string, "/foo");
       expect(msg.method, "PUT");
-      expect(msg.body.asMap(), {"foo": "bar"});
+      expect(msg.body.as<Map<String, dynamic>>(), {"foo": "bar"});
     });
 
     test("Default headers are added to requests", () async {
@@ -235,8 +235,8 @@ void main() {
 
       var defaultTestClient = new Agent.onPort(4000);
       var response = await defaultTestClient.request("/foo").get();
-      expect(response.body.asList().length, 1);
-      expect(response.body.asList().first["a"], "b");
+      expect(response.body.as<List>().length, 1);
+      expect(response.body.as<List>().first["a"], "b");
     });
 
     test("Responses with no body don't return one", () async {
@@ -262,7 +262,7 @@ void main() {
       var req = client.request("/foo")..accept = [ContentType.json, ContentType.text];
 
       var response = await req.post();
-      expect(response.body.asMap(), {"ACCEPT": "application/json; charset=utf-8,text/plain; charset=utf-8"});
+      expect(response.body.as<Map<String, dynamic>>(), {"ACCEPT": "application/json; charset=utf-8,text/plain; charset=utf-8"});
     });
   });
 }

--- a/aqueduct_test/test/mock_server_test.dart
+++ b/aqueduct_test/test/mock_server_test.dart
@@ -38,7 +38,7 @@ void main() {
 
       final serverRequest = await server.next();
       expect(serverRequest.method, "PUT");
-      expect(serverRequest.body.asMap()["a"], "b");
+      expect(serverRequest.body.as<Map>()["a"], "b");
       // expectRequest(serverRequest, method: "PUT", body: {"a": "b"});
     });
 
@@ -175,7 +175,7 @@ void main() {
     test("Can queue handler", () async {
       server.queueHandler((req) => new Response.ok({"k": req.raw.uri.queryParameters["k"]}));
       final response = await testClient.request("/ok?k=1").get();
-      expect(response.body.asMap()["k"], "1");
+      expect(response.body.as<Map>()["k"], "1");
 
       expect((await testClient.request("/ok").get()).statusCode, server.defaultResponse.statusCode);
     });

--- a/aqueduct_test/test/request_test.dart
+++ b/aqueduct_test/test/request_test.dart
@@ -24,7 +24,7 @@ void main() {
 
     final received = await server.next();
     expect(received.raw.headers.value("content-type"), "application/json; charset=utf-8");
-    expect(received.body.asMap(), {"k": "v"});
+    expect(received.body.as<Map>(), {"k": "v"});
 
     final req2 = agent.request("/")
       ..contentType = new ContentType("text", "html", charset: "utf-8")
@@ -33,7 +33,7 @@ void main() {
 
     final rec2 = await server.next();
     expect(rec2.raw.headers.value("content-type"), "text/html; charset=utf-8");
-    expect(rec2.body.asString(), "foobar");
+    expect(rec2.body.as<String>(), "foobar");
   });
 
   test("If opting out of body encoding, bytes can be set directly on request", () async {
@@ -44,7 +44,7 @@ void main() {
 
     final received = await server.next();
     expect(received.raw.headers.value("content-type"), "application/json; charset=utf-8");
-    expect(received.body.asMap(), {"k": "v"});
+    expect(received.body.as<Map>(), {"k": "v"});
   });
 
   test("Query parameters get URI encoded", () async {


### PR DESCRIPTION
Finishes #443.

Removes `asMap`, `asList`, `decodeAs*`, etc. methods from `BodyDecoder`. Replaces with `decode<T>` and `as<T>`. 