### PR TITLE
Prevent autoincrementing fields in managed object from being set in readFromMap

### DIFF
--- a/aqueduct/lib/src/db/managed/attributes.dart
+++ b/aqueduct/lib/src/db/managed/attributes.dart
@@ -170,10 +170,12 @@ class Column {
   /// This flag will remove the associated property from the result set unless it is explicitly specified by [Query.returningProperties].
   final bool shouldOmitByDefault;
 
-  /// Indicate to the underlying database to use a serial counter when inserted an instance.
+  /// A sequence generator will be used to generate the next value for this column when a row is inserted.
   ///
-  /// This is typically used for integer primary keys. In PostgreSQL, for example, an auto-incrementing bigInteger type
-  /// will be represented by "bigserial".
+  /// When this flag is true, the database will generate a value for this column on insert.
+  ///
+  /// Additionally, when [ManagedObject.readFromMap] is invoked, values in the map corresponding to columns with this flag set to true
+  /// will not be read.
   final bool autoincrement;
 
   /// Creates an instance of this type.

--- a/aqueduct/lib/src/db/managed/object.dart
+++ b/aqueduct/lib/src/db/managed/object.dart
@@ -225,10 +225,12 @@ abstract class ManagedObject<T> implements Serializable {
     return name;
   }
 
-  /// Populates the properties of a this instance from a map.
+  /// Reads values from [keyValues] and assigns them to properties of this object.
   ///
   /// This method will thrown an exception if a key in the map does not
   /// match a property of the receiver.
+  ///
+  /// Properties that are auto-incrementing will not be read from the map.
   ///
   /// Usage:
   ///     var values = json.decode(requestBody);
@@ -244,6 +246,9 @@ abstract class ManagedObject<T> implements Serializable {
       }
 
       var property = entity.properties[k];
+      if (property.autoincrement) {
+        return;
+      }
 
       if (property == null) {
         throw ValidationException(["invalid input key '$k'"]);

--- a/aqueduct/lib/src/db/managed/object.dart
+++ b/aqueduct/lib/src/db/managed/object.dart
@@ -245,13 +245,12 @@ abstract class ManagedObject<T> implements Serializable {
         return;
       }
 
-      var property = entity.properties[k];
-      if (property.autoincrement) {
-        return;
-      }
-
+      final property = entity.properties[k];
       if (property == null) {
         throw ValidationException(["invalid input key '$k'"]);
+      }
+      if (property.autoincrement) {
+        return;
       }
 
       if (property is ManagedAttributeDescription) {

--- a/aqueduct/test/db/model_test.dart
+++ b/aqueduct/test/db/model_test.dart
@@ -26,6 +26,7 @@ void main() {
       Middle,
       Bottom,
       OverrideField,
+      AutoField,
     ]);
     context = ManagedContext(dm, ps);
   });
@@ -183,6 +184,12 @@ void main() {
     expect(posts[1].id, 2);
     expect(posts[0].text, "hey");
     expect(posts[1].text, "ho");
+  });
+
+  test("Autoincrementing fields are not populated when read from map", () {
+    final map = {"id": 1, "foo": 2};
+    final a = AutoField()..readFromMap(map);
+    expect(a.backing.contents.isEmpty, true);
   });
 
   test("Reading from map with bad key fails", () {
@@ -1107,6 +1114,15 @@ class _OverrideField {
   int id;
 
   String field;
+}
+
+class AutoField extends ManagedObject<_AutoField> {}
+class _AutoField {
+  @primaryKey
+  int id;
+
+  @Column(autoincrement: true)
+  int foo;
 }
 
 T wash<T>(dynamic data) {

--- a/aqueduct/test/db/model_test.dart
+++ b/aqueduct/test/db/model_test.dart
@@ -180,15 +180,15 @@ void main() {
     expect(user.name, "Bob");
 
     var posts = postMap.map((e) => Post()..readFromMap(wash(e))).toList();
-    expect(posts[0].id, 1);
-    expect(posts[1].id, 2);
+    expect(posts[0].id, isNull);
+    expect(posts[1].id, isNull);
     expect(posts[0].text, "hey");
     expect(posts[1].text, "ho");
   });
 
   test("Autoincrementing fields are not populated when read from map", () {
     final map = {"id": 1, "foo": 2};
-    final a = AutoField()..readFromMap(map);
+    final a = AutoField()..readFromMap(wash(map));
     expect(a.backing.contents.isEmpty, true);
   });
 
@@ -255,7 +255,7 @@ void main() {
 
     var post = Post()..readFromMap(wash(postMap));
     expect(post.text, "hey");
-    expect(post.id, 1);
+    expect(post.id, isNull);
     expect(post.owner.id, 18);
     expect(post.owner.name, "Alex");
   });
@@ -312,7 +312,7 @@ void main() {
   test("mappableInput properties are read in readMap", () {
     var t = TransientTest()
       ..readFromMap(wash({"id": 1, "defaultedText": "bar foo"}));
-    expect(t.id, 1);
+    expect(t.id, isNull);
     expect(t.text, "foo");
     expect(t.inputInt, isNull);
     expect(t.inOut, isNull);
@@ -551,7 +551,7 @@ void main() {
       ]
     }));
     expect(u.posts.length, 1);
-    expect(u.posts[0].id, 1);
+    expect(u.posts[0].id, isNull);
     expect(u.posts[0].text, "Hi");
   });
 
@@ -1073,7 +1073,7 @@ class _ConstructorTableDef {
 class Top extends ManagedObject<_Top> implements _Top {}
 
 class _Top {
-  @primaryKey
+  @Column(primaryKey: true)
   int id;
 
   ManagedSet<Middle> middles;
@@ -1082,7 +1082,7 @@ class _Top {
 class Middle extends ManagedObject<_Middle> implements _Middle {}
 
 class _Middle {
-  @primaryKey
+  @Column(primaryKey: true)
   int id;
 
   @Relate(#middles)
@@ -1095,7 +1095,7 @@ class _Middle {
 class Bottom extends ManagedObject<_Bottom> implements _Bottom {}
 
 class _Bottom {
-  @primaryKey
+  @Column(primaryKey: true)
   int id;
 
   @Relate(#bottom)

--- a/aqueduct/test/http/resource_controller_body_binding_test.dart
+++ b/aqueduct/test/http/resource_controller_body_binding_test.dart
@@ -25,7 +25,7 @@ void main() {
   group("Happy path", () {
     test("Can read Map body object into Serializable", () async {
       server = await enableController("/", TestController);
-      var m = {"id": 2, "name": "Bob"};
+      var m = {"name": "Bob"};
       var response = await postJSON(m);
       expect(response.statusCode, 200);
       expect(json.decode(response.body), m);
@@ -35,8 +35,8 @@ void main() {
         () async {
       server = await enableController("/", ListTestController);
       var m = [
-        {"id": 2, "name": "Bob"},
-        {"id": 3, "name": "Fred"}
+        {"name": "Bob"},
+        {"name": "Fred"}
       ];
       var response = await postJSON(m);
       expect(response.statusCode, 200);
@@ -53,7 +53,7 @@ void main() {
 
     test("Body arg can be optional", () async {
       server = await enableController("/", OptionalTestController);
-      var m = {"id": 2, "name": "Bob"};
+      var m = {"name": "Bob"};
       var response = await postJSON(m);
       expect(response.statusCode, 200);
       expect(json.decode(response.body), m);
@@ -66,7 +66,7 @@ void main() {
 
     test("Can read body object declared as property", () async {
       server = await enableController("/", PropertyTestController);
-      var m = {"id": 2, "name": "Bob"};
+      var m = {"name": "Bob"};
       var response = await postJSON(m);
       expect(response.statusCode, 200);
       expect(json.decode(response.body), m);
@@ -85,7 +85,7 @@ void main() {
   group("Input error cases", () {
     test("Provide unknown key returns 400", () async {
       server = await enableController("/", TestController);
-      var m = {"id": 2, "name": "Bob", "job": "programmer"};
+      var m = {"name": "Bob", "job": "programmer"};
       var response = await postJSON(m);
       expect(response.statusCode, 400);
       expect(json.decode(response.body)["error"], "entity validation failed");
@@ -94,7 +94,7 @@ void main() {
 
     test("Body is empty returns 400", () async {
       server = await enableController("/", TestController);
-      var m = {"id": 2, "name": "Bob", "job": "programmer"};
+      var m = {"name": "Bob", "job": "programmer"};
       var response = await postJSON(m);
       expect(response.statusCode, 400);
       expect(json.decode(response.body)["error"], "entity validation failed");


### PR DESCRIPTION
This makes the typical behavior of having to guard against primary keys being updated the default behavior.