### PR TITLE
Log warning if PostgreSQL throws an exception.

### DIFF
--- a/aqueduct/lib/src/db/postgresql/postgresql_persistent_store.dart
+++ b/aqueduct/lib/src/db/postgresql/postgresql_persistent_store.dart
@@ -305,6 +305,7 @@ class PostgreSQLPersistentStore extends PersistentStore
     } on PostgreSQLException catch (e) {
       logger.fine(() =>
           "Query (${DateTime.now().toUtc().difference(now).inMilliseconds}ms) $formatString $values");
+      logger.warning(() => e.toString());
       final interpreted = _interpretException(e);
       if (interpreted != null) {
         throw interpreted;


### PR DESCRIPTION
A small issue I came across today: with the default `INFO` log level, PostgreSQL exceptions are not logged, which means an insert can fail silently without any output, which is quite confusing.

In my concrete case, I had a null constraint violation that prevented the insertion from happening. With the PR I now get a proper error message:

`[WARNING] aqueduct: PostgreSQLSeverity.error 23502: null value in column "password" violates not-null constraint Detail: Failing row contains (13, Mein toller Test, {"version": "1.0", "encoding": "utf-8", "questestinterop": {"ass..., 2018-11-15 11:49:53.67694, 0, null, 0). Table: _exam Column: password`

Not sure if it should be warning or an error, and not sure how to really log this. Anyway, this PR pins the location where something should happen I guess.