### PR TITLE
Prevent Query.where.oneOf from allowing null or empty set

### DIFF
--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -249,6 +249,9 @@ class QueryExpression<T, InstanceType> {
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.department).oneOf(["Engineering", "HR"]);
   QueryExpressionJunction<T, InstanceType> oneOf(Iterable<T> values) {
+    if (values?.isEmpty ?? true) {
+      throw ArgumentError("'Query.where.oneOf' cannot be the empty set or null.");
+    }
     expression = SetMembershipExpression(values.toList());
 
     return _createJunction();

--- a/aqueduct/test/db/postgresql/matcher_test.dart
+++ b/aqueduct/test/db/postgresql/matcher_test.dart
@@ -190,7 +190,7 @@ void main() {
     });
   });
 
-  test("whereIn matcher", () async {
+  test("oneOf matcher", () async {
     var q = Query<TestModel>(context)..where((o) => o.id).oneOf([1, 2]);
     var results = await q.fetch();
     expect(results.length, 2);
@@ -202,6 +202,13 @@ void main() {
     expect(results.length, 4);
     expect(results.any((t) => t.id == 1), false);
     expect(results.any((t) => t.id == 2), false);
+
+    try {
+      Query<TestModel>(context).where((o) => o.id).not.oneOf([]);
+      fail('unreachable');
+    } on ArgumentError catch (e) {
+      expect(e.toString(), contains("oneOf' cannot be the empty set or null"));
+    }
   });
 
   test("whereBetween matcher", () async {


### PR DESCRIPTION
Finishes #518 