### PR TITLE
Adds optional values argument to Query constructor

### DIFF
--- a/aqueduct/CHANGELOG.md
+++ b/aqueduct/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix regression when generating OpenAPI documentation for `ManagedObject`s
 - Adds `--resolve-relative-urls` flag to `document` commands to improve client applications
 - Adds `Serializable.documentSchema` instance method. Removes `Serializable.document` static method.
+- Adds optional `values` argument to `Query` constructor
 
 ## 3.0.1
 

--- a/aqueduct/lib/src/db/persistent_store/persistent_store.dart
+++ b/aqueduct/lib/src/db/persistent_store/persistent_store.dart
@@ -20,7 +20,7 @@ abstract class PersistentStore {
   /// specific to this type. Objects returned from this method must implement [Query]. They
   /// should mixin [QueryMixin] to most of the behavior provided by a query.
   Query<T> newQuery<T extends ManagedObject>(
-      ManagedContext context, ManagedEntity entity);
+      ManagedContext context, ManagedEntity entity, {T values});
 
   /// Executes an arbitrary command.
   Future execute(String sql, {Map<String, dynamic> substitutionValues});

--- a/aqueduct/lib/src/db/postgresql/postgresql_persistent_store.dart
+++ b/aqueduct/lib/src/db/postgresql/postgresql_persistent_store.dart
@@ -128,8 +128,12 @@ class PostgreSQLPersistentStore extends PersistentStore
 
   @override
   Query<T> newQuery<T extends ManagedObject>(
-      ManagedContext context, ManagedEntity entity) {
-    return PostgresQuery<T>.withEntity(context, entity);
+      ManagedContext context, ManagedEntity entity, {T values}) {
+    final query = PostgresQuery<T>.withEntity(context, entity);
+    if (values != null) {
+      query.values = values;
+    }
+    return query;
   }
 
   @override

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -55,6 +55,11 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
 
   @override
   set values(InstanceType obj) {
+    if (obj == null) {
+      _valueObject = null;
+      return;
+    }
+
     _valueObject = entity.instanceOf(
         backing: ManagedBuilderBacking.from(entity, obj.backing));
   }

--- a/aqueduct/lib/src/db/query/query.dart
+++ b/aqueduct/lib/src/db/query/query.dart
@@ -23,14 +23,17 @@ abstract class Query<InstanceType extends ManagedObject> {
   /// Creates a new [Query].
   ///
   /// The query will be sent to the database described by [context].
-  factory Query(ManagedContext context) {
+  /// For insert or update queries, you may provide [values] through this constructor
+  /// or set the field of the same name later. If set in the constructor,
+  /// [InstanceType] is inferred.
+  factory Query(ManagedContext context, {InstanceType values}) {
     final entity = context.dataModel.entityForType(InstanceType);
     if (entity == null) {
       throw ArgumentError(
           "Invalid context. The data model of 'context' does not contain '$InstanceType'.");
     }
 
-    return context.persistentStore.newQuery<InstanceType>(context, entity);
+    return context.persistentStore.newQuery<InstanceType>(context, entity, values: values);
   }
 
   /// Creates a new [Query] without a static type.

--- a/aqueduct/test/db/postgresql/insert_test.dart
+++ b/aqueduct/test/db/postgresql/insert_test.dart
@@ -21,6 +21,20 @@ void main() {
     expect(q.values.id, 1);
   });
 
+  test("May set values to null, but the query will fail", () async {
+    context = await contextWithModels([TestModel]);
+
+    final q = Query<TestModel>(context);
+    q.values = null;
+
+    try {
+      await q.insert();
+      fail('unreachable');
+    } on QueryException catch (e) {
+      expect(e.message, contains("non_null_violation"));
+    }
+  });
+
   test("Insert Bad Key", () async {
     context = await contextWithModels([TestModel]);
 
@@ -297,6 +311,16 @@ void main() {
 
     var result = await q.insert();
     expect(result.enumValues, isNull);
+  });
+
+  test("Can infer query from values in constructor", () async {
+    context = await contextWithModels([TestModel]);
+
+    final tm = TestModel()..id = 1..name = "Fred";
+    final q = Query(context, values: tm);
+    final t = await q.insert();
+    expect(t.id, 1);
+    expect(t.name, "Fred");
   });
 }
 

--- a/aqueduct/test/helpers.dart
+++ b/aqueduct/test/helpers.dart
@@ -274,8 +274,12 @@ class InMemoryAuthStorage extends AuthServerDelegate {
 class DefaultPersistentStore extends PersistentStore {
   @override
   Query<T> newQuery<T extends ManagedObject>(
-      ManagedContext context, ManagedEntity entity) {
-    return _MockQuery<T>.withEntity(context, entity);
+      ManagedContext context, ManagedEntity entity, {T values}) {
+    final q = _MockQuery<T>.withEntity(context, entity);
+    if (values != null) {
+      q.values = values;
+    }
+    return q;
   }
 
   @override


### PR DESCRIPTION
Allows for Query parameterized type to be inferred from this argument, e.g. `Query(context, MyObject())`.