### PR TITLE
Additional OAI tests and changing the way serializables are documented

### DIFF
--- a/aqueduct/CHANGELOG.md
+++ b/aqueduct/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix regression when generating OpenAPI documentation for `ManagedObject`s
 - Adds `--resolve-relative-urls` flag to `document` commands to improve client applications
+- Adds `Serializable.documentSchema` instance method. Removes `Serializable.document` static method.
 
 ## 3.0.1
 

--- a/aqueduct/lib/src/db/managed/entity.dart
+++ b/aqueduct/lib/src/db/managed/entity.dart
@@ -288,19 +288,7 @@ class ManagedEntity implements APIComponentDocumenter {
     return tracker.keyPaths;
   }
 
-  /// Two entities are considered equal if they have the same [tableName].
-  @override
-  bool operator ==(dynamic other) {
-    return tableName == other.tableName;
-  }
-
-  @override
-  String toString() {
-    return "ManagedEntity on $tableName";
-  }
-
-  @override
-  void documentComponents(APIDocumentContext context) {
+  APISchemaObject document(APIDocumentContext context) {
     final schemaProperties = <String, APISchemaObject>{};
     final obj = APISchemaObject.object(schemaProperties)
       ..title = "$name";
@@ -317,8 +305,8 @@ class ManagedEntity implements APIComponentDocumenter {
 
     properties.forEach((name, def) {
       if (def is ManagedAttributeDescription &&
-          !def.isIncludedInDefaultResultSet &&
-          !def.isTransient) {
+        !def.isIncludedInDefaultResultSet &&
+        !def.isTransient) {
         return;
       }
 
@@ -326,6 +314,23 @@ class ManagedEntity implements APIComponentDocumenter {
       schemaProperties[name] = schemaProperty;
     });
 
+    return obj;
+  }
+
+  /// Two entities are considered equal if they have the same [tableName].
+  @override
+  bool operator ==(dynamic other) {
+    return tableName == other.tableName;
+  }
+
+  @override
+  String toString() {
+    return "ManagedEntity on $tableName";
+  }
+
+  @override
+  void documentComponents(APIDocumentContext context) {
+    final obj = document(context);
     context.schema
         .register(name, obj, representation: instanceType.reflectedType);
   }

--- a/aqueduct/lib/src/db/managed/object.dart
+++ b/aqueduct/lib/src/db/managed/object.dart
@@ -1,6 +1,7 @@
 import 'dart:mirrors';
 
 import 'package:aqueduct/src/db/managed/data_model_manager.dart';
+import 'package:aqueduct/src/openapi/openapi.dart';
 
 import '../../http/serializable.dart';
 import '../query/query.dart';
@@ -301,6 +302,9 @@ abstract class ManagedObject<T> implements Serializable {
 
     return outputMap;
   }
+
+  @override
+  APISchemaObject documentSchema(APIDocumentContext context) => entity.document(context);
 
   static bool _isPropertyPrivate(String propertyName) =>
       propertyName.startsWith("_");

--- a/aqueduct/lib/src/http/resource_controller.dart
+++ b/aqueduct/lib/src/http/resource_controller.dart
@@ -304,8 +304,9 @@ abstract class ResourceController extends Controller
         final type = b.reflectedType;
         if (!context.schema.hasRegisteredType(type) &&
             _shouldDocumentSerializable(type)) {
+          final instance = b.newInstance(const Symbol(''), []).reflectee as Serializable;
           context.schema.register(MirrorSystem.getName(b.simpleName),
-              Serializable.document(context, type),
+              instance.documentSchema(context),
               representation: type);
         }
       });

--- a/aqueduct/lib/src/http/serializable.dart
+++ b/aqueduct/lib/src/http/serializable.dart
@@ -8,38 +8,14 @@ import 'http.dart';
 ///
 /// Implementers of this interface may be a [Response.body] and bound with an [Bind.body] in [ResourceController].
 abstract class Serializable {
-  /// Documents [serializable].
+  /// Returns an [APISchemaObject] describing this object's type.
   ///
-  /// [serializable] must implement, extend or mixin [Serializable]. The returned [APISchemaObject]
-  /// will be of type 'object'. Each instance variable declared in [serializable] will be a property of this object.
-  /// Instance variables are documented according to [APIComponentDocumenter.documentVariable]. See the API reference
+  /// The returned [APISchemaObject] will be of type [APIType.object]. By default, each instance variable
+  /// of the receiver's type will be a property of the return value. These variables are documented
+  /// with [APIComponentDocumenter.documentVariable]. See the API reference
   /// for this method for supported types.
-  ///
-  /// You may override the default behavior: f [serializable] implements a static [document] method
-  /// with the same signature of this method, the 'overridden' will be invoked instead of the default behavior.
-  static APISchemaObject document(
-      APIDocumentContext context, Type serializable) {
-    final mirror = reflectClass(serializable);
-    if (!mirror.isAssignableTo(reflectType(Serializable))) {
-      throw ArgumentError(
-          "Cannot document '${MirrorSystem.getName(mirror.simpleName)}' as 'Serializable', because it is not an 'Serializable'.");
-    }
-
-    final overridden = mirror.staticMembers[#document];
-    if (overridden != null) {
-      final isValidInvocation = overridden.returnType.isAssignableTo(reflectType(APISchemaObject)) &&
-        overridden.parameters.length == 2 &&
-        overridden.parameters.first.type
-          .isAssignableTo(reflectType(APIDocumentContext)) &&
-        overridden.parameters.last.type.isAssignableTo(reflectType(Type));
-
-      if (isValidInvocation) {
-        return mirror.invoke(#document, [context, serializable]).reflectee as APISchemaObject;
-      } else {
-        throw StateError("Type '$serializable' provides static method 'document', "
-          "but does not have same signature as 'Serializable.document'.");
-      }
-    }
+  APISchemaObject documentSchema(APIDocumentContext context) {
+    final mirror = reflect(this).type;
 
     final obj = APISchemaObject.object({})..title = MirrorSystem.getName(mirror.simpleName);
     try {

--- a/aqueduct/lib/src/openapi/documentable.dart
+++ b/aqueduct/lib/src/openapi/documentable.dart
@@ -36,7 +36,7 @@ abstract class APIComponentDocumenter {
   /// [type] must be representable as an [APISchemaObject]. This includes primitive types (int, String, etc.),
   /// maps, lists and any type that implements [Serializable].
   ///
-  /// See [Serializable.document] for details on automatic document generation behavior for these types.
+  /// See [Serializable.documentSchema] for details on automatic document generation behavior for these types.
   static APISchemaObject documentType(
       APIDocumentContext context, TypeMirror type) {
     if (type.isAssignableTo(reflectType(int))) {
@@ -61,7 +61,8 @@ abstract class APIComponentDocumenter {
         ..additionalPropertySchema =
             documentType(context, type.typeArguments.last);
     } else if (type.isAssignableTo(reflectType(Serializable))) {
-      return Serializable.document(context, type.reflectedType);
+      final instance = (type as ClassMirror).newInstance(const Symbol(''), []).reflectee as Serializable;
+      return instance.documentSchema(context);
     }
 
     throw ArgumentError(

--- a/aqueduct/test/http/controller_test.dart
+++ b/aqueduct/test/http/controller_test.dart
@@ -355,7 +355,7 @@ void main() {
   });
 }
 
-class SomeObject implements Serializable {
+class SomeObject extends Serializable {
   String name;
 
   @override

--- a/aqueduct/test/openapi/serializable_test.dart
+++ b/aqueduct/test/openapi/serializable_test.dart
@@ -19,16 +19,8 @@ void main() {
     await ctx.finalize();
   });
 
-  test("Try to decode non-serializable throws error", () async {
-    try {
-      Serializable.document(ctx, String);
-      fail("unreachable");
-      // ignore: empty_catches
-    } on ArgumentError {}
-  });
-
   test("Serializable contains properties for each declared field", () async {
-    final doc = Serializable.document(ctx, A);
+    final doc = A().documentSchema(ctx);
     await ctx.finalize();
 
     expect(doc.properties.length, 2);
@@ -41,7 +33,7 @@ void main() {
   });
 
   test("Nested serializable is documented", () async {
-    final doc = Serializable.document(ctx, A);
+    final doc = A().documentSchema(ctx);
     expect(doc.properties["b"].properties.length, 1);
     expect(doc.properties["b"].properties["y"].type, APIType.string);
   });
@@ -49,7 +41,7 @@ void main() {
   test(
       "If Serializable cannot be documented, it still allows doc generation but shows error in document",
       () async {
-    final doc = Serializable.document(ctx, FailsToDocument);
+    final doc = FailsToDocument().documentSchema(ctx);
     await ctx.finalize();
 
     expect(doc.title, "FailsToDocument");
@@ -59,7 +51,7 @@ void main() {
   });
 
   test("Serializable can override static document method", () async {
-    final doc = Serializable.document(ctx, OverrideDocument);
+    final doc = OverrideDocument().documentSchema(ctx);
     await ctx.finalize();
 
     expect(doc.properties["k"], isNotNull);
@@ -115,8 +107,9 @@ class FailsToDocument extends Serializable {
 }
 
 class OverrideDocument extends Serializable {
-  static APISchemaObject document(
-      APIDocumentContext context, Type serializable) {
+  @override
+  APISchemaObject documentSchema(
+      APIDocumentContext context) {
     return APISchemaObject.object({"k": APISchemaObject.string()});
   }
 
@@ -128,7 +121,7 @@ class OverrideDocument extends Serializable {
 }
 
 
-class BoundBody implements Serializable {
+class BoundBody extends Serializable {
   int x;
 
   @override


### PR DESCRIPTION
Serializable.document was a static method. Now is an instance method named documentSchema.