### PR TITLE
#539 Response bodies for non_null_violation returns the field name

### DIFF
--- a/aqueduct/lib/src/db/query/error.dart
+++ b/aqueduct/lib/src/db/query/error.dart
@@ -32,8 +32,19 @@ class QueryException<T> implements HandlerException {
 
   @override
   Response get response {
-    return Response(
-        _getStatus(event), null, {"error": message ?? "query failed"});
+    return Response(_getStatus(event), null, _getBody(message, offendingItems));
+  }
+
+  static Map<String, String> _getBody(String message, List<String> offendingItems) {
+    var body = {
+      "error": message ?? "query failed",
+    };
+
+    if (offendingItems != null && offendingItems.isNotEmpty) {
+      body["detail"] = "Offending Items: ${offendingItems.join(", ")}";
+    }
+
+    return body;
   }
 
   static int _getStatus(QueryExceptionEvent event) {

--- a/aqueduct/test/db/postgresql/insert_test.dart
+++ b/aqueduct/test/db/postgresql/insert_test.dart
@@ -35,6 +35,24 @@ void main() {
     }
   });
 
+  test("Setting a non-null value to null will identify offending column in response", () async {
+    context = await contextWithModels([TestModel]);
+
+    var m = TestModel()
+      ..name = null
+      ..emailAddress = "dup@a.com";
+
+    final q = Query<TestModel>(context)..values = m;
+
+    try {
+      await q.insert();
+      fail('unreachable');
+    } on QueryException catch (e) {
+      expect(e.message, contains("non_null_violation"));
+      expect(e.response.body["detail"], contains("simple.name"));
+    }
+  });
+
   test("Insert Bad Key", () async {
     context = await contextWithModels([TestModel]);
 

--- a/aqueduct/test/db/query_exception_test.dart
+++ b/aqueduct/test/db/query_exception_test.dart
@@ -5,18 +5,28 @@ void main() {
   test("Conflict returns 409", () {
     final exception = QueryException.conflict("invalid", ["xyz"]);
     expect(exception.response.statusCode, 409);
-    expect(exception.response.body, {"error": "invalid"});
+    expect(exception.response.body, {"error": "invalid", "detail": "Offending Items: xyz"});
   });
 
   test("Input returns 400", () {
     final exception = QueryException.input("invalid", ["xyz"]);
     expect(exception.response.statusCode, 400);
-    expect(exception.response.body, {"error": "invalid"});
+    expect(exception.response.body, {"error": "invalid", "detail": "Offending Items: xyz"});
   });
 
   test("Transport returns 503", () {
     final exception = QueryException.transport("invalid");
     expect(exception.response.statusCode, 503);
+    expect(exception.response.body, {"error": "invalid"});
+  });
+
+  test("Offending items show in response detail", () {
+    final exception = QueryException.input("invalid", ["xyz"]);
+    expect(exception.response.body["detail"], contains("xyz"));
+  });
+
+  test("No detail is provided when there are no offending items", () {
+    final exception = QueryException.input("invalid", []);
     expect(exception.response.body, {"error": "invalid"});
   });
 }


### PR DESCRIPTION
Issue #539 
The response object for a QueryException will now contain a "detail" entry if offending items were reported. E.g. 
```
{
    "error": "non_null_violation",
    "detail": "Offending Items: person.name"
}
```