### PR TITLE
Adding Must Call Super Annotations

### DIFF
--- a/aqueduct/lib/src/application/channel.dart
+++ b/aqueduct/lib/src/application/channel.dart
@@ -177,6 +177,7 @@ abstract class ApplicationChannel implements APIComponentDocumenter {
     return doc;
   }
 
+  @mustCallSuper
   @override
   void documentComponents(APIDocumentContext registry) {
     entryPoint.documentComponents(registry);

--- a/aqueduct/lib/src/db/managed/object.dart
+++ b/aqueduct/lib/src/db/managed/object.dart
@@ -2,6 +2,7 @@ import 'dart:mirrors';
 
 import 'package:aqueduct/src/db/managed/data_model_manager.dart';
 import 'package:aqueduct/src/openapi/openapi.dart';
+import 'package:meta/meta.dart';
 
 import '../../http/serializable.dart';
 import '../query/query.dart';
@@ -186,6 +187,7 @@ abstract class ManagedObject<T> implements Serializable {
   ///
   ///           return context;
   ///         }
+  @mustCallSuper
   ValidationContext validate({Validating forEvent = Validating.insert}) {
     return ManagedValidator.run(this, event: forEvent);
   }

--- a/aqueduct/lib/src/http/controller.dart
+++ b/aqueduct/lib/src/http/controller.dart
@@ -4,6 +4,7 @@ import 'dart:mirrors';
 
 import 'package:aqueduct/src/openapi/openapi.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 
 import 'http.dart';
 
@@ -152,7 +153,8 @@ abstract class Controller
   /// must be stored in a static structure, not the instance itself, since that instance will only be used to handle one request
   /// before it is garbage collected.
   ///
-  /// If you override this method, you must call the superclass' implementation.
+  /// If you override this method you should call the superclass' implementation so that linked controllers invoke this same method.
+  /// If you do not invoke the superclass' implementation, you must ensure that any linked controllers invoked this method through other means.
   void didAddToChannel() {
     _nextController?.didAddToChannel();
   }

--- a/aqueduct/lib/src/http/resource_controller.dart
+++ b/aqueduct/lib/src/http/resource_controller.dart
@@ -5,6 +5,7 @@ import 'dart:mirrors';
 import 'package:aqueduct/src/auth/objects.dart';
 import 'package:aqueduct/src/openapi/openapi.dart';
 import 'package:aqueduct/src/utilities/mirror_helpers.dart';
+import 'package:meta/meta.dart';
 
 import 'http.dart';
 import 'resource_controller_internal/internal.dart';
@@ -149,6 +150,7 @@ abstract class ResourceController extends Controller
   /// If an operation method requires additional parameters that cannot be bound using [Bind] annotations, override
   /// this method. When overriding this method, call the superclass' implementation and add the additional parameters
   /// to the returned list before returning the combined list.
+  @mustCallSuper
   List<APIParameter> documentOperationParameters(
       APIDocumentContext context, Operation operation) {
     bool usesFormEncodedData = operation.method == "POST" &&


### PR DESCRIPTION
Issue #514 

Searched for "superclass" and "super" with a space before or after to find comments stating the method must call super when overridden.

This caused warnings to popup for Controller.didAddToChannel overrides. Specifically for the Router and _ControllerRecycler class.
![screen shot 2018-10-10 at 10 57 35 am](https://user-images.githubusercontent.com/20878393/46746170-75d98200-cc7c-11e8-9fba-7426a54886bf.png)
