### PR TITLE
Query orWhere

### DIFF
--- a/aqueduct/lib/src/db/postgresql/builders/column.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/column.dart
@@ -9,8 +9,6 @@ import 'package:postgres/postgres.dart';
 abstract class Returnable {}
 
 class ColumnBuilder extends Returnable {
-  // this constructor exists to allow subclasses to have mixins: https://github.com/dart-lang/sdk/issues/15101#issuecomment-108403919
-  ColumnBuilder.mixin(this.table, this.property);
   ColumnBuilder(this.table, this.property, {this.documentKeyPath});
 
   static List<Returnable> fromKeys(TableBuilder table, List<KeyPath> keys) {

--- a/aqueduct/lib/src/db/postgresql/builders/column.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/column.dart
@@ -9,7 +9,6 @@ import 'package:postgres/postgres.dart';
 abstract class Returnable {}
 
 class ColumnBuilder extends Returnable {
-  ColumnBuilder.mixin(this.table, this.property);
   ColumnBuilder(this.table, this.property, {this.documentKeyPath});
 
   static List<Returnable> fromKeys(TableBuilder table, List<KeyPath> keys) {

--- a/aqueduct/lib/src/db/postgresql/builders/column.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/column.dart
@@ -9,6 +9,7 @@ import 'package:postgres/postgres.dart';
 abstract class Returnable {}
 
 class ColumnBuilder extends Returnable {
+  ColumnBuilder.mixin(this.table, this.property);
   ColumnBuilder(this.table, this.property, {this.documentKeyPath});
 
   static List<Returnable> fromKeys(TableBuilder table, List<KeyPath> keys) {

--- a/aqueduct/lib/src/db/postgresql/builders/column.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/column.dart
@@ -67,13 +67,13 @@ class ColumnBuilder extends Returnable {
     ManagedPropertyType.document: PostgreSQLDataType.json
   };
 
-  static Map<ComparisonOperant, String> symbolTable = {
-    ComparisonOperant.lessThan: "<",
-    ComparisonOperant.greaterThan: ">",
-    ComparisonOperant.notEqual: "!=",
-    ComparisonOperant.lessThanEqualTo: "<=",
-    ComparisonOperant.greaterThanEqualTo: ">=",
-    ComparisonOperant.equalTo: "="
+  static Map<ComparisonOperator, String> symbolTable = {
+    ComparisonOperator.lessThan: "<",
+    ComparisonOperator.greaterThan: ">",
+    ComparisonOperator.notEqual: "!=",
+    ComparisonOperator.lessThanEqualTo: "<=",
+    ComparisonOperator.greaterThanEqualTo: ">=",
+    ComparisonOperator.equalTo: "="
   };
 
   final TableBuilder table;

--- a/aqueduct/lib/src/db/postgresql/builders/column.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/column.dart
@@ -9,6 +9,8 @@ import 'package:postgres/postgres.dart';
 abstract class Returnable {}
 
 class ColumnBuilder extends Returnable {
+  // this constructor exists to allow subclasses to have mixins: https://github.com/dart-lang/sdk/issues/15101#issuecomment-108403919
+  ColumnBuilder.mixin(this.table, this.property);
   ColumnBuilder(this.table, this.property, {this.documentKeyPath});
 
   static List<Returnable> fromKeys(TableBuilder table, List<KeyPath> keys) {

--- a/aqueduct/lib/src/db/postgresql/builders/column.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/column.dart
@@ -68,13 +68,13 @@ class ColumnBuilder extends Returnable {
     ManagedPropertyType.document: PostgreSQLDataType.json
   };
 
-  static Map<PredicateOperator, String> symbolTable = {
-    PredicateOperator.lessThan: "<",
-    PredicateOperator.greaterThan: ">",
-    PredicateOperator.notEqual: "!=",
-    PredicateOperator.lessThanEqualTo: "<=",
-    PredicateOperator.greaterThanEqualTo: ">=",
-    PredicateOperator.equalTo: "="
+  static Map<ComparisonOperant, String> symbolTable = {
+    ComparisonOperant.lessThan: "<",
+    ComparisonOperant.greaterThan: ">",
+    ComparisonOperant.notEqual: "!=",
+    ComparisonOperant.lessThanEqualTo: "<=",
+    ComparisonOperant.greaterThanEqualTo: ">=",
+    ComparisonOperant.equalTo: "="
   };
 
   final TableBuilder table;

--- a/aqueduct/lib/src/db/postgresql/builders/expression.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/expression.dart
@@ -3,47 +3,231 @@ import 'package:aqueduct/src/db/postgresql/builders/column.dart';
 import 'package:aqueduct/src/db/postgresql/builders/table.dart';
 import 'package:aqueduct/src/db/query/matcher_internal.dart';
 import 'package:aqueduct/src/db/query/query.dart';
+import 'package:aqueduct/src/db/managed/key_path.dart';
 
-abstract class ColumnExpressionBuilderNode {}
-
-abstract class ColumnExpressionCombiner {
-  ColumnExpressionBuilderNode lhs;
-  ColumnExpressionBuilderNode rhs;
+abstract class ColumnExpressionBuilderNode
+    implements ColumnExpressionWithTables, ColumnExpressionWithPredicate {
+  ColumnExpressionBuilderORNode or(ColumnExpressionBuilderNode builder);
+  ColumnExpressionBuilderANDNode and(ColumnExpressionBuilderNode builder);
 }
 
-class ColumnExpressionBuilderORNode implements ColumnExpressionBuilderNode, ColumnExpressionCombiner {
+abstract class AbstractColumnExpressionCombiner {
   ColumnExpressionBuilderNode lhs;
   ColumnExpressionBuilderNode rhs;
-  ColumnExpressionBuilderORNode(this.lhs, this.rhs);
-}
-class ColumnExpressionBuilderANDNode implements ColumnExpressionBuilderNode, ColumnExpressionCombiner {
-  ColumnExpressionBuilderNode lhs;
-  ColumnExpressionBuilderNode rhs;
-  ColumnExpressionBuilderANDNode(this.lhs, this.rhs);
+  AbstractColumnExpressionCombiner(this.lhs, this.rhs);
 }
 
-class ColumnExpressionBuilderGroupORNode implements ColumnExpressionBuilderNode, ColumnExpressionCombiner {
-  ColumnExpressionBuilderNode lhs;
-  ColumnExpressionBuilderNode rhs;
-  ColumnExpressionBuilderGroupORNode(this.lhs, this.rhs);
+abstract class ColumnExpressionWithPredicate {
+  QueryPredicate get predicate;
 }
 
-class ColumnExpressionBuilderGroupAndNode implements ColumnExpressionBuilderNode, ColumnExpressionCombiner {
-  ColumnExpressionBuilderNode lhs;
-  ColumnExpressionBuilderNode rhs;
-  ColumnExpressionBuilderGroupAndNode(this.lhs, this.rhs);
+abstract class ColumnExpressionWithPredicateMixin
+    implements ColumnExpressionBuilderNode {
+  QueryPredicate get predicate => getPredicateFromNode(this);
+
+  static QueryPredicate getPredicateFromNode(ColumnExpressionBuilderNode node) {
+    if (node is ColumnExpressionBuilder) {
+      return node.predicate;
+    }
+    if (node is ColumnExpressionBuilderANDNode) {
+      return QueryPredicate.and([
+        getPredicateFromNode(node.lhs),
+        getPredicateFromNode(node.rhs)
+      ]);
+    }
+    if (node is ColumnExpressionBuilderORNode) {
+      return QueryPredicate.or([
+        getPredicateFromNode(node.lhs),
+        getPredicateFromNode(node.rhs)
+      ]);
+    }
+    if (node is ColumnExpressionBuilderGroupAndNode) {
+      return QueryPredicate.andGroup(
+          getPredicateFromNode(node.lhs),
+          getPredicateFromNode(node.rhs)
+      );
+    }
+    if (node is ColumnExpressionBuilderGroupORNode) {
+      return QueryPredicate.orGroup(
+          getPredicateFromNode(node.lhs),
+          getPredicateFromNode(node.rhs)
+      );
+    }
+
+    return QueryPredicate.empty();
+  }
 }
 
-class ColumnExpressionBuilder extends ColumnBuilder implements ColumnExpressionBuilderNode {
-  ColumnExpressionBuilder(
-      TableBuilder table, ManagedPropertyDescription property, this.expression,
-      {this.prefix = ""})
-      : super(table, property);
+abstract class ColumnExpressionWithTables {
+  List<TableBuilder> get tables;
+}
 
-  final String prefix;
+abstract class ColumnExpressionWithTablesMixin
+    implements ColumnExpressionBuilderNode {
+  List<TableBuilder> get tables {
+    if (this is ColumnExpressionBuilder) {
+      return [(this as ColumnExpressionBuilder).table];
+    } else if (this is AbstractColumnExpressionCombiner) {
+      final combiner = this as AbstractColumnExpressionCombiner;
+      return combiner.lhs.tables..addAll(combiner.rhs.tables);
+    } else {
+      return []; //should assert here?
+    }
+  }
+}
+
+abstract class ExpressionMixin implements ColumnExpressionBuilderNode {
+  ColumnExpressionBuilderORNode or(ColumnExpressionBuilderNode builder) =>
+      ColumnExpressionBuilderORNode(this, builder);
+
+  ColumnExpressionBuilderANDNode and(ColumnExpressionBuilderNode builder) =>
+      ColumnExpressionBuilderANDNode(this, builder);
+}
+
+class ColumnExpressionBuilderORNode = AbstractColumnExpressionCombiner
+    with
+        ExpressionMixin,
+        ColumnExpressionWithTablesMixin,
+        ColumnExpressionWithPredicateMixin
+    implements ColumnExpressionBuilderNode;
+
+class ColumnExpressionBuilderANDNode = AbstractColumnExpressionCombiner
+    with
+        ExpressionMixin,
+        ColumnExpressionWithTablesMixin,
+        ColumnExpressionWithPredicateMixin
+    implements ColumnExpressionBuilderNode;
+
+class ColumnExpressionBuilderGroupORNode = AbstractColumnExpressionCombiner
+    with
+        ExpressionMixin,
+        ColumnExpressionWithTablesMixin,
+        ColumnExpressionWithPredicateMixin
+    implements ColumnExpressionBuilderNode;
+
+class ColumnExpressionBuilderGroupAndNode = AbstractColumnExpressionCombiner
+    with
+        ExpressionMixin,
+        ColumnExpressionWithTablesMixin,
+        ColumnExpressionWithPredicateMixin
+    implements ColumnExpressionBuilderNode;
+
+class ColumnExpressionBuilder extends ColumnBuilder with ExpressionMixin, ColumnExpressionWithTablesMixin, ColumnExpressionWithPredicateMixin implements ColumnExpressionBuilderNode {
+  ColumnExpressionBuilder.property(TableBuilder table, this.expression, ManagedPropertyDescription property) :
+      super.mixin(table, property);
+  ColumnExpressionBuilder.keyPath(TableBuilder table, this.expression, KeyPath keyPath) :
+        super.mixin(isOnJoinedTable(keyPath)
+              ? _findJoinedTable(table, keyPath)
+              : table,
+          getProperty(keyPath)
+      );
+
+  static ColumnExpressionBuilderNode query(TableBuilder table,
+      QueryExpression expression) {
+    final predicateExpression = expression.expression;
+    if (predicateExpression is AndExpression) {
+      return ColumnExpressionBuilderANDNode(
+          ColumnExpressionBuilder.query(table, predicateExpression.lhs),
+          ColumnExpressionBuilder.query(table, predicateExpression.rhs)
+      );
+    } else if (predicateExpression is AndGroupExpression) {
+        return ColumnExpressionBuilderGroupAndNode(
+            ColumnExpressionBuilder.query(table, predicateExpression.lhs),
+            ColumnExpressionBuilder.query(table, predicateExpression.rhs)
+        );
+    } else if (predicateExpression is OrExpression) {
+      return ColumnExpressionBuilderORNode(
+          ColumnExpressionBuilder.query(table, predicateExpression.lhs),
+          ColumnExpressionBuilder.query(table, predicateExpression.rhs)
+      );
+    } else if (predicateExpression is OrGroupExpression) {
+      return ColumnExpressionBuilderGroupORNode(
+          ColumnExpressionBuilder.query(table, predicateExpression.lhs),
+          ColumnExpressionBuilder.query(table, predicateExpression.rhs)
+      );
+    } else {
+      return ColumnExpressionBuilder.keyPath(
+          table, expression.expression, expression.keyPath);
+    }
+  }
+
+  static bool isOnJoinedTable(KeyPath keyPath) {
+    final firstElement = keyPath.path.first;
+    final lastElement = keyPath.path.last;
+
+    bool isPropertyOnThisEntity = keyPath.length == 1;
+    bool isForeignKey = keyPath.length == 2 &&
+        lastElement is ManagedAttributeDescription &&
+        lastElement.isPrimaryKey &&
+        firstElement is ManagedRelationshipDescription &&
+        firstElement.isBelongsTo;
+    bool isBelongsTo = lastElement is ManagedRelationshipDescription &&
+        lastElement.isBelongsTo;
+    bool isColumn = lastElement is ManagedAttributeDescription || isBelongsTo;
+
+    return (!((isPropertyOnThisEntity && isColumn) || // TODO: further understand to decmopose these into named variables
+        isForeignKey)
+        && !(keyPath.length == 0
+            || (keyPath.length == 1 &&
+                keyPath[0] is! ManagedRelationshipDescription)
+        )
+    );
+  }
+
+  static TableBuilder _findJoinedTable(TableBuilder table, KeyPath keyPath) {
+    // creates & joins a TableBuilder for any relationship in keyPath
+    // if it doesn't exist.
+    if (keyPath.length == 0) {
+      return table;
+    } else if (keyPath.length == 1 && keyPath[0] is! ManagedRelationshipDescription) {
+      return table;
+    } else {
+      final ManagedRelationshipDescription head = keyPath[0];
+      TableBuilder join = table.returning
+          .whereType<TableBuilder>()
+          .firstWhere((m) => m.isJoinOnProperty(head), orElse: () => null);
+      if (join == null) {
+        join = TableBuilder.implicit(table, head);
+        table.addJoinTableBuilder(join);
+      }
+      return _findJoinedTable(join, KeyPath.byRemovingFirstNKeys(keyPath, 1));
+    }
+  }
+
+  static ManagedPropertyDescription getProperty(KeyPath keyPath) {
+    final firstElement = keyPath.path.first;
+    final lastElement = keyPath.path.last;
+
+    bool isPropertyOnThisEntity = keyPath.length == 1;
+    bool isForeignKey = keyPath.length == 2 &&
+        lastElement is ManagedAttributeDescription &&
+        lastElement.isPrimaryKey &&
+        firstElement is ManagedRelationshipDescription &&
+        firstElement.isBelongsTo;
+    bool isBelongsTo = lastElement is ManagedRelationshipDescription &&
+        lastElement.isBelongsTo;
+    bool isColumn = lastElement is ManagedAttributeDescription || isBelongsTo;
+
+    if (isPropertyOnThisEntity && isColumn) {
+      // This will occur if we selected a column.
+      return lastElement;
+    } else if (isForeignKey) {
+      // This will occur if we selected a belongs to relationship or a belongs to relationship's
+      // primary key. In either case, this is a column in this table (a foreign key column).
+      return firstElement;
+    } else if (lastElement is ManagedRelationshipDescription) {
+      final inversePrimaryKey = lastElement.inverse.entity.primaryKeyAttribute;
+      return inversePrimaryKey;
+    } else {
+      return lastElement;
+    }
+  }
+
   PredicateExpression expression;
 
   String get defaultPrefix => "$prefix${table.sqlTableReference}_";
+
+  String get prefix => table.tableAlias != null ? table.tableAlias : "";
 
   QueryPredicate get predicate {
     var expr = expression;

--- a/aqueduct/lib/src/db/postgresql/builders/expression.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/expression.dart
@@ -41,8 +41,8 @@ class ColumnExpressionBuilder {
   List<TableBuilder> _getTablesFromExpression(Tree<QueryExpression> expression, TableBuilder table) {
     List<TableBuilder> tables = [];
 
-    if (expression is LogicalOperantNode<Tree<QueryExpression>>) {
-      final node = expression as LogicalOperantNode<Tree<QueryExpression>>;
+    if (expression is LogicalOperatorNode<Tree<QueryExpression>>) {
+      final node = expression as LogicalOperatorNode<Tree<QueryExpression>>;
       tables.addAll(_getTablesFromExpression(node.operand, table));
       tables.addAll(_getTablesFromExpression(node.operand2, table));
     } else if (expression is LeafNode<QueryExpression>) {
@@ -78,8 +78,8 @@ class ColumnExpressionBuilder {
   }
 
   QueryPredicate _getExplicitPredicate(PredicateExpression predicateExpression, ManagedPropertyDescription property) {
-    if (predicateExpression is LogicalOperantNode<Tree<QueryExpression>>) {
-      final node = predicateExpression as LogicalOperantNode<Tree<QueryExpression>>;
+    if (predicateExpression is LogicalOperatorNode<Tree<QueryExpression>>) {
+      final node = predicateExpression as LogicalOperatorNode<Tree<QueryExpression>>;
       return _getPredicateFromBranchNode(node);
     } else {
       return _getPredicateFromLeaf(predicateExpression, property: property);
@@ -87,8 +87,8 @@ class ColumnExpressionBuilder {
   }
 
   QueryPredicate _getPredicateFromExpression(Tree<QueryExpression> expression) {
-    if (expression is LogicalOperantNode<Tree<QueryExpression>>) {
-      final node = expression as LogicalOperantNode<Tree<QueryExpression>>;
+    if (expression is LogicalOperatorNode<Tree<QueryExpression>>) {
+      final node = expression as LogicalOperatorNode<Tree<QueryExpression>>;
       return _getPredicateFromBranchNode(node);
     } else if (expression is LeafNode<QueryExpression>){
       return _getPredicateFromLeaf(expression.value.expression, keyPath: expression.value.keyPath);
@@ -97,7 +97,7 @@ class ColumnExpressionBuilder {
     throw "Unreachable";
   }
 
-  QueryPredicate _getPredicateFromBranchNode(LogicalOperantNode<Tree<QueryExpression>> expression) {
+  QueryPredicate _getPredicateFromBranchNode(LogicalOperatorNode<Tree<QueryExpression>> expression) {
     final lhs = _getPredicateFromExpression(expression.operand);
     final rhs = _getPredicateFromExpression(expression.operand2);
 
@@ -126,9 +126,9 @@ class ColumnExpressionBuilder {
     }
 
     if (predicateExpression is ComparisonExpression) {
-      return columnExpression.comparisonPredicate(predicateExpression.operant, predicateExpression.operand);
+      return columnExpression.comparisonPredicate(predicateExpression.operator, predicateExpression.operand);
     } else if (predicateExpression is RangeExpression) {
-      return columnExpression.rangePredicate(predicateExpression.operand, predicateExpression.operand2, insideRange: predicateExpression.operant == RangeOperant.between);
+      return columnExpression.rangePredicate(predicateExpression.operand, predicateExpression.operand2, insideRange: predicateExpression.operator == RangeOperator.between);
     } else if (predicateExpression is NullCheckExpression) {
       return columnExpression.nullPredicate(isNull: predicateExpression.operand);
     } else if (predicateExpression is SetMembershipExpression) {
@@ -227,7 +227,7 @@ class ColumnExpressionConcrete extends ColumnBuilder {
   String get prefix => table.tableAlias != null ? table.tableAlias : "";
 
   QueryPredicate comparisonPredicate(
-      ComparisonOperant operator, dynamic value) {
+      ComparisonOperator operator, dynamic value) {
     var name = sqlColumnName(withTableNamespace: true);
     var variableName = sqlColumnName(withPrefix: defaultPrefix);
 
@@ -278,7 +278,7 @@ class ColumnExpressionConcrete extends ColumnBuilder {
   }
 
   QueryPredicate stringPredicate(
-      StringComparisonOperant operator, dynamic value,
+      StringComparisonOperator operator, dynamic value,
       {bool caseSensitive = true, bool invertOperator = false}) {
     var n = sqlColumnName(withTableNamespace: true);
     var variableName = sqlColumnName(withPrefix: defaultPrefix);
@@ -289,13 +289,13 @@ class ColumnExpressionConcrete extends ColumnBuilder {
       operation = "NOT $operation";
     }
     switch (operator) {
-      case StringComparisonOperant.beginsWith:
+      case StringComparisonOperator.beginsWith:
         matchValue = "$value%";
         break;
-      case StringComparisonOperant.endsWith:
+      case StringComparisonOperator.endsWith:
         matchValue = "%$value";
         break;
-      case StringComparisonOperant.contains:
+      case StringComparisonOperator.contains:
         matchValue = "%$value%";
         break;
       default:

--- a/aqueduct/lib/src/db/postgresql/builders/expression.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/expression.dart
@@ -94,9 +94,9 @@ class ColumnExpressionBuilder {
     final rhs = _getPredicate(queryExpression: expression.operand2);
 
     if (expression is AndExpression<QueryExpression>) {
-      return QueryPredicate.and([lhs, rhs], isGrouped: expression.isGrouped);
+      return QueryPredicate.and([lhs, rhs]);
     } else if (expression is OrExpression<QueryExpression>) {
-      return QueryPredicate.or([lhs, rhs], isGrouped: expression.isGrouped);
+      return QueryPredicate.or([lhs, rhs]);
     }
   }
 

--- a/aqueduct/lib/src/db/postgresql/builders/expression.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/expression.dart
@@ -4,7 +4,37 @@ import 'package:aqueduct/src/db/postgresql/builders/table.dart';
 import 'package:aqueduct/src/db/query/matcher_internal.dart';
 import 'package:aqueduct/src/db/query/query.dart';
 
-class ColumnExpressionBuilder extends ColumnBuilder {
+abstract class ColumnExpressionBuilderNode {}
+
+abstract class ColumnExpressionCombiner {
+  ColumnExpressionBuilderNode lhs;
+  ColumnExpressionBuilderNode rhs;
+}
+
+class ColumnExpressionBuilderORNode implements ColumnExpressionBuilderNode, ColumnExpressionCombiner {
+  ColumnExpressionBuilderNode lhs;
+  ColumnExpressionBuilderNode rhs;
+  ColumnExpressionBuilderORNode(this.lhs, this.rhs);
+}
+class ColumnExpressionBuilderANDNode implements ColumnExpressionBuilderNode, ColumnExpressionCombiner {
+  ColumnExpressionBuilderNode lhs;
+  ColumnExpressionBuilderNode rhs;
+  ColumnExpressionBuilderANDNode(this.lhs, this.rhs);
+}
+
+class ColumnExpressionBuilderGroupORNode implements ColumnExpressionBuilderNode, ColumnExpressionCombiner {
+  ColumnExpressionBuilderNode lhs;
+  ColumnExpressionBuilderNode rhs;
+  ColumnExpressionBuilderGroupORNode(this.lhs, this.rhs);
+}
+
+class ColumnExpressionBuilderGroupAndNode implements ColumnExpressionBuilderNode, ColumnExpressionCombiner {
+  ColumnExpressionBuilderNode lhs;
+  ColumnExpressionBuilderNode rhs;
+  ColumnExpressionBuilderGroupAndNode(this.lhs, this.rhs);
+}
+
+class ColumnExpressionBuilder extends ColumnBuilder implements ColumnExpressionBuilderNode {
   ColumnExpressionBuilder(
       TableBuilder table, ManagedPropertyDescription property, this.expression,
       {this.prefix = ""})

--- a/aqueduct/lib/src/db/postgresql/builders/table.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/table.dart
@@ -69,7 +69,7 @@ class TableBuilder implements Returnable {
   final ManagedEntity entity;
   final TableBuilder parent;
   final ManagedRelationshipDescription joinedBy;
-  ColumnExpressionNode columnExpressionBuilderNode;
+  Tree columnExpressionBuilderNode;
   String tableAlias;
   QueryPredicate predicate;
   List<ColumnSortBuilder> columnSortBuilders;

--- a/aqueduct/lib/src/db/postgresql/builders/table.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/table.dart
@@ -45,7 +45,7 @@ class TableBuilder implements Returnable {
           parent: this, joinedBy: relationshipDesc));
     });
 
-    addColumnExpressions(query.expressions);
+    addColumnExpressions(query.expression);
   }
 
   TableBuilder.implicit(this.parent, this.joinedBy)
@@ -130,24 +130,19 @@ class TableBuilder implements Returnable {
   }
 
   void addColumnExpressions(
-      List<QueryExpression<dynamic, dynamic, dynamic>> expressions) {
-    if (expressions == null) {
+      QueryExpression<dynamic, dynamic, dynamic> expression) {
+    if (expression == null) {
       return;
     }
 
-    if (expressions.isEmpty) {
-      return;
-    }
-
-    final expression = expressions.first;
     final predicateExpression = expression.expression;
     if (predicateExpression is AndExpression) {
-      addColumnExpressions([predicateExpression.lhs]);
-      addColumnExpressions([predicateExpression.rhs]);
+      addColumnExpressions(predicateExpression.lhs);
+      addColumnExpressions(predicateExpression.rhs);
       return;
     }
 
-    expressions.forEach(addColumnExpression);
+    addColumnExpression(expression);
   }
 
   void addColumnExpression(QueryExpression<dynamic, dynamic, dynamic> expression) {

--- a/aqueduct/lib/src/db/postgresql/builders/table.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/table.dart
@@ -32,8 +32,8 @@ class TableBuilder implements Returnable {
       if (query.pageDescriptor.boundingValue != null) {
         final prop = entity.properties[query.pageDescriptor.propertyName];
         final operator = query.pageDescriptor.order == QuerySortOrder.ascending
-            ? PredicateOperator.greaterThan
-            : PredicateOperator.lessThan;
+            ? ComparisonOperant.greaterThan
+            : ComparisonOperant.lessThan;
         final expr = ColumnExpressionBuilder.property(this,
             ComparisonExpression(query.pageDescriptor.boundingValue, operator), prop);
         columnExpressionBuilderNode = expr;
@@ -69,7 +69,7 @@ class TableBuilder implements Returnable {
   final ManagedEntity entity;
   final TableBuilder parent;
   final ManagedRelationshipDescription joinedBy;
-  Tree columnExpressionBuilderNode;
+  ColumnExpression columnExpressionBuilderNode;
   String tableAlias;
   QueryPredicate predicate;
   List<ColumnSortBuilder> columnSortBuilders;

--- a/aqueduct/lib/src/db/postgresql/builders/table.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/table.dart
@@ -53,7 +53,7 @@ class TableBuilder implements Returnable {
     }
 
     if (columnExpressionBuilder != null) {
-      columnExpressionBuilder.queryExpression = query.expression;
+      columnExpressionBuilder.expressionTree = query.expression;
     } else {
       columnExpressionBuilder = ColumnExpressionBuilder(this, query.expression);
     }

--- a/aqueduct/lib/src/db/postgresql/builders/table.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/table.dart
@@ -30,8 +30,8 @@ class TableBuilder implements Returnable {
       if (query.pageDescriptor.boundingValue != null) {
         final prop = entity.properties[query.pageDescriptor.propertyName];
         final operator = query.pageDescriptor.order == QuerySortOrder.ascending
-            ? ComparisonOperant.greaterThan
-            : ComparisonOperant.lessThan;
+            ? ComparisonOperator.greaterThan
+            : ComparisonOperator.lessThan;
         final expr = ColumnExpressionBuilder.property(
             this,
             ComparisonExpression(query.pageDescriptor.boundingValue, operator),

--- a/aqueduct/lib/src/db/postgresql/builders/table.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/table.dart
@@ -34,8 +34,8 @@ class TableBuilder implements Returnable {
         final operator = query.pageDescriptor.order == QuerySortOrder.ascending
             ? PredicateOperator.greaterThan
             : PredicateOperator.lessThan;
-        final expr = ColumnExpressionBuilder(this, prop,
-            ComparisonExpression(query.pageDescriptor.boundingValue, operator));
+        final expr = ColumnExpressionBuilder.property(this,
+            ComparisonExpression(query.pageDescriptor.boundingValue, operator), prop);
         columnExpressionBuilderNode = expr;
       }
     }
@@ -45,13 +45,17 @@ class TableBuilder implements Returnable {
           parent: this, joinedBy: relationshipDesc));
     });
 
-    if (columnExpressionBuilderNode == null) {
-      columnExpressionBuilderNode = addColumnExpressions(query.expression);
-    } else {
-      columnExpressionBuilderNode = ColumnExpressionBuilderANDNode(
-          columnExpressionBuilderNode,
-          addColumnExpressions(query.expression));
+    final predicateExpression = query.expression;
+
+    if (predicateExpression == null) {
+      return;
     }
+
+    final queryNode = ColumnExpressionBuilder.query(this, query.expression);
+
+    columnExpressionBuilderNode = (columnExpressionBuilderNode == null)
+        ? queryNode
+        : columnExpressionBuilderNode.and(queryNode);
   }
 
   TableBuilder.implicit(this.parent, this.joinedBy)
@@ -122,11 +126,13 @@ class TableBuilder implements Returnable {
   }
 
   void finalize(Map<String, dynamic> variables) {
-    final expressionPredicate = queryPredicateFromNode(columnExpressionBuilderNode);
+    final expressionPredicate = columnExpressionBuilderNode != null
+        ? columnExpressionBuilderNode.predicate
+        : QueryPredicate.empty();
 
     predicate = _manualPredicate != null
     ? QueryPredicate.and([_manualPredicate, expressionPredicate])
-    : queryPredicateFromNode(columnExpressionBuilderNode);
+    : expressionPredicate;
 
     if (predicate?.parameters != null) {
       variables.addAll(predicate.parameters);
@@ -135,139 +141,6 @@ class TableBuilder implements Returnable {
     returning.whereType<TableBuilder>().forEach((r) {
       r.finalize(variables);
     });
-  }
-
-  QueryPredicate queryPredicateFromNode(ColumnExpressionBuilderNode node) {
-    if (node is ColumnExpressionBuilderANDNode) {
-      return QueryPredicate.and(
-          [queryPredicateFromNode(node.lhs), queryPredicateFromNode(node.rhs)]);
-    }
-    if (node is ColumnExpressionBuilderORNode) {
-      return QueryPredicate.or(
-          [queryPredicateFromNode(node.lhs), queryPredicateFromNode(node.rhs)]);
-    }
-
-    if ( node is ColumnExpressionBuilderGroupAndNode ) {
-      return QueryPredicate.andGroup(queryPredicateFromNode(node.lhs), queryPredicateFromNode(node.rhs));
-    }
-
-    if ( node is ColumnExpressionBuilderGroupORNode ) {
-      return QueryPredicate.orGroup(queryPredicateFromNode(node.lhs), queryPredicateFromNode(node.rhs));
-    }
-
-    if (node is ColumnExpressionBuilder) {
-      return node.predicate;
-    }
-
-    return QueryPredicate.empty();
-  }
-
-  ColumnExpressionBuilderNode addColumnExpressions(
-      QueryExpression<dynamic, dynamic, dynamic> expression) {
-    if (expression == null) {
-      return;
-    }
-
-    final predicateExpression = expression.expression;
-
-    if (predicateExpression is AndGroupExpression) {
-      return ColumnExpressionBuilderGroupAndNode(
-          addColumnExpressions(predicateExpression.lhs),
-          addColumnExpressions(predicateExpression.rhs)
-      );
-    }
-
-    if (predicateExpression is OrGroupExpression) {
-      return ColumnExpressionBuilderGroupORNode(
-          addColumnExpressions(predicateExpression.lhs),
-          addColumnExpressions(predicateExpression.rhs)
-      );
-    }
-
-    if (predicateExpression is AndExpression) {
-      return ColumnExpressionBuilderANDNode(
-          addColumnExpressions(predicateExpression.lhs),
-          addColumnExpressions(predicateExpression.rhs)
-      );
-    }
-
-    if (predicateExpression is OrExpression) {
-      return ColumnExpressionBuilderORNode(
-          addColumnExpressions(predicateExpression.lhs),
-          addColumnExpressions(predicateExpression.rhs)
-      );
-    }
-
-    final firstElement = expression.keyPath.path.first;
-    final lastElement = expression.keyPath.path.last;
-
-    bool isPropertyOnThisEntity = expression.keyPath.length == 1;
-    bool isForeignKey = expression.keyPath.length == 2 &&
-        lastElement is ManagedAttributeDescription &&
-        lastElement.isPrimaryKey &&
-        firstElement is ManagedRelationshipDescription &&
-        firstElement.isBelongsTo;
-
-    if (isPropertyOnThisEntity) {
-      bool isBelongsTo = lastElement is ManagedRelationshipDescription &&
-          lastElement.isBelongsTo;
-      bool isColumn =
-          lastElement is ManagedAttributeDescription || isBelongsTo;
-
-      if (isColumn) {
-        // This will occur if we selected a column.
-        final expr =
-        ColumnExpressionBuilder(this, lastElement, expression.expression);
-        return expr;
-      }
-    } else if (isForeignKey) {
-      // This will occur if we selected a belongs to relationship or a belongs to relationship's
-      // primary key. In either case, this is a column in this table (a foreign key column).
-      final expr = ColumnExpressionBuilder(
-          this, expression.keyPath.path.first, expression.expression);
-      return expr;
-    }
-
-    return addColumnExpressionToJoinedTable(expression);
-  }
-
-  ColumnExpressionBuilder addColumnExpressionToJoinedTable(
-      QueryExpression<dynamic, dynamic, dynamic> expression) {
-    TableBuilder joinedTable = _findJoinedTable(expression.keyPath);
-    final lastElement = expression.keyPath.path.last;
-    if (lastElement is ManagedRelationshipDescription) {
-      final inversePrimaryKey = lastElement.inverse.entity.primaryKeyAttribute;
-      final expr = ColumnExpressionBuilder(
-          joinedTable, inversePrimaryKey, expression.expression,
-          prefix: tableAlias);
-      return expr;
-    } else {
-      final expr = ColumnExpressionBuilder(
-          joinedTable, lastElement, expression.expression,
-          prefix: tableAlias);
-      return expr;
-    }
-  }
-
-  TableBuilder _findJoinedTable(KeyPath keyPath) {
-    // creates & joins a TableBuilder for any relationship in keyPath
-    // if it doesn't exist.
-    if (keyPath.length == 0) {
-      return this;
-    } else if (keyPath.length == 1 &&
-        keyPath[0] is! ManagedRelationshipDescription) {
-      return this;
-    } else {
-      final ManagedRelationshipDescription head = keyPath[0];
-      TableBuilder join = returning
-          .whereType<TableBuilder>()
-          .firstWhere((m) => m.isJoinOnProperty(head), orElse: () => null);
-      if (join == null) {
-        join = TableBuilder.implicit(this, head);
-        addJoinTableBuilder(join);
-      }
-      return join._findJoinedTable(KeyPath.byRemovingFirstNKeys(keyPath, 1));
-    }
   }
 
   void addJoinTableBuilder(TableBuilder r) {
@@ -335,11 +208,9 @@ class TableBuilder implements Returnable {
     // If we have a predicate that references a column in a joined table,
     // then we can't use a simple join, we have to use an inner select.
     final joinedTables = returning.whereType<TableBuilder>().toList();
-    final columnExpressionTables = columnExpressionBuilderNode != null
-        ? getTablesFromBuilderNode(columnExpressionBuilderNode)
-        : [];
 
-    if (columnExpressionTables.any((table) => joinedTables.contains(table))) {
+    if (columnExpressionBuilderNode != null
+        && columnExpressionBuilderNode.tables.any((table) => joinedTables.contains(table))) {
       return sqlInnerSelect;
     }
 
@@ -357,14 +228,5 @@ class TableBuilder implements Returnable {
     }
 
     return thisJoin;
-  }
-
-  List<TableBuilder> getTablesFromBuilderNode(ColumnExpressionBuilderNode node) {
-    if (node is ColumnExpressionCombiner) {
-      final combinerNode = node as ColumnExpressionCombiner;
-      return getTablesFromBuilderNode(combinerNode.lhs).addAll(getTablesFromBuilderNode(combinerNode.rhs));
-    }
-
-    return [(node as ColumnExpressionBuilder).table];
   }
 }

--- a/aqueduct/lib/src/db/postgresql/builders/table.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/table.dart
@@ -69,7 +69,7 @@ class TableBuilder implements Returnable {
   final ManagedEntity entity;
   final TableBuilder parent;
   final ManagedRelationshipDescription joinedBy;
-  ColumnExpressionBuilderNode columnExpressionBuilderNode;
+  ColumnExpressionNode columnExpressionBuilderNode;
   String tableAlias;
   QueryPredicate predicate;
   List<ColumnSortBuilder> columnSortBuilders;

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -21,14 +21,10 @@ class QueryExpression<T, U, InstanceType> {
       : keyPath = KeyPath.byAddingKey(original.keyPath, byAdding),
         _expression = original.expression;
 
-  QueryExpression.and(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
-        _expression = AndExpression(lhs, rhs);
-  QueryExpression.or(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
-        _expression = OrExpression(lhs, rhs);
-  QueryExpression.andGroup(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
-      _expression = AndGroupExpression(lhs, rhs);
-  QueryExpression.orGroup(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
-        _expression = OrGroupExpression(lhs, rhs);
+  QueryExpression.and(QueryExpression lhs, QueryExpression rhs, {bool isGrouped = false}):
+        _expression = AndExpression(lhs, rhs, isGrouped: isGrouped);
+  QueryExpression.or(QueryExpression lhs, QueryExpression rhs, {bool isGrouped = false}):
+        _expression = OrExpression(lhs, rhs, isGrouped: isGrouped);
 
   final KeyPath keyPath;
 
@@ -73,13 +69,13 @@ class QueryExpression<T, U, InstanceType> {
   ///       final query = new Query<User>()
   ///         ..where((u) => u.id ).equalTo(1);
   ///
-  equalTo(T value,
+  void equalTo(T value,
       {bool caseSensitive = true}) {
     if (value is String) {
-      expression = StringExpression(value, PredicateStringOperator.equals,
+      expression = StringExpression(value, StringComparisonOperant.equals,
           caseSensitive: caseSensitive);
     } else {
-      expression = ComparisonExpression(value, PredicateOperator.equalTo);
+      expression = ComparisonExpression(value, ComparisonOperant.equalTo);
     }
   }
 
@@ -96,13 +92,13 @@ class QueryExpression<T, U, InstanceType> {
   ///       final query = new Query<Employee>()
   ///         ..where((e) => e.id).notEqualTo(60000);
   ///
-  notEqualTo(T value,
+  void notEqualTo(T value,
       {bool caseSensitive = true}) {
     if (value is String) {
-      expression = StringExpression(value, PredicateStringOperator.equals,
+      expression = StringExpression(value, StringComparisonOperant.equals,
           caseSensitive: caseSensitive, invertOperator: true);
     } else {
-      expression = ComparisonExpression(value, PredicateOperator.notEqual);
+      expression = ComparisonExpression(value, ComparisonOperant.notEqual);
     }
   }
 
@@ -118,8 +114,8 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).greaterThan(60000);
-  greaterThan(T value) {
-    expression = ComparisonExpression(value, PredicateOperator.greaterThan);
+  void greaterThan(T value) {
+    expression = ComparisonExpression(value, ComparisonOperant.greaterThan);
     }
 
   /// Adds a 'greater than or equal to' expression to a query.
@@ -133,9 +129,9 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).greaterThanEqualTo(60000);
-  greaterThanEqualTo(T value) {
+  void greaterThanEqualTo(T value) {
     expression =
-        ComparisonExpression(value, PredicateOperator.greaterThanEqualTo);
+        ComparisonExpression(value, ComparisonOperant.greaterThanEqualTo);
     }
 
   /// Adds a 'less than' expression to a query.
@@ -149,8 +145,8 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).lessThan(60000);
-  lessThan(T value) {
-    expression = ComparisonExpression(value, PredicateOperator.lessThan);
+  void lessThan(T value) {
+    expression = ComparisonExpression(value, ComparisonOperant.lessThan);
     }
 
   /// Adds a 'less than or equal to' expression to a query.
@@ -164,8 +160,8 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).lessThanEqualTo(60000);
-  lessThanEqualTo(T value) {
-    expression = ComparisonExpression(value, PredicateOperator.lessThanEqualTo);
+  void lessThanEqualTo(T value) {
+    expression = ComparisonExpression(value, ComparisonOperant.lessThanEqualTo);
     }
 
   /// Adds a 'contains string' expression to a query.
@@ -180,9 +176,9 @@ class QueryExpression<T, U, InstanceType> {
   ///       var query = new Query<Employee>()
   ///         ..where((s) => s.title).contains("Director");
   ///
-   contains(String value,
+  void contains(String value,
       {bool caseSensitive = true}) {
-    expression = StringExpression(value, PredicateStringOperator.contains,
+    expression = StringExpression(value, StringComparisonOperant.contains,
         caseSensitive: caseSensitive);
     }
 
@@ -196,9 +192,9 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((s) => s.name).beginsWith("B");
-  beginsWith(String value,
+  void beginsWith(String value,
       {bool caseSensitive = true}) {
-    expression = StringExpression(value, PredicateStringOperator.beginsWith,
+    expression = StringExpression(value, StringComparisonOperant.beginsWith,
         caseSensitive: caseSensitive);
     }
 
@@ -212,9 +208,9 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.name).endsWith("son");
-  endsWith(String value,
+  void endsWith(String value,
       {bool caseSensitive = true}) {
-    expression = StringExpression(value, PredicateStringOperator.endsWith,
+    expression = StringExpression(value, StringComparisonOperant.endsWith,
         caseSensitive: caseSensitive);
 
   }
@@ -229,7 +225,7 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.department).oneOf(["Engineering", "HR"]);
-  oneOf(Iterable<T> values) {
+  void oneOf(Iterable<T> values) {
     if (values?.isEmpty ?? true) {
       throw ArgumentError("'Query.where.oneOf' cannot be the empty set or null.");
     }
@@ -248,8 +244,8 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).between(80000, 100000);
-  between(T lhs, T rhs) {
-    expression = RangeExpression(lhs, rhs, within: true);
+  void between(T lhs, T rhs) {
+    expression = RangeExpression<T>(lhs, rhs, scope: RangeOperant.between);
 
   }
 
@@ -265,8 +261,8 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).outsideOf(80000, 100000);
-  outsideOf(T lhs, T rhs) {
-    expression = RangeExpression(lhs, rhs, within: false);
+  void outsideOf(T lhs, T rhs) {
+    expression = RangeExpression(lhs, rhs, scope: RangeOperant.notBetween);
 
   }
 
@@ -279,8 +275,8 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var q = new Query<Employee>()
   ///         ..where((e) => e.manager).identifiedBy(5);
-  identifiedBy(dynamic identifier) {
-    expression = ComparisonExpression(identifier, PredicateOperator.equalTo);
+  void identifiedBy(dynamic identifier) {
+    expression = ComparisonExpression(identifier, ComparisonOperant.equalTo);
 
   }
 
@@ -294,7 +290,7 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var q = new Query<Employee>()
   ///         ..where((e) => e.manager).isNull();
-  isNull() {
+  void isNull() {
     expression = const NullCheckExpression(shouldBeNull: true);
 
   }
@@ -309,7 +305,7 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///       var q = new Query<Employee>()
   ///         ..where((e) => e.manager).isNotNull();
-  isNotNull() {
+  void isNotNull() {
     expression = const NullCheckExpression(shouldBeNull: false);
     }
 }

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -4,13 +4,6 @@ import '../managed/managed.dart';
 import 'matcher_internal.dart';
 import 'query.dart';
 
-/// Contains binary logic operations to be applied to a [QueryExpression].
-class QueryExpressionJunction<T, InstanceType> {
-  QueryExpressionJunction._(this.lhs);
-
-  final QueryExpression<T, InstanceType> lhs;
-}
-
 /// Contains methods for adding logical expressions to properties when building a [Query].
 ///
 /// You do not create instances of this type directly, but instead are returned an instance when selecting a property
@@ -45,10 +38,6 @@ class QueryExpression<T, InstanceType> {
   bool _invertNext = false;
   PredicateExpression _expression;
 
-  // ignore: use_to_and_as_if_applicable
-  QueryExpressionJunction<T, InstanceType> _createJunction() =>
-      QueryExpressionJunction<T, InstanceType>._(this);
-
   /// Inverts the next expression.
   ///
   /// You use this method to apply an inversion to the expression that follows. For example,
@@ -75,7 +64,7 @@ class QueryExpression<T, InstanceType> {
   ///       final query = new Query<User>()
   ///         ..where((u) => u.id ).equalTo(1);
   ///
-  QueryExpressionJunction<T, InstanceType> equalTo(T value,
+  equalTo(T value,
       {bool caseSensitive = true}) {
     if (value is String) {
       expression = StringExpression(value, PredicateStringOperator.equals,
@@ -83,8 +72,6 @@ class QueryExpression<T, InstanceType> {
     } else {
       expression = ComparisonExpression(value, PredicateOperator.equalTo);
     }
-
-    return _createJunction();
   }
 
   /// Adds an 'not equal' expression to a query.
@@ -100,7 +87,7 @@ class QueryExpression<T, InstanceType> {
   ///       final query = new Query<Employee>()
   ///         ..where((e) => e.id).notEqualTo(60000);
   ///
-  QueryExpressionJunction<T, InstanceType> notEqualTo(T value,
+  notEqualTo(T value,
       {bool caseSensitive = true}) {
     if (value is String) {
       expression = StringExpression(value, PredicateStringOperator.equals,
@@ -108,8 +95,6 @@ class QueryExpression<T, InstanceType> {
     } else {
       expression = ComparisonExpression(value, PredicateOperator.notEqual);
     }
-
-    return _createJunction();
   }
 
   /// Adds a 'greater than' expression to a query.
@@ -124,11 +109,9 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).greaterThan(60000);
-  QueryExpressionJunction<T, InstanceType> greaterThan(T value) {
+  greaterThan(T value) {
     expression = ComparisonExpression(value, PredicateOperator.greaterThan);
-
-    return _createJunction();
-  }
+    }
 
   /// Adds a 'greater than or equal to' expression to a query.
   ///
@@ -141,12 +124,10 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).greaterThanEqualTo(60000);
-  QueryExpressionJunction<T, InstanceType> greaterThanEqualTo(T value) {
+  greaterThanEqualTo(T value) {
     expression =
         ComparisonExpression(value, PredicateOperator.greaterThanEqualTo);
-
-    return _createJunction();
-  }
+    }
 
   /// Adds a 'less than' expression to a query.
   ///
@@ -159,11 +140,9 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).lessThan(60000);
-  QueryExpressionJunction<T, InstanceType> lessThan(T value) {
+  lessThan(T value) {
     expression = ComparisonExpression(value, PredicateOperator.lessThan);
-
-    return _createJunction();
-  }
+    }
 
   /// Adds a 'less than or equal to' expression to a query.
   ///
@@ -176,11 +155,9 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).lessThanEqualTo(60000);
-  QueryExpressionJunction<T, InstanceType> lessThanEqualTo(T value) {
+  lessThanEqualTo(T value) {
     expression = ComparisonExpression(value, PredicateOperator.lessThanEqualTo);
-
-    return _createJunction();
-  }
+    }
 
   /// Adds a 'contains string' expression to a query.
   ///
@@ -194,13 +171,11 @@ class QueryExpression<T, InstanceType> {
   ///       var query = new Query<Employee>()
   ///         ..where((s) => s.title).contains("Director");
   ///
-  QueryExpressionJunction<T, InstanceType> contains(String value,
+   contains(String value,
       {bool caseSensitive = true}) {
     expression = StringExpression(value, PredicateStringOperator.contains,
         caseSensitive: caseSensitive);
-
-    return _createJunction();
-  }
+    }
 
   /// Adds a 'begins with string' expression to a query.
   ///
@@ -212,13 +187,11 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((s) => s.name).beginsWith("B");
-  QueryExpressionJunction<T, InstanceType> beginsWith(String value,
+  beginsWith(String value,
       {bool caseSensitive = true}) {
     expression = StringExpression(value, PredicateStringOperator.beginsWith,
         caseSensitive: caseSensitive);
-
-    return _createJunction();
-  }
+    }
 
   /// Adds a 'ends with string' expression to a query.
   ///
@@ -230,12 +203,11 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.name).endsWith("son");
-  QueryExpressionJunction<T, InstanceType> endsWith(String value,
+  endsWith(String value,
       {bool caseSensitive = true}) {
     expression = StringExpression(value, PredicateStringOperator.endsWith,
         caseSensitive: caseSensitive);
 
-    return _createJunction();
   }
 
   /// Adds a 'equal to one of' expression to a query.
@@ -248,14 +220,12 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.department).oneOf(["Engineering", "HR"]);
-  QueryExpressionJunction<T, InstanceType> oneOf(Iterable<T> values) {
+  oneOf(Iterable<T> values) {
     if (values?.isEmpty ?? true) {
       throw ArgumentError("'Query.where.oneOf' cannot be the empty set or null.");
     }
     expression = SetMembershipExpression(values.toList());
-
-    return _createJunction();
-  }
+    }
 
   /// Adds a 'between two values' expression to a query.
   ///
@@ -269,10 +239,9 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).between(80000, 100000);
-  QueryExpressionJunction<T, InstanceType> between(T lhs, T rhs) {
+  between(T lhs, T rhs) {
     expression = RangeExpression(lhs, rhs, within: true);
 
-    return _createJunction();
   }
 
   /// Adds a 'outside of the range crated by two values' expression to a query.
@@ -287,10 +256,9 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).outsideOf(80000, 100000);
-  QueryExpressionJunction<T, InstanceType> outsideOf(T lhs, T rhs) {
+  outsideOf(T lhs, T rhs) {
     expression = RangeExpression(lhs, rhs, within: false);
 
-    return _createJunction();
   }
 
   /// Adds an equality expression for foreign key columns to a query.
@@ -302,10 +270,9 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var q = new Query<Employee>()
   ///         ..where((e) => e.manager).identifiedBy(5);
-  QueryExpressionJunction<T, InstanceType> identifiedBy(dynamic identifier) {
+  identifiedBy(dynamic identifier) {
     expression = ComparisonExpression(identifier, PredicateOperator.equalTo);
 
-    return _createJunction();
   }
 
   /// Adds a 'null check' expression to a query.
@@ -318,10 +285,9 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var q = new Query<Employee>()
   ///         ..where((e) => e.manager).isNull();
-  QueryExpressionJunction<T, InstanceType> isNull() {
+  isNull() {
     expression = const NullCheckExpression(shouldBeNull: true);
 
-    return _createJunction();
   }
 
   /// Adds a 'not null check' expression to a query.
@@ -334,9 +300,7 @@ class QueryExpression<T, InstanceType> {
   ///
   ///       var q = new Query<Employee>()
   ///         ..where((e) => e.manager).isNotNull();
-  QueryExpressionJunction<T, InstanceType> isNotNull() {
+  isNotNull() {
     expression = const NullCheckExpression(shouldBeNull: false);
-
-    return _createJunction();
-  }
+    }
 }

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -21,6 +21,9 @@ class QueryExpression<T, U, InstanceType> {
       : keyPath = KeyPath.byAddingKey(original.keyPath, byAdding),
         _expression = original.expression;
 
+  QueryExpression.and(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
+        _expression = AndExpression(lhs, rhs);
+
   final KeyPath keyPath;
 
   // todo: This needs to be extended to an expr tree

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -13,10 +13,10 @@ import 'query.dart';
 ///         final query = new Query<Employee>()
 ///           ..where((e) => e.name).equalTo("Bob");
 ///
-class QueryExpression<T, U, InstanceType> {
+class QueryExpression<T, InstanceType> {
   QueryExpression(this.keyPath);
 
-  QueryExpression.byAddingKey(QueryExpression<T, U, InstanceType> original,
+  QueryExpression.byAddingKey(QueryExpression<T, InstanceType> original,
       ManagedPropertyDescription byAdding)
       : keyPath = KeyPath.byAddingKey(original.keyPath, byAdding),
         _expression = original.expression;
@@ -44,7 +44,7 @@ class QueryExpression<T, U, InstanceType> {
   ///
   ///         final query = new Query<Employee>()
   ///           ..where((e) => e.name).not.equalTo("Bob");
-  QueryExpression<T, U, InstanceType> get not {
+  QueryExpression<T, InstanceType> get not {
     _invertNext = !_invertNext;
 
     return this;

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -66,10 +66,10 @@ class QueryExpression<T, InstanceType> {
   void equalTo(T value,
       {bool caseSensitive = true}) {
     if (value is String) {
-      expression = StringExpression(value, StringComparisonOperant.equals,
+      expression = StringExpression(value, StringComparisonOperator.equals,
           caseSensitive: caseSensitive);
     } else {
-      expression = ComparisonExpression(value, ComparisonOperant.equalTo);
+      expression = ComparisonExpression(value, ComparisonOperator.equalTo);
     }
   }
 
@@ -89,10 +89,10 @@ class QueryExpression<T, InstanceType> {
   void notEqualTo(T value,
       {bool caseSensitive = true}) {
     if (value is String) {
-      expression = StringExpression(value, StringComparisonOperant.equals,
+      expression = StringExpression(value, StringComparisonOperator.equals,
           caseSensitive: caseSensitive, invertOperator: true);
     } else {
-      expression = ComparisonExpression(value, ComparisonOperant.notEqual);
+      expression = ComparisonExpression(value, ComparisonOperator.notEqual);
     }
   }
 
@@ -109,7 +109,7 @@ class QueryExpression<T, InstanceType> {
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).greaterThan(60000);
   void greaterThan(T value) {
-    expression = ComparisonExpression(value, ComparisonOperant.greaterThan);
+    expression = ComparisonExpression(value, ComparisonOperator.greaterThan);
     }
 
   /// Adds a 'greater than or equal to' expression to a query.
@@ -125,7 +125,7 @@ class QueryExpression<T, InstanceType> {
   ///         ..where((e) => e.salary).greaterThanEqualTo(60000);
   void greaterThanEqualTo(T value) {
     expression =
-        ComparisonExpression(value, ComparisonOperant.greaterThanEqualTo);
+        ComparisonExpression(value, ComparisonOperator.greaterThanEqualTo);
     }
 
   /// Adds a 'less than' expression to a query.
@@ -140,7 +140,7 @@ class QueryExpression<T, InstanceType> {
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).lessThan(60000);
   void lessThan(T value) {
-    expression = ComparisonExpression(value, ComparisonOperant.lessThan);
+    expression = ComparisonExpression(value, ComparisonOperator.lessThan);
     }
 
   /// Adds a 'less than or equal to' expression to a query.
@@ -155,7 +155,7 @@ class QueryExpression<T, InstanceType> {
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).lessThanEqualTo(60000);
   void lessThanEqualTo(T value) {
-    expression = ComparisonExpression(value, ComparisonOperant.lessThanEqualTo);
+    expression = ComparisonExpression(value, ComparisonOperator.lessThanEqualTo);
     }
 
   /// Adds a 'contains string' expression to a query.
@@ -172,7 +172,7 @@ class QueryExpression<T, InstanceType> {
   ///
   void contains(String value,
       {bool caseSensitive = true}) {
-    expression = StringExpression(value, StringComparisonOperant.contains,
+    expression = StringExpression(value, StringComparisonOperator.contains,
         caseSensitive: caseSensitive);
     }
 
@@ -188,7 +188,7 @@ class QueryExpression<T, InstanceType> {
   ///         ..where((s) => s.name).beginsWith("B");
   void beginsWith(String value,
       {bool caseSensitive = true}) {
-    expression = StringExpression(value, StringComparisonOperant.beginsWith,
+    expression = StringExpression(value, StringComparisonOperator.beginsWith,
         caseSensitive: caseSensitive);
     }
 
@@ -204,7 +204,7 @@ class QueryExpression<T, InstanceType> {
   ///         ..where((e) => e.name).endsWith("son");
   void endsWith(String value,
       {bool caseSensitive = true}) {
-    expression = StringExpression(value, StringComparisonOperant.endsWith,
+    expression = StringExpression(value, StringComparisonOperator.endsWith,
         caseSensitive: caseSensitive);
 
   }
@@ -239,7 +239,7 @@ class QueryExpression<T, InstanceType> {
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).between(80000, 100000);
   void between(T lhs, T rhs) {
-    expression = RangeExpression<T>(lhs, rhs, scope: RangeOperant.between);
+    expression = RangeExpression<T>(lhs, rhs, scope: RangeOperator.between);
 
   }
 
@@ -256,7 +256,7 @@ class QueryExpression<T, InstanceType> {
   ///       var query = new Query<Employee>()
   ///         ..where((e) => e.salary).outsideOf(80000, 100000);
   void outsideOf(T lhs, T rhs) {
-    expression = RangeExpression(lhs, rhs, scope: RangeOperant.notBetween);
+    expression = RangeExpression(lhs, rhs, scope: RangeOperator.notBetween);
 
   }
 
@@ -270,7 +270,7 @@ class QueryExpression<T, InstanceType> {
   ///       var q = new Query<Employee>()
   ///         ..where((e) => e.manager).identifiedBy(5);
   void identifiedBy(dynamic identifier) {
-    expression = ComparisonExpression(identifier, ComparisonOperant.equalTo);
+    expression = ComparisonExpression(identifier, ComparisonOperator.equalTo);
 
   }
 

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -23,6 +23,12 @@ class QueryExpression<T, U, InstanceType> {
 
   QueryExpression.and(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
         _expression = AndExpression(lhs, rhs);
+  QueryExpression.or(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
+        _expression = OrExpression(lhs, rhs);
+  QueryExpression.andGroup(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
+      _expression = AndGroupExpression(lhs, rhs);
+  QueryExpression.orGroup(QueryExpression<T, T, InstanceType> lhs, QueryExpression<U, U, InstanceType> rhs):
+        _expression = OrGroupExpression(lhs, rhs);
 
   final KeyPath keyPath;
 

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -21,14 +21,8 @@ class QueryExpression<T, U, InstanceType> {
       : keyPath = KeyPath.byAddingKey(original.keyPath, byAdding),
         _expression = original.expression;
 
-  QueryExpression.and(QueryExpression lhs, QueryExpression rhs, {bool isGrouped = false}):
-        _expression = AndExpression(lhs, rhs, isGrouped: isGrouped);
-  QueryExpression.or(QueryExpression lhs, QueryExpression rhs, {bool isGrouped = false}):
-        _expression = OrExpression(lhs, rhs, isGrouped: isGrouped);
-
   final KeyPath keyPath;
 
-  // todo: This needs to be extended to an expr tree
   PredicateExpression get expression => _expression;
 
   set expression(PredicateExpression expr) {

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -13,10 +13,10 @@ import 'query.dart';
 ///         final query = new Query<Employee>()
 ///           ..where((e) => e.name).equalTo("Bob");
 ///
-class QueryExpression<T, InstanceType> {
+class QueryExpression<T, U, InstanceType> {
   QueryExpression(this.keyPath);
 
-  QueryExpression.byAddingKey(QueryExpression<T, InstanceType> original,
+  QueryExpression.byAddingKey(QueryExpression<T, U, InstanceType> original,
       ManagedPropertyDescription byAdding)
       : keyPath = KeyPath.byAddingKey(original.keyPath, byAdding),
         _expression = original.expression;
@@ -45,7 +45,7 @@ class QueryExpression<T, InstanceType> {
   ///
   ///         final query = new Query<Employee>()
   ///           ..where((e) => e.name).not.equalTo("Bob");
-  QueryExpression<T, InstanceType> get not {
+  QueryExpression<T, U, InstanceType> get not {
     _invertNext = !_invertNext;
 
     return this;

--- a/aqueduct/lib/src/db/query/matcher_internal.dart
+++ b/aqueduct/lib/src/db/query/matcher_internal.dart
@@ -8,42 +8,28 @@ abstract class AbstractBinaryNode<E> extends AbstractUnaryNode<E> {
   const AbstractBinaryNode(E operand, this.operand2): super(operand);
 }
 
-abstract class AbstractLeaf {}
-
-abstract class PredicateExpressionLeaf<E> {}
-
-abstract class UnaryOperantNode<E, O> extends AbstractUnaryNode<E> {
-  final O operant;
-
-  const UnaryOperantNode(E lhs, this.operant) : super(lhs);
+abstract class UnaryOperatorNode<E, O> extends AbstractUnaryNode<E> {
+  final O operator;
+  const UnaryOperatorNode(E lhs, this.operator) : super(lhs);
 }
 
-abstract class BinaryOperantNode<E, O> extends AbstractBinaryNode<E> {
-  final O operant;
-
-  const BinaryOperantNode(E lhs, E rhs, this.operant) : super(lhs, rhs);
+abstract class BinaryOperatorNode<E, O> extends AbstractBinaryNode<E> {
+  final O operator;
+  const BinaryOperatorNode(E lhs, E rhs, this.operator) : super(lhs, rhs);
 }
 
-abstract class ComparisonBinaryNode<E> extends BinaryOperantNode<E, ComparisonOperant> {
-  const ComparisonBinaryNode(E lhs, E rhs, ComparisonOperant operant) : super(lhs, rhs, operant);
+abstract class LogicalOperatorNode<E> extends BinaryOperatorNode<E, LogicalOperator> {
+  const LogicalOperatorNode(E lhs, E rhs, LogicalOperator operator) : super(lhs, rhs, operator);
 }
 
-abstract class StringComparisonOperantNode<String> extends BinaryOperantNode<String, StringComparisonOperant> {
-  StringComparisonOperantNode(String lhs, String rhs, StringComparisonOperant operant) : super(lhs, rhs, operant);
+abstract class ComparisonUnaryNode<E> extends UnaryOperatorNode<E, ComparisonOperator> {
+  const ComparisonUnaryNode(E lhs, ComparisonOperator operator) : super(lhs, operator);
 }
 
-abstract class LogicalOperantNode<E> extends BinaryOperantNode<E, LogicalOperant> {
-  const LogicalOperantNode(E lhs, E rhs, LogicalOperant operant) : super(lhs, rhs, operant);
-}
-
-abstract class ComparisonUnaryNode<E> extends UnaryOperantNode<E, ComparisonOperant> {
-  const ComparisonUnaryNode(E lhs, ComparisonOperant operant) : super(lhs, operant);
-}
-
-enum LogicalOperant { and, or }
+enum LogicalOperator { and, or }
 
 /// The operator in a comparison matcher.
-enum ComparisonOperant {
+enum ComparisonOperator {
   lessThan,
   greaterThan,
   notEqual,
@@ -53,34 +39,34 @@ enum ComparisonOperant {
 }
 
 /// The operator in a string matcher.
-enum StringComparisonOperant { beginsWith, contains, endsWith, equals }
+enum StringComparisonOperator { beginsWith, contains, endsWith, equals }
 
 abstract class PredicateExpression {
   PredicateExpression get inverse;
 }
 
 class ComparisonExpression<E> extends ComparisonUnaryNode<E> implements PredicateExpression {
-  const ComparisonExpression(E value, ComparisonOperant operant): super(value, operant);
+  const ComparisonExpression(E value, ComparisonOperator operator): super(value, operator);
 
   @override
   PredicateExpression get inverse {
     return ComparisonExpression(operand, inverseOperator);
   }
 
-  ComparisonOperant get inverseOperator {
-    switch (operant) {
-      case ComparisonOperant.lessThan:
-        return ComparisonOperant.greaterThanEqualTo;
-      case ComparisonOperant.greaterThan:
-        return ComparisonOperant.lessThanEqualTo;
-      case ComparisonOperant.notEqual:
-        return ComparisonOperant.equalTo;
-      case ComparisonOperant.lessThanEqualTo:
-        return ComparisonOperant.greaterThan;
-      case ComparisonOperant.greaterThanEqualTo:
-        return ComparisonOperant.lessThan;
-      case ComparisonOperant.equalTo:
-        return ComparisonOperant.notEqual;
+  ComparisonOperator get inverseOperator {
+    switch (operator) {
+      case ComparisonOperator.lessThan:
+        return ComparisonOperator.greaterThanEqualTo;
+      case ComparisonOperator.greaterThan:
+        return ComparisonOperator.lessThanEqualTo;
+      case ComparisonOperator.notEqual:
+        return ComparisonOperator.equalTo;
+      case ComparisonOperator.lessThanEqualTo:
+        return ComparisonOperator.greaterThan;
+      case ComparisonOperator.greaterThanEqualTo:
+        return ComparisonOperator.lessThan;
+      case ComparisonOperator.equalTo:
+        return ComparisonOperator.notEqual;
     }
 
     // this line just shuts up the analyzer
@@ -88,20 +74,20 @@ class ComparisonExpression<E> extends ComparisonUnaryNode<E> implements Predicat
   }
 }
 
-enum RangeOperant {
+enum RangeOperator {
   between,
   notBetween
 }
 
-class RangeExpression<E> extends BinaryOperantNode<E, RangeOperant> implements PredicateExpression {
-  const RangeExpression(E operand, E operand2, {RangeOperant scope = RangeOperant.between}): super(operand, operand2, scope);
+class RangeExpression<E> extends BinaryOperatorNode<E, RangeOperator> implements PredicateExpression {
+  const RangeExpression(E operand, E operand2, {RangeOperator scope = RangeOperator.between}): super(operand, operand2, scope);
 
   @override
   PredicateExpression get inverse {
-    final inverseOperant = operant == RangeOperant.between
-        ? RangeOperant.notBetween
-        : RangeOperant.between;
-    return RangeExpression(operand, operand2, scope: inverseOperant);
+    final inverseOperator = operator == RangeOperator.between
+        ? RangeOperator.notBetween
+        : RangeOperator.between;
+    return RangeExpression(operand, operand2, scope: inverseOperator);
   }
 }
 
@@ -129,7 +115,7 @@ class StringExpression extends AbstractUnaryNode<String> implements PredicateExp
   const StringExpression(String value, this.operator,
       {this.caseSensitive = true, this.invertOperator = false}): super(value);
 
-  final StringComparisonOperant operator;
+  final StringComparisonOperator operator;
   final bool invertOperator;
   final bool caseSensitive;
 
@@ -140,9 +126,6 @@ class StringExpression extends AbstractUnaryNode<String> implements PredicateExp
   }
 }
 
-class Expression<E> extends AbstractUnaryNode<E> {
-  Expression(E operand): super(operand);
-}
 abstract class Tree<E> {}
 
 class LeafNode<E> implements Tree<E> {
@@ -150,14 +133,12 @@ class LeafNode<E> implements Tree<E> {
  LeafNode(this.value);
 }
 
-class AndNode<E> extends LogicalOperantNode<Tree<E>> implements Tree<E> {
+class AndNode<E> extends LogicalOperatorNode<Tree<E>> implements Tree<E> {
   const AndNode(Tree<E> lhs, Tree<E> rhs)
-      : super(lhs, rhs, LogicalOperant.and);
+      : super(lhs, rhs, LogicalOperator.and);
 }
 
-class OrNode<E> extends LogicalOperantNode<Tree<E>> implements Tree<E> {
+class OrNode<E> extends LogicalOperatorNode<Tree<E>> implements Tree<E> {
   const OrNode(Tree<E> lhs, Tree<E> rhs)
-      : super(lhs, rhs, LogicalOperant.or);
+      : super(lhs, rhs, LogicalOperator.or);
 }
-
-

--- a/aqueduct/lib/src/db/query/matcher_internal.dart
+++ b/aqueduct/lib/src/db/query/matcher_internal.dart
@@ -3,9 +3,9 @@ abstract class AbstractUnaryNode<E> {
   const AbstractUnaryNode(this.operand);
 }
 
-abstract class AbstractBinaryNode<E> {
-  final E operand, operand2;
-  const AbstractBinaryNode(this.operand, this.operand2);
+abstract class AbstractBinaryNode<E> extends AbstractUnaryNode<E> {
+  final E operand2;
+  const AbstractBinaryNode(E operand, this.operand2): super(operand);
 }
 
 abstract class AbstractLeaf {}

--- a/aqueduct/lib/src/db/query/matcher_internal.dart
+++ b/aqueduct/lib/src/db/query/matcher_internal.dart
@@ -1,3 +1,5 @@
+import 'package:aqueduct/src/db/query/matcher_expression.dart';
+
 /// The operator in a comparison matcher.
 enum PredicateOperator {
   lessThan,
@@ -44,6 +46,28 @@ class ComparisonExpression implements PredicateExpression {
 
     // this line just shuts up the analyzer
     return null;
+  }
+}
+
+class AndExpression implements PredicateExpression {
+  const AndExpression(this.lhs, this.rhs);
+
+  final QueryExpression lhs, rhs; //FIXME: this should probably be more generic
+
+  @override
+  PredicateExpression get inverse {
+    return RangeExpression(rhs, lhs);
+  }
+}
+
+class OrExpression implements PredicateExpression {
+  const OrExpression(this.lhs, this.rhs);
+
+  final QueryExpression lhs, rhs; //FIXME: this should probably be more generic
+
+  @override
+  PredicateExpression get inverse {
+    return RangeExpression(rhs, lhs);
   }
 }
 

--- a/aqueduct/lib/src/db/query/matcher_internal.dart
+++ b/aqueduct/lib/src/db/query/matcher_internal.dart
@@ -49,6 +49,26 @@ class ComparisonExpression implements PredicateExpression {
   }
 }
 
+class AndGroupExpression implements PredicateExpression {
+  final QueryExpression lhs, rhs;
+  const AndGroupExpression(this.lhs, this.rhs);
+
+  @override
+  PredicateExpression get inverse {
+    return RangeExpression(rhs, lhs);
+  }
+}
+
+class OrGroupExpression implements PredicateExpression {
+  final QueryExpression lhs, rhs;
+  const OrGroupExpression(this.lhs, this.rhs);
+
+  @override
+  PredicateExpression get inverse {
+    return RangeExpression(rhs, lhs);
+  }
+}
+
 class AndExpression implements PredicateExpression {
   const AndExpression(this.lhs, this.rhs);
 

--- a/aqueduct/lib/src/db/query/matcher_internal.dart
+++ b/aqueduct/lib/src/db/query/matcher_internal.dart
@@ -154,7 +154,7 @@ class AndExpression<E> extends LogicalOperantNode<E> implements PredicateExpress
 
 class OrExpression<E> extends LogicalOperantNode<E> implements PredicateExpression {
   const OrExpression(E lhs, E rhs, {this.isGrouped = false})
-      : super(lhs, rhs, LogicalOperant.and);
+      : super(lhs, rhs, LogicalOperant.or);
 
   final bool isGrouped;
 

--- a/aqueduct/lib/src/db/query/matcher_internal.dart
+++ b/aqueduct/lib/src/db/query/matcher_internal.dart
@@ -140,26 +140,24 @@ class StringExpression extends AbstractUnaryNode<String> implements PredicateExp
   }
 }
 
-class AndExpression<E> extends LogicalOperantNode<E> implements PredicateExpression {
-  const AndExpression(E lhs, E rhs, {this.isGrouped = false})
+class Expression<E> extends AbstractUnaryNode<E> {
+  Expression(E operand): super(operand);
+}
+abstract class Tree<E> {}
+
+class LeafNode<E> implements Tree<E> {
+ E value;
+ LeafNode(this.value);
+}
+
+class AndNode<E> extends LogicalOperantNode<Tree<E>> implements Tree<E> {
+  const AndNode(Tree<E> lhs, Tree<E> rhs)
       : super(lhs, rhs, LogicalOperant.and);
-
-  final bool isGrouped;
-
-  @override
-  PredicateExpression get inverse {
-    return RangeExpression(operand, operand2);
-  }
 }
 
-class OrExpression<E> extends LogicalOperantNode<E> implements PredicateExpression {
-  const OrExpression(E lhs, E rhs, {this.isGrouped = false})
+class OrNode<E> extends LogicalOperantNode<Tree<E>> implements Tree<E> {
+  const OrNode(Tree<E> lhs, Tree<E> rhs)
       : super(lhs, rhs, LogicalOperant.or);
-
-  final bool isGrouped;
-
-  @override
-  PredicateExpression get inverse {
-    return RangeExpression(operand, operand2);
-  }
 }
+
+

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -110,7 +110,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     if (expression == null) {
       expression = standin.expression;
     } else {
-      expression = QueryExpression.andGroup(expression, standin.expression);
+      expression = QueryExpression.and(expression, standin.expression, isGrouped: true);
     }
   }
 
@@ -122,7 +122,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     if (expression == null) {
       expression = standin.expression;
     } else {
-      expression = QueryExpression.orGroup(expression, standin.expression);
+      expression = QueryExpression.or(expression, standin.expression, isGrouped: true);
     }
   }
 

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -68,7 +68,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   }
 
   @override
-  QueryExpression<T, T, InstanceType> where<T>(
+  QueryExpression<T, InstanceType> where<T>(
       T propertyIdentifier(InstanceType x)) {
     final properties = entity.identifyProperties(propertyIdentifier);
     if (properties.length != 1) {
@@ -76,7 +76,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
           "Invalid property selector. Must reference a single property only.");
     }
 
-    final expr = QueryExpression<T, T, InstanceType>(properties.first);
+    final expr = QueryExpression<T, InstanceType>(properties.first);
     final leaf = LeafNode(expr);
     if (expression == null) {
       expression = leaf;
@@ -87,7 +87,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   }
 
   @override
-  QueryExpression<T, U, InstanceType> orWhere<T, U>(
+  QueryExpression<T, InstanceType> orWhere<T, U>(
       T propertyIdentifier(InstanceType x)) {
     final properties = entity.identifyProperties(propertyIdentifier);
     if (properties.length != 1) {
@@ -95,7 +95,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
           "Invalid property selector. Must reference a single property only.");
     }
 
-    final expr = QueryExpression<T, U, InstanceType>(properties.first);
+    final expr = QueryExpression<T, InstanceType>(properties.first);
     final leaf = LeafNode(expr);
     if (expression == null) {
       expression = leaf;

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -32,7 +32,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   Map<ManagedRelationshipDescription, Query> subQueries;
 
   QueryMixin _parentQuery;
-  List<QueryExpression<dynamic, dynamic>> expressions = [];
+  List<QueryExpression<dynamic, dynamic, dynamic>> expressions = [];
   InstanceType _valueObject;
 
   List<KeyPath> _propertiesToFetch;
@@ -65,7 +65,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   }
 
   @override
-  QueryExpression<T, InstanceType> where<T>(
+  QueryExpression<T, T, InstanceType> where<T>(
       T propertyIdentifier(InstanceType x)) {
     final properties = entity.identifyProperties(propertyIdentifier);
     if (properties.length != 1) {

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -32,7 +32,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   Map<ManagedRelationshipDescription, Query> subQueries;
 
   QueryMixin _parentQuery;
-  List<QueryExpression<dynamic, dynamic, dynamic>> expressions = [];
+  QueryExpression<dynamic, dynamic, dynamic> expression;
   InstanceType _valueObject;
 
   List<KeyPath> _propertiesToFetch;
@@ -74,11 +74,10 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     }
 
     final expr = QueryExpression<T, T, InstanceType>(properties.first);
-    if (expressions.isNotEmpty) {
-      final expression = expressions.first;
-      expressions = [QueryExpression.and(expression, expr)];
+    if (expression == null) {
+      expression = expr;
     } else {
-      expressions = [expr];
+      expression = QueryExpression.and(expression, expr);
     }
     return expr;
   }

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -110,7 +110,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     if (expression == null) {
       expression = standin.expression;
     } else {
-      expression = QueryExpression.and(expression, standin.expression, isGrouped: true);
+      expression = QueryExpression.and(expression, standin.expression);
     }
   }
 
@@ -122,7 +122,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     if (expression == null) {
       expression = standin.expression;
     } else {
-      expression = QueryExpression.or(expression, standin.expression, isGrouped: true);
+      expression = QueryExpression.or(expression, standin.expression);
     }
   }
 

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -232,35 +232,37 @@ class QueryStandin<InstanceType extends ManagedObject> extends Object
 
   @override
   Future<int> delete() {
-    // TODO: implement delete
+    throw getStateError("delete");
   }
 
   @override
   Future<List<InstanceType>> fetch() {
-    // TODO: implement fetch
+    throw getStateError("fetch");
   }
 
   @override
   Future<InstanceType> fetchOne() {
-    // TODO: implement fetchOne
+    throw getStateError("fetchOne");
   }
 
   @override
   Future<InstanceType> insert() {
-    // TODO: implement insert
+    throw getStateError("insert");
   }
 
-  // TODO: implement reduce
   @override
-  QueryReduceOperation<InstanceType> get reduce => null;
+  QueryReduceOperation<InstanceType> get reduce => throw getStateError("reduce");
+
 
   @override
   Future<List<InstanceType>> update() {
-    // TODO: implement update
+    throw getStateError("update");
   }
 
   @override
   Future<InstanceType> updateOne() {
-    // TODO: implement updateOne
+    throw getStateError("updateOne");
   }
+
+  StateError getStateError(String methodName) => StateError("Cannot call ${methodName} on QueryStandin. Do you mean to call ${methodName} on the Query itself?");
 }

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import 'package:aqueduct/src/db/managed/key_path.dart';
 import 'package:aqueduct/src/db/managed/relationship_type.dart';
+import 'package:aqueduct/src/db/query/matcher_internal.dart';
 
 import '../managed/backing.dart';
 import '../managed/managed.dart';
@@ -34,7 +35,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
   Map<ManagedRelationshipDescription, Query> subQueries;
 
   QueryMixin _parentQuery;
-  QueryExpression<dynamic, dynamic, dynamic> expression;
+  Tree<QueryExpression> expression;
   InstanceType _valueObject;
 
   List<KeyPath> _propertiesToFetch;
@@ -76,10 +77,11 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     }
 
     final expr = QueryExpression<T, T, InstanceType>(properties.first);
+    final leaf = LeafNode(expr);
     if (expression == null) {
-      expression = expr;
+      expression = leaf;
     } else {
-      expression = QueryExpression.and(expression, expr);
+      expression = AndNode(expression, leaf);
     }
     return expr;
   }
@@ -94,10 +96,11 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     }
 
     final expr = QueryExpression<T, U, InstanceType>(properties.first);
+    final leaf = LeafNode(expr);
     if (expression == null) {
-      expression = expr;
+      expression = leaf;
     } else {
-      expression = QueryExpression.or(expression, expr);
+      expression = OrNode(expression, leaf);
     }
     return expr;
   }
@@ -110,7 +113,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     if (expression == null) {
       expression = standin.expression;
     } else {
-      expression = QueryExpression.and(expression, standin.expression);
+      expression = AndNode(expression, standin.expression);
     }
   }
 
@@ -122,7 +125,7 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     if (expression == null) {
       expression = standin.expression;
     } else {
-      expression = QueryExpression.or(expression, standin.expression);
+      expression = OrNode(expression, standin.expression);
     }
   }
 

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -73,8 +73,13 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
           "Invalid property selector. Must reference a single property only.");
     }
 
-    final expr = QueryExpression<T, InstanceType>(properties.first);
-    expressions.add(expr);
+    final expr = QueryExpression<T, T, InstanceType>(properties.first);
+    if (expressions.isNotEmpty) {
+      final expression = expressions.first;
+      expressions = [QueryExpression.and(expression, expr)];
+    } else {
+      expressions = [expr];
+    }
     return expr;
   }
 

--- a/aqueduct/lib/src/db/query/mixin.dart
+++ b/aqueduct/lib/src/db/query/mixin.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import 'package:aqueduct/src/db/managed/key_path.dart';
 import 'package:aqueduct/src/db/managed/relationship_type.dart';
 
@@ -80,6 +82,48 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
       expression = QueryExpression.and(expression, expr);
     }
     return expr;
+  }
+
+  @override
+  QueryExpression<T, U, InstanceType> orWhere<T, U>(
+      T propertyIdentifier(InstanceType x)) {
+    final properties = entity.identifyProperties(propertyIdentifier);
+    if (properties.length != 1) {
+      throw ArgumentError(
+          "Invalid property selector. Must reference a single property only.");
+    }
+
+    final expr = QueryExpression<T, U, InstanceType>(properties.first);
+    if (expression == null) {
+      expression = expr;
+    } else {
+      expression = QueryExpression.or(expression, expr);
+    }
+    return expr;
+  }
+
+  @override
+  void whereGroup<T, U>(
+      void expressionGetter(Query<InstanceType> q)) {
+    final standin = QueryStandin<InstanceType>(entity);
+    expressionGetter(standin);
+    if (expression == null) {
+      expression = standin.expression;
+    } else {
+      expression = QueryExpression.andGroup(expression, standin.expression);
+    }
+  }
+
+  @override
+  void orWhereGroup<T, U>(
+      void expressionGetter(Query<InstanceType> q)) {
+    final standin = QueryStandin<InstanceType>(entity);
+    expressionGetter(standin);
+    if (expression == null) {
+      expression = standin.expression;
+    } else {
+      expression = QueryExpression.orGroup(expression, standin.expression);
+    }
   }
 
   @override
@@ -170,5 +214,53 @@ abstract class QueryMixin<InstanceType extends ManagedObject>
     subQueries[fromRelationship] = subquery;
 
     return subquery;
+  }
+}
+
+class QueryStandin<InstanceType extends ManagedObject> extends Object
+    with QueryMixin<InstanceType> implements Query<InstanceType> {
+  ManagedEntity _entity;
+  QueryStandin(ManagedEntity entity) {
+    this._entity = entity;
+  }
+
+  @override
+  ManagedEntity get entity => _entity;
+
+  @override
+  ManagedContext get context => null;
+
+  @override
+  Future<int> delete() {
+    // TODO: implement delete
+  }
+
+  @override
+  Future<List<InstanceType>> fetch() {
+    // TODO: implement fetch
+  }
+
+  @override
+  Future<InstanceType> fetchOne() {
+    // TODO: implement fetchOne
+  }
+
+  @override
+  Future<InstanceType> insert() {
+    // TODO: implement insert
+  }
+
+  // TODO: implement reduce
+  @override
+  QueryReduceOperation<InstanceType> get reduce => null;
+
+  @override
+  Future<List<InstanceType>> update() {
+    // TODO: implement update
+  }
+
+  @override
+  Future<InstanceType> updateOne() {
+    // TODO: implement updateOne
   }
 }

--- a/aqueduct/lib/src/db/query/predicate.dart
+++ b/aqueduct/lib/src/db/query/predicate.dart
@@ -100,12 +100,12 @@ class QueryPredicate {
   ///
   /// If [predicates] is null or empty, an empty predicate is returned. If [predicates] contains only
   /// one predicate, that predicate is returned.
-  factory QueryPredicate.and(Iterable<QueryPredicate> predicates, {isGrouped: false}) {
-    return QueryPredicate._(predicates, "AND");
+  factory QueryPredicate.and(Iterable<QueryPredicate> predicates, {bool isGrouped: false}) {
+    return QueryPredicate._(predicates, "AND", isGrouped: isGrouped);
   }
 
-  factory QueryPredicate.or(Iterable<QueryPredicate> predicates, {isGrouped: false}) {
-    return QueryPredicate._(predicates, "OR");
+  factory QueryPredicate.or(Iterable<QueryPredicate> predicates, {bool isGrouped: false}) {
+    return QueryPredicate._(predicates, "OR", isGrouped: isGrouped);
   }
 
   factory QueryPredicate.andGroup(QueryPredicate lhs, QueryPredicate rhs) {

--- a/aqueduct/lib/src/db/query/predicate.dart
+++ b/aqueduct/lib/src/db/query/predicate.dart
@@ -84,7 +84,8 @@ class QueryPredicate {
     }
 
 
-    String predicateFormat = allFormatStrings.reduce((accum, value) => "$accum $infixOperator ${isGrouped ? "($value)" : "$value"}");
+    String predicateInnerString = allFormatStrings.reduce((accum, value) => "$accum $infixOperator $value");
+    String predicateFormat = "($predicateInnerString)";
 
     return QueryPredicate(predicateFormat, valueMap);
   }
@@ -100,19 +101,11 @@ class QueryPredicate {
   ///
   /// If [predicates] is null or empty, an empty predicate is returned. If [predicates] contains only
   /// one predicate, that predicate is returned.
-  factory QueryPredicate.and(Iterable<QueryPredicate> predicates, {bool isGrouped: false}) {
-    return QueryPredicate._(predicates, "AND", isGrouped: isGrouped);
+  factory QueryPredicate.and(Iterable<QueryPredicate> predicates) {
+    return QueryPredicate._(predicates, "AND");
   }
 
-  factory QueryPredicate.or(Iterable<QueryPredicate> predicates, {bool isGrouped: false}) {
-    return QueryPredicate._(predicates, "OR", isGrouped: isGrouped);
-  }
-
-  factory QueryPredicate.andGroup(QueryPredicate lhs, QueryPredicate rhs) {
-    return QueryPredicate._([lhs, rhs], "AND", isGrouped: true);
-  }
-
-  factory QueryPredicate.orGroup(QueryPredicate lhs, QueryPredicate rhs) {
-    return QueryPredicate._([lhs, rhs], "OR", isGrouped: true);
+  factory QueryPredicate.or(Iterable<QueryPredicate> predicates) {
+    return QueryPredicate._(predicates, "OR");
   }
 }

--- a/aqueduct/lib/src/db/query/predicate.dart
+++ b/aqueduct/lib/src/db/query/predicate.dart
@@ -100,11 +100,11 @@ class QueryPredicate {
   ///
   /// If [predicates] is null or empty, an empty predicate is returned. If [predicates] contains only
   /// one predicate, that predicate is returned.
-  factory QueryPredicate.and(Iterable<QueryPredicate> predicates) {
+  factory QueryPredicate.and(Iterable<QueryPredicate> predicates, {isGrouped: false}) {
     return QueryPredicate._(predicates, "AND");
   }
 
-  factory QueryPredicate.or(Iterable<QueryPredicate> predicates) {
+  factory QueryPredicate.or(Iterable<QueryPredicate> predicates, {isGrouped: false}) {
     return QueryPredicate._(predicates, "OR");
   }
 

--- a/aqueduct/lib/src/db/query/predicate.dart
+++ b/aqueduct/lib/src/db/query/predicate.dart
@@ -37,68 +37,7 @@ class QueryPredicate {
       : format = "",
         parameters = {};
 
-  /// Combines [predicates] with 'AND' keyword.
-  ///
-  /// The [format] of the return value is produced by joining together each [predicates]
-  /// [format] string with 'AND'. Each [parameters] from individual [predicates] is combined
-  /// into the returned [parameters].
-  ///
-  /// If there are duplicate parameter names in [predicates], they will be disambiguated by suffixing
-  /// the parameter name in both [format] and [parameters] with a unique integer.
-  ///
-  /// If [predicates] is null or empty, an empty predicate is returned. If [predicates] contains only
-  /// one predicate, that predicate is returned.
-  factory QueryPredicate.and(Iterable<QueryPredicate> predicates) {
-    var predicateList = predicates
-        ?.where((p) => p?.format != null && p.format.isNotEmpty)
-        ?.toList();
-    if (predicateList == null) {
-      return QueryPredicate.empty();
-    }
-
-    if (predicateList.isEmpty) {
-      return QueryPredicate.empty();
-    }
-
-    if (predicateList.length == 1) {
-      return predicateList.first;
-    }
-
-    // If we have duplicate keys anywhere, we need to disambiguate them.
-    int dupeCounter = 0;
-    final allFormatStrings = [];
-    final valueMap = <String, dynamic>{};
-    for (var predicate in predicateList) {
-      final duplicateKeys = predicate.parameters?.keys
-              ?.where((k) => valueMap.keys.contains(k))
-              ?.toList() ??
-          [];
-
-      if (duplicateKeys.isNotEmpty) {
-        var fmt = predicate.format;
-        Map<String, String> dupeMap = {};
-        duplicateKeys.forEach((key) {
-          final replacementKey = "$key$dupeCounter";
-          fmt = fmt.replaceAll("@$key", "@$replacementKey");
-          dupeMap[key] = replacementKey;
-          dupeCounter++;
-        });
-
-        allFormatStrings.add(fmt);
-        predicate?.parameters?.forEach((key, value) {
-          valueMap[dupeMap[key] ?? key] = value;
-        });
-      } else {
-        allFormatStrings.add(predicate.format);
-        valueMap.addAll(predicate?.parameters ?? {});
-      }
-    }
-
-    final predicateFormat = "${allFormatStrings.join(" AND ")}";
-    return QueryPredicate(predicateFormat, valueMap);
-  }
-
-  factory QueryPredicate.or(Iterable<QueryPredicate> predicates) {
+  factory QueryPredicate._(Iterable<QueryPredicate> predicates, String infixOperator, {bool isGrouped: false}) {
     var predicateList = predicates
         ?.where((p) => p?.format != null && p.format.isNotEmpty)
         ?.toList();
@@ -144,7 +83,39 @@ class QueryPredicate {
       }
     }
 
-    final predicateFormat = "${allFormatStrings.join(" OR ")}";
+    var predicateFormat = "${allFormatStrings.join(" $infixOperator ")}";
+
+    if (isGrouped) {
+      predicateFormat = "(${predicateFormat})";
+    }
+
     return QueryPredicate(predicateFormat, valueMap);
+  }
+
+  /// Combines [predicates] with 'AND' keyword.
+  ///
+  /// The [format] of the return value is produced by joining together each [predicates]
+  /// [format] string with 'AND'. Each [parameters] from individual [predicates] is combined
+  /// into the returned [parameters].
+  ///
+  /// If there are duplicate parameter names in [predicates], they will be disambiguated by suffixing
+  /// the parameter name in both [format] and [parameters] with a unique integer.
+  ///
+  /// If [predicates] is null or empty, an empty predicate is returned. If [predicates] contains only
+  /// one predicate, that predicate is returned.
+  factory QueryPredicate.and(Iterable<QueryPredicate> predicates) {
+    return QueryPredicate._(predicates, "AND");
+  }
+
+  factory QueryPredicate.or(Iterable<QueryPredicate> predicates) {
+    return QueryPredicate._(predicates, "OR");
+  }
+
+  factory QueryPredicate.andGroup(QueryPredicate lhs, QueryPredicate rhs) {
+    return QueryPredicate._([lhs, rhs], "AND", isGrouped: true);
+  }
+
+  factory QueryPredicate.orGroup(QueryPredicate lhs, QueryPredicate rhs) {
+    return QueryPredicate._([lhs, rhs], "OR", isGrouped: true);
   }
 }

--- a/aqueduct/lib/src/db/query/predicate.dart
+++ b/aqueduct/lib/src/db/query/predicate.dart
@@ -37,7 +37,7 @@ class QueryPredicate {
       : format = "",
         parameters = {};
 
-  factory QueryPredicate._(Iterable<QueryPredicate> predicates, String infixOperator, {bool isGrouped: false}) {
+  factory QueryPredicate._(Iterable<QueryPredicate> predicates, String infixOperator) {
     var predicateList = predicates
         ?.where((p) => p?.format != null && p.format.isNotEmpty)
         ?.toList();

--- a/aqueduct/lib/src/db/query/predicate.dart
+++ b/aqueduct/lib/src/db/query/predicate.dart
@@ -37,7 +37,7 @@ class QueryPredicate {
       : format = "",
         parameters = {};
 
-  factory QueryPredicate._(Iterable<QueryPredicate> predicates, String infixOperator) {
+  factory QueryPredicate._compound(Iterable<QueryPredicate> predicates, String infixOperator) {
     var predicateList = predicates
         ?.where((p) => p?.format != null && p.format.isNotEmpty)
         ?.toList();
@@ -102,10 +102,21 @@ class QueryPredicate {
   /// If [predicates] is null or empty, an empty predicate is returned. If [predicates] contains only
   /// one predicate, that predicate is returned.
   factory QueryPredicate.and(Iterable<QueryPredicate> predicates) {
-    return QueryPredicate._(predicates, "AND");
+    return QueryPredicate._compound(predicates, "AND");
   }
 
+  /// Combines [predicates] with 'OR' keyword.
+  ///
+  /// The [format] of the return value is produced by joining together each [predicates]
+  /// [format] string with 'OR'. Each [parameters] from individual [predicates] is combined
+  /// into the returned [parameters].
+  ///
+  /// If there are duplicate parameter names in [predicates], they will be disambiguated by suffixing
+  /// the parameter name in both [format] and [parameters] with a unique integer.
+  ///
+  /// If [predicates] is null or empty, an empty predicate is returned. If [predicates] contains only
+  /// one predicate, that predicate is returned.
   factory QueryPredicate.or(Iterable<QueryPredicate> predicates) {
-    return QueryPredicate._(predicates, "OR");
+    return QueryPredicate._compound(predicates, "OR");
   }
 }

--- a/aqueduct/lib/src/db/query/predicate.dart
+++ b/aqueduct/lib/src/db/query/predicate.dart
@@ -94,7 +94,7 @@ class QueryPredicate {
       }
     }
 
-    final predicateFormat = "(${allFormatStrings.join(" AND ")})";
+    final predicateFormat = "${allFormatStrings.join(" AND ")}";
     return QueryPredicate(predicateFormat, valueMap);
   }
 
@@ -144,7 +144,7 @@ class QueryPredicate {
       }
     }
 
-    final predicateFormat = "(${allFormatStrings.join(" OR ")})";
+    final predicateFormat = "${allFormatStrings.join(" OR ")}";
     return QueryPredicate(predicateFormat, valueMap);
   }
 }

--- a/aqueduct/lib/src/db/query/predicate.dart
+++ b/aqueduct/lib/src/db/query/predicate.dart
@@ -83,11 +83,8 @@ class QueryPredicate {
       }
     }
 
-    var predicateFormat = "${allFormatStrings.join(" $infixOperator ")}";
 
-    if (isGrouped) {
-      predicateFormat = "(${predicateFormat})";
-    }
+    String predicateFormat = allFormatStrings.reduce((accum, value) => "$accum $infixOperator ${isGrouped ? "($value)" : "$value"}");
 
     return QueryPredicate(predicateFormat, valueMap);
   }

--- a/aqueduct/lib/src/db/query/query.dart
+++ b/aqueduct/lib/src/db/query/query.dart
@@ -187,7 +187,7 @@ abstract class Query<InstanceType extends ManagedObject> {
   ///         final query = Query<Employee>()
   ///           ..where((e) => e.manager.name).equalTo("Sally");
   ///
-  QueryExpression<T, InstanceType> where<T>(
+  QueryExpression<T, T, InstanceType> where<T>(
       T propertyIdentifier(InstanceType x));
 
   /// Confirms that a query has no predicate before executing it.

--- a/aqueduct/lib/src/db/query/query.dart
+++ b/aqueduct/lib/src/db/query/query.dart
@@ -190,6 +190,14 @@ abstract class Query<InstanceType extends ManagedObject> {
   QueryExpression<T, T, InstanceType> where<T>(
       T propertyIdentifier(InstanceType x));
 
+  QueryExpression<T, U, InstanceType> orWhere<T, U>(
+      T propertyIdentifier(InstanceType x));
+
+  void whereGroup<T, U>(
+      void expressionGetter(Query<InstanceType> q));
+
+  void orWhereGroup<T, U>(
+      void expressionGetter(Query<InstanceType> q));
   /// Confirms that a query has no predicate before executing it.
   ///
   /// This is a safety measure for update and delete queries to prevent accidentally updating or deleting every row.

--- a/aqueduct/lib/src/db/query/query.dart
+++ b/aqueduct/lib/src/db/query/query.dart
@@ -187,10 +187,10 @@ abstract class Query<InstanceType extends ManagedObject> {
   ///         final query = Query<Employee>()
   ///           ..where((e) => e.manager.name).equalTo("Sally");
   ///
-  QueryExpression<T, T, InstanceType> where<T>(
+  QueryExpression<T, InstanceType> where<T>(
       T propertyIdentifier(InstanceType x));
 
-  QueryExpression<T, U, InstanceType> orWhere<T, U>(
+  QueryExpression<T, InstanceType> orWhere<T, U>(
       T propertyIdentifier(InstanceType x));
 
   void whereGroup<T, U>(

--- a/aqueduct/test/db/model_controller_test.dart
+++ b/aqueduct/test/db/model_controller_test.dart
@@ -173,8 +173,8 @@ class StringController extends QueryController<StringModel> {
   }
 
   List<QueryExpression>getExpressionListFromExpression(Tree<QueryExpression> tree) {
-    if (tree is LogicalOperantNode<Tree<QueryExpression>>) {
-      final node = tree as LogicalOperantNode<Tree<QueryExpression>>;
+    if (tree is LogicalOperatorNode<Tree<QueryExpression>>) {
+      final node = tree as LogicalOperatorNode<Tree<QueryExpression>>;
       final expressions = getExpressionListFromExpression(node.operand);
       expressions.addAll(getExpressionListFromExpression(node.operand2));
       return expressions;

--- a/aqueduct/test/db/model_controller_test.dart
+++ b/aqueduct/test/db/model_controller_test.dart
@@ -21,7 +21,7 @@ void main() {
     server = await HttpServer.bind(InternetAddress.loopbackIPv4, 8888);
     var router = Router();
     router.route("/users/[:id]").link(() => TestModelController(context));
-//    router.route("/string/:id").link(() => StringController(context));
+    router.route("/string/:id").link(() => StringController(context));
     router.didAddToChannel();
 
     server.listen((req) async {
@@ -40,22 +40,22 @@ void main() {
     expect(response.statusCode, 200);
   });
 
-//  test("Request with path parameter of type needing parse OK", () async {
-//    var response = await http.get("http://localhost:8888/users/1");
-//    expect(response.statusCode, 200);
-//  });
+  test("Request with path parameter of type needing parse OK", () async {
+    var response = await http.get("http://localhost:8888/users/1");
+    expect(response.statusCode, 200);
+  });
 
   test("Request with path parameter of wrong type returns 404", () async {
     var response = await http.get("http://localhost:8888/users/foo");
     expect(response.statusCode, 404);
   });
 
-//  test("Request with path parameter and body", () async {
-//    var response = await http.put("http://localhost:8888/users/2",
-//        headers: {"Content-Type": "application/json;charset=utf-8"},
-//        body: json.encode({"name": "joe"}));
-//    expect(response.statusCode, 200);
-//  });
+  test("Request with path parameter and body", () async {
+    var response = await http.put("http://localhost:8888/users/2",
+        headers: {"Content-Type": "application/json;charset=utf-8"},
+        body: json.encode({"name": "joe"}));
+    expect(response.statusCode, 200);
+  });
 
   test("Request without path parameter and body", () async {
     var response = await http.post("http://localhost:8888/users",
@@ -64,10 +64,10 @@ void main() {
     expect(response.statusCode, 200);
   });
 
-//  test("Non-integer, oddly named identifier", () async {
-//    var response = await http.get("http://localhost:8888/string/bar");
-//    expect(response.body, '"bar"');
-//  });
+  test("Non-integer, oddly named identifier", () async {
+    var response = await http.get("http://localhost:8888/string/bar");
+    expect(response.body, '"bar"');
+  });
 }
 
 class TestModelController extends QueryController<TestModel> {
@@ -88,63 +88,63 @@ class TestModelController extends QueryController<TestModel> {
     return Response(statusCode, {}, null);
   }
 
-//  @Operation.get("id")
-//  Future<Response> getOne(@Bind.path("id") int id) async {
-//    int statusCode = 200;
-//
-//    if (query == null) {
-//      statusCode = 400;
-//    }
-//
-//    ComparisonExpression comparisonMatcher = (query as QueryMixin)
-//        .expressions
-//        .firstWhere((expr) => expr.keyPath.path.first.name == "id")
-//        .expression;
-//    if (comparisonMatcher.operator != PredicateOperator.equalTo ||
-//        comparisonMatcher.value != id) {
-//      statusCode = 400;
-//    }
-//
-//    if (query.values.backing.contents.isNotEmpty) {
-//      statusCode = 400;
-//    }
-//
-//    return Response(statusCode, {}, null);
-//  }
+  @Operation.get("id")
+  Future<Response> getOne(@Bind.path("id") int id) async {
+    int statusCode = 200;
 
-//  @Operation.put("id")
-//  Future<Response> putOne(@Bind.path("id") int id) async {
-//    int statusCode = 200;
-//
-//    if (query.values == null) {
-//      statusCode = 400;
-//    }
-//    if (query.values.name != "joe") {
-//      statusCode = 400;
-//    }
-//    if (query == null) {
-//      statusCode = 400;
-//    }
-//
-//    ComparisonExpression comparisonMatcher = (query as QueryMixin)
-//        .expressions
-//        .firstWhere((expr) => expr.keyPath.path.first.name == "id")
-//        .expression;
-//    if (comparisonMatcher.operator != PredicateOperator.equalTo ||
-//        comparisonMatcher.value != id) {
-//      statusCode = 400;
-//    }
-//
-//    if (query.values == null) {
-//      statusCode = 400;
-//    }
-//
-//    if (query.values.name != "joe") {
-//      statusCode = 400;
-//    }
-//
-//    return Response(statusCode, {}, null);
-//  }
+    if (query == null) {
+      statusCode = 400;
+    }
+
+    ComparisonExpression comparisonMatcher = (query as QueryMixin)
+        .expressions
+        .firstWhere((expr) => expr.keyPath.path.first.name == "id")
+        .expression;
+    if (comparisonMatcher.operator != PredicateOperator.equalTo ||
+        comparisonMatcher.value != id) {
+      statusCode = 400;
+    }
+
+    if (query.values.backing.contents.isNotEmpty) {
+      statusCode = 400;
+    }
+
+    return Response(statusCode, {}, null);
+  }
+
+  @Operation.put("id")
+  Future<Response> putOne(@Bind.path("id") int id) async {
+    int statusCode = 200;
+
+    if (query.values == null) {
+      statusCode = 400;
+    }
+    if (query.values.name != "joe") {
+      statusCode = 400;
+    }
+    if (query == null) {
+      statusCode = 400;
+    }
+
+    ComparisonExpression comparisonMatcher = (query as QueryMixin)
+        .expressions
+        .firstWhere((expr) => expr.keyPath.path.first.name == "id")
+        .expression;
+    if (comparisonMatcher.operator != PredicateOperator.equalTo ||
+        comparisonMatcher.value != id) {
+      statusCode = 400;
+    }
+
+    if (query.values == null) {
+      statusCode = 400;
+    }
+
+    if (query.values.name != "joe") {
+      statusCode = 400;
+    }
+
+    return Response(statusCode, {}, null);
+  }
 
   @Operation.post()
   Future<Response> create() async {
@@ -178,18 +178,18 @@ class _TestModel {
   String email;
 }
 
-//class StringController extends QueryController<StringModel> {
-//  StringController(ManagedContext context) : super(context);
-//
-//  @Operation.get("id")
-//  Future<Response> get(@Bind.path("id") String id) async {
-//    StringExpression comparisonMatcher = (query as QueryMixin)
-//        .expressions
-//        .firstWhere((expr) => expr.keyPath.path.first.name == "foo")
-//        .expression;
-//    return Response.ok(comparisonMatcher.value);
-//  }
-//}
+class StringController extends QueryController<StringModel> {
+  StringController(ManagedContext context) : super(context);
+
+  @Operation.get("id")
+  Future<Response> get(@Bind.path("id") String id) async {
+    StringExpression comparisonMatcher = (query as QueryMixin)
+        .expressions
+        .firstWhere((expr) => expr.keyPath.path.first.name == "foo")
+        .expression;
+    return Response.ok(comparisonMatcher.value);
+  }
+}
 
 class StringModel extends ManagedObject<_StringModel> implements _StringModel {}
 

--- a/aqueduct/test/db/model_controller_test.dart
+++ b/aqueduct/test/db/model_controller_test.dart
@@ -21,7 +21,7 @@ void main() {
     server = await HttpServer.bind(InternetAddress.loopbackIPv4, 8888);
     var router = Router();
     router.route("/users/[:id]").link(() => TestModelController(context));
-    router.route("/string/:id").link(() => StringController(context));
+//    router.route("/string/:id").link(() => StringController(context));
     router.didAddToChannel();
 
     server.listen((req) async {
@@ -40,22 +40,22 @@ void main() {
     expect(response.statusCode, 200);
   });
 
-  test("Request with path parameter of type needing parse OK", () async {
-    var response = await http.get("http://localhost:8888/users/1");
-    expect(response.statusCode, 200);
-  });
+//  test("Request with path parameter of type needing parse OK", () async {
+//    var response = await http.get("http://localhost:8888/users/1");
+//    expect(response.statusCode, 200);
+//  });
 
   test("Request with path parameter of wrong type returns 404", () async {
     var response = await http.get("http://localhost:8888/users/foo");
     expect(response.statusCode, 404);
   });
 
-  test("Request with path parameter and body", () async {
-    var response = await http.put("http://localhost:8888/users/2",
-        headers: {"Content-Type": "application/json;charset=utf-8"},
-        body: json.encode({"name": "joe"}));
-    expect(response.statusCode, 200);
-  });
+//  test("Request with path parameter and body", () async {
+//    var response = await http.put("http://localhost:8888/users/2",
+//        headers: {"Content-Type": "application/json;charset=utf-8"},
+//        body: json.encode({"name": "joe"}));
+//    expect(response.statusCode, 200);
+//  });
 
   test("Request without path parameter and body", () async {
     var response = await http.post("http://localhost:8888/users",
@@ -64,10 +64,10 @@ void main() {
     expect(response.statusCode, 200);
   });
 
-  test("Non-integer, oddly named identifier", () async {
-    var response = await http.get("http://localhost:8888/string/bar");
-    expect(response.body, '"bar"');
-  });
+//  test("Non-integer, oddly named identifier", () async {
+//    var response = await http.get("http://localhost:8888/string/bar");
+//    expect(response.body, '"bar"');
+//  });
 }
 
 class TestModelController extends QueryController<TestModel> {
@@ -88,63 +88,63 @@ class TestModelController extends QueryController<TestModel> {
     return Response(statusCode, {}, null);
   }
 
-  @Operation.get("id")
-  Future<Response> getOne(@Bind.path("id") int id) async {
-    int statusCode = 200;
+//  @Operation.get("id")
+//  Future<Response> getOne(@Bind.path("id") int id) async {
+//    int statusCode = 200;
+//
+//    if (query == null) {
+//      statusCode = 400;
+//    }
+//
+//    ComparisonExpression comparisonMatcher = (query as QueryMixin)
+//        .expressions
+//        .firstWhere((expr) => expr.keyPath.path.first.name == "id")
+//        .expression;
+//    if (comparisonMatcher.operator != PredicateOperator.equalTo ||
+//        comparisonMatcher.value != id) {
+//      statusCode = 400;
+//    }
+//
+//    if (query.values.backing.contents.isNotEmpty) {
+//      statusCode = 400;
+//    }
+//
+//    return Response(statusCode, {}, null);
+//  }
 
-    if (query == null) {
-      statusCode = 400;
-    }
-
-    ComparisonExpression comparisonMatcher = (query as QueryMixin)
-        .expressions
-        .firstWhere((expr) => expr.keyPath.path.first.name == "id")
-        .expression;
-    if (comparisonMatcher.operator != PredicateOperator.equalTo ||
-        comparisonMatcher.value != id) {
-      statusCode = 400;
-    }
-
-    if (query.values.backing.contents.isNotEmpty) {
-      statusCode = 400;
-    }
-
-    return Response(statusCode, {}, null);
-  }
-
-  @Operation.put("id")
-  Future<Response> putOne(@Bind.path("id") int id) async {
-    int statusCode = 200;
-
-    if (query.values == null) {
-      statusCode = 400;
-    }
-    if (query.values.name != "joe") {
-      statusCode = 400;
-    }
-    if (query == null) {
-      statusCode = 400;
-    }
-
-    ComparisonExpression comparisonMatcher = (query as QueryMixin)
-        .expressions
-        .firstWhere((expr) => expr.keyPath.path.first.name == "id")
-        .expression;
-    if (comparisonMatcher.operator != PredicateOperator.equalTo ||
-        comparisonMatcher.value != id) {
-      statusCode = 400;
-    }
-
-    if (query.values == null) {
-      statusCode = 400;
-    }
-
-    if (query.values.name != "joe") {
-      statusCode = 400;
-    }
-
-    return Response(statusCode, {}, null);
-  }
+//  @Operation.put("id")
+//  Future<Response> putOne(@Bind.path("id") int id) async {
+//    int statusCode = 200;
+//
+//    if (query.values == null) {
+//      statusCode = 400;
+//    }
+//    if (query.values.name != "joe") {
+//      statusCode = 400;
+//    }
+//    if (query == null) {
+//      statusCode = 400;
+//    }
+//
+//    ComparisonExpression comparisonMatcher = (query as QueryMixin)
+//        .expressions
+//        .firstWhere((expr) => expr.keyPath.path.first.name == "id")
+//        .expression;
+//    if (comparisonMatcher.operator != PredicateOperator.equalTo ||
+//        comparisonMatcher.value != id) {
+//      statusCode = 400;
+//    }
+//
+//    if (query.values == null) {
+//      statusCode = 400;
+//    }
+//
+//    if (query.values.name != "joe") {
+//      statusCode = 400;
+//    }
+//
+//    return Response(statusCode, {}, null);
+//  }
 
   @Operation.post()
   Future<Response> create() async {
@@ -178,18 +178,18 @@ class _TestModel {
   String email;
 }
 
-class StringController extends QueryController<StringModel> {
-  StringController(ManagedContext context) : super(context);
-
-  @Operation.get("id")
-  Future<Response> get(@Bind.path("id") String id) async {
-    StringExpression comparisonMatcher = (query as QueryMixin)
-        .expressions
-        .firstWhere((expr) => expr.keyPath.path.first.name == "foo")
-        .expression;
-    return Response.ok(comparisonMatcher.value);
-  }
-}
+//class StringController extends QueryController<StringModel> {
+//  StringController(ManagedContext context) : super(context);
+//
+//  @Operation.get("id")
+//  Future<Response> get(@Bind.path("id") String id) async {
+//    StringExpression comparisonMatcher = (query as QueryMixin)
+//        .expressions
+//        .firstWhere((expr) => expr.keyPath.path.first.name == "foo")
+//        .expression;
+//    return Response.ok(comparisonMatcher.value);
+//  }
+//}
 
 class StringModel extends ManagedObject<_StringModel> implements _StringModel {}
 

--- a/aqueduct/test/db/model_controller_test.dart
+++ b/aqueduct/test/db/model_controller_test.dart
@@ -172,16 +172,17 @@ class StringController extends QueryController<StringModel> {
     return Response.ok(expression.operand);
   }
 
-  List<QueryExpression>getExpressionListFromExpression(QueryExpression queryExpression) {
-    final predicateExpression = queryExpression.expression;
-    if (predicateExpression is LogicalOperantNode<QueryExpression>) {
-      final node = predicateExpression as LogicalOperantNode<QueryExpression>;
+  List<QueryExpression>getExpressionListFromExpression(Tree<QueryExpression> tree) {
+    if (tree is LogicalOperantNode<Tree<QueryExpression>>) {
+      final node = tree as LogicalOperantNode<Tree<QueryExpression>>;
       final expressions = getExpressionListFromExpression(node.operand);
       expressions.addAll(getExpressionListFromExpression(node.operand2));
       return expressions;
+    } else if (tree is LeafNode<QueryExpression>) {
+      return [tree.value];
     }
 
-    return [queryExpression];
+    throw "Unreachable";
   }
 }
 

--- a/aqueduct/test/db/postgresql/matcher_test.dart
+++ b/aqueduct/test/db/postgresql/matcher_test.dart
@@ -381,8 +381,6 @@ void main() {
   });
 
   group("Or Where", () {
-    justLogEverything();
-
     setUpAll(() async {
       var realBob = Query<AnotherTestModel>(context)
         ..values.name = "Bob"

--- a/aqueduct/test/db/postgresql/matcher_test.dart
+++ b/aqueduct/test/db/postgresql/matcher_test.dart
@@ -486,7 +486,7 @@ void main() {
 
       var results2 = await r2.fetch();
 
-      expect(results2.length, 3);
+      expect(results2.length, 2);
 
       final firstResult2 = results2[0];
       expect(firstResult2.name, "Bob");
@@ -497,11 +497,6 @@ void main() {
       expect(secondResult2.name, "Bob");
       expect(secondResult2.email, "bob@company.com");
       expect(secondResult2.rank, "9999");
-
-      final thirdResult2 = results2[2];
-      expect(thirdResult2.name, "Jeff");
-      expect(thirdResult2.email, "founder@company.com");
-      expect(thirdResult2.rank, "9998");
     });
 
     test("Complex And Or", () async {

--- a/aqueduct/test/db/postgresql/matcher_test.dart
+++ b/aqueduct/test/db/postgresql/matcher_test.dart
@@ -541,9 +541,9 @@ void main() {
             ..orWhere((o) => o.name).equalTo("Jeff"))
       ..sortBy((r) => r.name, QuerySortOrder.ascending);
 
-      var results= await r.fetch();
+      var results = await r.fetch();
 
-      expect(results.length, 3);
+      expect(results.length, 2);
 
       final firstResult = results[0];
       expect(firstResult.name, "Bob");
@@ -554,11 +554,6 @@ void main() {
       expect(secondResult.name, "Jeff");
       expect(secondResult.email, "founder@company.com");
       expect(secondResult.rank, "9998");
-
-      final thirdResult = results[2];
-      expect(thirdResult.name, "Jeff");
-      expect(thirdResult.email, "intern@company.com");
-      expect(thirdResult.rank, "2");
     });
 
     test("orWhereGroup", () async {

--- a/aqueduct/test/db/postgresql/matcher_test.dart
+++ b/aqueduct/test/db/postgresql/matcher_test.dart
@@ -382,50 +382,45 @@ void main() {
 
   group("Or Where", () {
     setUpAll(() async {
-      var realBob = Query<AnotherTestModel>(context)
-        ..values.name = "Bob"
-        ..values.email = "founder@company.com"
-        ..values.rank = "8000";
-      await realBob.insert();
+      var realBob = AnotherTestModel()
+        ..name = "Bob"
+        ..email = "founder@company.com"
+        ..rank = "8000";
 
-      var alsoRealBob = Query<AnotherTestModel>(context)
-        ..values.name = "Bob"
-        ..values.email = "bob@company.com"
-        ..values.rank = "9999";
-      await alsoRealBob.insert();
+      var alsoRealBob = AnotherTestModel()
+        ..name = "Bob"
+        ..email = "bob@company.com"
+        ..rank = "9999";
 
-      var decoyDude = Query<AnotherTestModel>(context)
-        ..values.name = "The Dude"
-        ..values.email = "bowling@alley.com"
-        ..values.rank = '1';
-      await decoyDude.insert();
+      var decoyDude = AnotherTestModel()
+        ..name = "The Dude"
+        ..email = "bowling@alley.com"
+        ..rank = '1';
 
-      var imposterBob = Query<AnotherTestModel>(context)
-        ..values.name = "Bob"
-        ..values.email = "contractor@company.com"
-        ..values.rank = "8000";
-      await imposterBob.insert();
+      var imposterBob = AnotherTestModel()
+        ..name = "Bob"
+        ..email = "contractor@company.com"
+        ..rank = "8000";
 
-      var anotherImposterBob = Query<AnotherTestModel>(context)
-        ..values.name = "Bob"
-        ..values.email = "bobby@company.com"
-        ..values.rank = "100";
-      await anotherImposterBob.insert();
+      var anotherImposterBob = AnotherTestModel()
+        ..name = "Bob"
+        ..email = "bobby@company.com"
+        ..rank = "100";
 
-      var cofounder = Query<AnotherTestModel>(context)
-        ..values.name = "Jeff"
-        ..values.email = "founder@company.com"
-        ..values.rank = "9998";
-      await cofounder.insert();
+      var cofounder = AnotherTestModel()
+        ..name = "Jeff"
+        ..email = "founder@company.com"
+        ..rank = "9998";
 
-      var imposterCoFounder = Query<AnotherTestModel>(context)
-        ..values.name = "Jeff"
-        ..values.email = "intern@company.com"
-        ..values.rank = "2";
-      await imposterCoFounder.insert();
+      var imposterCoFounder = AnotherTestModel()
+        ..name = "Jeff"
+        ..email = "intern@company.com"
+        ..rank = "2";
+
+      await Query.insertObjects(context, [realBob, alsoRealBob, decoyDude, imposterBob, anotherImposterBob, cofounder, imposterCoFounder]);
     });
 
-    test("simple Or", () async {
+      test("simple Or", () async {
       // WHERE _AnotherTestModel.rank > @_AnotherTestModel_rank:text OR _AnotherTestModel.email LIKE @_AnotherTestModel_email:text
 
       var r = Query<AnotherTestModel>(context)

--- a/aqueduct/test/db/postgresql/matcher_test.dart
+++ b/aqueduct/test/db/postgresql/matcher_test.dart
@@ -428,7 +428,7 @@ void main() {
     });
 
     test("simple Or", () async {
-      //select * from users where name = 'Bob' and (email = "ceo@company.com" or rank > 9000)
+      // WHERE _AnotherTestModel.rank > @_AnotherTestModel_rank:text OR _AnotherTestModel.email LIKE @_AnotherTestModel_email:text
 
       var r = Query<AnotherTestModel>(context)
         ..where((o) => o.email).equalTo("founder@company.com")
@@ -456,8 +456,7 @@ void main() {
     });
 
     test("And Or", () async {
-      // SELECT id,name,rank,email FROM _AnotherTestModel
-      // WHERE _AnotherTestModel.rank > @_AnotherTestModel_rank:text AND _AnotherTestModel.name LIKE @_AnotherTestModel_name:text OR _AnotherTestModel.email LIKE @_AnotherTestModel_email:text
+      // WHERE _AnotherTestModel.rank LIKE @_AnotherTestModel_rank:text OR _AnotherTestModel.name LIKE @_AnotherTestModel_name:text AND _AnotherTestModel.email LIKE @_AnotherTestModel_email:text
 
       var r1 = Query<AnotherTestModel>(context)
         ..where((o) => o.email).equalTo("founder@company.com")
@@ -478,6 +477,8 @@ void main() {
       expect(secondResult1.name, "Bob");
       expect(secondResult1.email, "bob@company.com");
       expect(secondResult1.rank, "9999");
+
+      // WHERE _AnotherTestModel.name LIKE @_AnotherTestModel_name:text AND _AnotherTestModel.rank LIKE @_AnotherTestModel_rank:text OR _AnotherTestModel.email LIKE @_AnotherTestModel_email:text
 
       var r2 = Query<AnotherTestModel>(context)
         ..where((o) => o.email).equalTo("founder@company.com")
@@ -506,9 +507,7 @@ void main() {
     });
 
     test("Complex And Or", () async {
-      // SELECT id,name,rank,email FROM _AnotherTestModel
-      // WHERE _AnotherTestModel.name LIKE @_AnotherTestModel_name:text AND _AnotherTestModel.email LIKE @_AnotherTestModel_email:text OR _AnotherTestModel.rank > @_AnotherTestModel_rank:text AND _AnotherTestModel.name LIKE @_AnotherTestModel_name0:text
-      // ORDER BY _AnotherTestModel.name ASC
+      // WHERE _AnotherTestModel.name LIKE @_AnotherTestModel_name0:text AND _AnotherTestModel.rank > @_AnotherTestModel_rank:text OR _AnotherTestModel.email LIKE @_AnotherTestModel_email:text AND _AnotherTestModel.name LIKE @_AnotherTestModel_name:text
 
       var r = Query<AnotherTestModel>(context)
         ..where((o) => o.name).equalTo("Bob")
@@ -533,7 +532,7 @@ void main() {
     });
 
     test("whereGroup (implicit and)", () async {
-      // SELECT id,name,rank,email FROM _AnotherTestModel WHERE (_AnotherTestModel.name LIKE @_AnotherTestModel_name:text AND ((_AnotherTestModel.email LIKE @_AnotherTestModel_email:text OR _AnotherTestModel.rank > @_AnotherTestModel_rank:text)))   Substitutes: {_AnotherTestModel_name: Bob, _AnotherTestModel_email: ceo@company.com, _AnotherTestModel_rank: 9000} -> [[1, Bob, 8000, ceo@company.com], [2, Bob, 9999, bob@company.com]] null null
+      // WHERE _AnotherTestModel.name LIKE @_AnotherTestModel_name0:text OR _AnotherTestModel.name LIKE @_AnotherTestModel_name:text AND (_AnotherTestModel.email LIKE @_AnotherTestModel_email:text)
 
       var r = Query<AnotherTestModel>(context)
         ..where((o) => o.email).equalTo("founder@company.com")
@@ -563,8 +562,8 @@ void main() {
     });
 
     test("orWhereGroup", () async {
-      // SELECT id,name,rank,email FROM _AnotherTestModel
-      // WHERE (_AnotherTestModel.email LIKE @_AnotherTestModel_email:text OR (_AnotherTestModel.name LIKE @_AnotherTestModel_name:text AND _AnotherTestModel.rank > @_AnotherTestModel_rank:text))
+      // WHERE _AnotherTestModel.rank > @_AnotherTestModel_rank:text AND _AnotherTestModel.name LIKE @_AnotherTestModel_name:text OR (_AnotherTestModel.email LIKE @_AnotherTestModel_email:text)
+
       var r = Query<AnotherTestModel>(context)
         ..where((o) => o.email).equalTo("founder@company.com")
         ..orWhereGroup((query) => query

--- a/aqueduct/test/db/predicate_test.dart
+++ b/aqueduct/test/db/predicate_test.dart
@@ -80,7 +80,7 @@ void main() {
     test("QueryPredicate.orGroup", () {
       var p1 = QueryPredicate("p=q", null);
       var p2 = QueryPredicate("a=b", null);
-      final combined = QueryPredicate.orGroup(p1, p2);
+      final combined = QueryPredicate.or([p1, p2], isGrouped: true);
       expect(combined.format, "p=q OR (a=b)");
     });
 
@@ -88,7 +88,7 @@ void main() {
       test("Simplest", () {
         var p1 = QueryPredicate("p=q", null);
         var p2 = QueryPredicate("a=b", null);
-        final combined = QueryPredicate.andGroup(p1, p2);
+        final combined = QueryPredicate.and([p1, p2], isGrouped: true);
         expect(combined.format, "p=q AND (a=b)");
       });
     });

--- a/aqueduct/test/db/predicate_test.dart
+++ b/aqueduct/test/db/predicate_test.dart
@@ -7,7 +7,7 @@ void main() {
       var p1 = QueryPredicate("p=@p", {"p": 1});
       var p2 = QueryPredicate("p=@p", {"p": 2});
       final combined = QueryPredicate.and([p1, p2]);
-      expect(combined.format, "(p=@p AND p=@p0)");
+      expect(combined.format, "p=@p AND p=@p0");
       expect(combined.parameters, {"p": 1, "p0": 2});
     });
 
@@ -16,7 +16,7 @@ void main() {
       var p2 = QueryPredicate("p=@p", {"p": 2});
       var p3 = QueryPredicate("p=@p", {"p": 3});
       final combined = QueryPredicate.and([p1, p2, p3]);
-      expect(combined.format, "(p=@p AND p=@p0 AND p=@p1)");
+      expect(combined.format, "p=@p AND p=@p0 AND p=@p1");
       expect(combined.parameters, {"p": 1, "p0": 2, "p1": 3});
     });
 
@@ -64,7 +64,7 @@ void main() {
       var p1 = QueryPredicate("p=q", null);
       var p2 = QueryPredicate("a=b", null);
       final combined = QueryPredicate.or([p1, p2]);
-      expect(combined.format, "(p=q OR a=b)");
+      expect(combined.format, "p=q OR a=b");
     });
 
     test("A few predicates", () {
@@ -72,14 +72,14 @@ void main() {
       var p2 = QueryPredicate("a=b", null);
       var p3 = QueryPredicate("x=y", null);
       final combined = QueryPredicate.or([p1, p2, p3]);
-      expect(combined.format, "(p=q OR a=b OR x=y)");
+      expect(combined.format, "p=q OR a=b OR x=y");
     });
 
     test("Duplicate keys are replaced", () {
       var p1 = QueryPredicate("p=@p", {"p": 1});
       var p2 = QueryPredicate("p=@p", {"p": 2});
       final combined = QueryPredicate.or([p1, p2]);
-      expect(combined.format, "(p=@p OR p=@p0)");
+      expect(combined.format, "p=@p OR p=@p0");
       expect(combined.parameters, {"p": 1, "p0": 2});
     });
 

--- a/aqueduct/test/db/predicate_test.dart
+++ b/aqueduct/test/db/predicate_test.dart
@@ -58,4 +58,76 @@ void main() {
       expect(p.parameters, {});
     });
   });
+
+  group("QueryPredicate.or", () {
+    test("Simplest", () {
+      var p1 = QueryPredicate("p=q", null);
+      var p2 = QueryPredicate("a=b", null);
+      final combined = QueryPredicate.or([p1, p2]);
+      expect(combined.format, "(p=q OR a=b)");
+    });
+
+    test("A few predicates", () {
+      var p1 = QueryPredicate("p=q", null);
+      var p2 = QueryPredicate("a=b", null);
+      var p3 = QueryPredicate("x=y", null);
+      final combined = QueryPredicate.or([p1, p2, p3]);
+      expect(combined.format, "(p=q OR a=b OR x=y)");
+    });
+
+    test("Duplicate keys are replaced", () {
+      var p1 = QueryPredicate("p=@p", {"p": 1});
+      var p2 = QueryPredicate("p=@p", {"p": 2});
+      final combined = QueryPredicate.or([p1, p2]);
+      expect(combined.format, "(p=@p OR p=@p0)");
+      expect(combined.parameters, {"p": 1, "p0": 2});
+    });
+
+//    test("Multiple duplicate keys are replaced", () {
+//      var p1 = QueryPredicate("p=@p", {"p": 1});
+//      var p2 = QueryPredicate("p=@p", {"p": 2});
+//      var p3 = QueryPredicate("p=@p", {"p": 3});
+//      final combined = QueryPredicate.and([p1, p2, p3]);
+//      expect(combined.format, "(p=@p AND p=@p0 AND p=@p1)");
+//      expect(combined.parameters, {"p": 1, "p0": 2, "p1": 3});
+//    });
+//
+//    test("If empty list, return empty predicate", () {
+//      expect(QueryPredicate.and([]).format, "");
+//      expect(QueryPredicate.and([]).parameters, {});
+//    });
+//
+//    test("If null, return empty predicate", () {
+//      expect(QueryPredicate.and(null).format, "");
+//      expect(QueryPredicate.and(null).parameters, {});
+//    });
+//
+//    test("If only one element in list, return that element", () {
+//      final valid = QueryPredicate("x=@a", {"a": 0});
+//      final p = QueryPredicate.and([valid]);
+//      expect(p.format, valid.format);
+//      expect(p.parameters, valid.parameters);
+//    });
+//
+//    test("If and'ing empty predicate, ignore it", () {
+//      final valid = QueryPredicate("x=@a", {"a": 0});
+//      final p = QueryPredicate.and([valid, QueryPredicate.empty()]);
+//      expect(p.format, valid.format);
+//      expect(p.parameters, valid.parameters);
+//    });
+//
+//    test("If and'ing null predicate, ignore it", () {
+//      final valid = QueryPredicate("x=@a", {"a": 0});
+//      final p = QueryPredicate.and([valid, null]);
+//      expect(p.format, valid.format);
+//      expect(p.parameters, valid.parameters);
+//    });
+//
+//    test("And'ing predicate with no parameters", () {
+//      final valid = QueryPredicate("x=y", null);
+//      final p = QueryPredicate.and([valid]);
+//      expect(p.format, valid.format);
+//      expect(p.parameters, {});
+//    });
+  });
 }

--- a/aqueduct/test/db/predicate_test.dart
+++ b/aqueduct/test/db/predicate_test.dart
@@ -7,7 +7,7 @@ void main() {
       var p1 = QueryPredicate("p=@p", {"p": 1});
       var p2 = QueryPredicate("p=@p", {"p": 2});
       final combined = QueryPredicate.and([p1, p2]);
-      expect(combined.format, "p=@p AND p=@p0");
+      expect(combined.format, "(p=@p AND p=@p0)");
       expect(combined.parameters, {"p": 1, "p0": 2});
     });
 
@@ -16,7 +16,7 @@ void main() {
       var p2 = QueryPredicate("p=@p", {"p": 2});
       var p3 = QueryPredicate("p=@p", {"p": 3});
       final combined = QueryPredicate.and([p1, p2, p3]);
-      expect(combined.format, "p=@p AND p=@p0 AND p=@p1");
+      expect(combined.format, "(p=@p AND p=@p0 AND p=@p1)");
       expect(combined.parameters, {"p": 1, "p0": 2, "p1": 3});
     });
 
@@ -64,7 +64,7 @@ void main() {
       var p1 = QueryPredicate("p=q", null);
       var p2 = QueryPredicate("a=b", null);
       final combined = QueryPredicate.or([p1, p2]);
-      expect(combined.format, "p=q OR a=b");
+      expect(combined.format, "(p=q OR a=b)");
     });
 
     test("A few predicates", () {
@@ -72,25 +72,7 @@ void main() {
       var p2 = QueryPredicate("a=b", null);
       var p3 = QueryPredicate("x=y", null);
       final combined = QueryPredicate.or([p1, p2, p3]);
-      expect(combined.format, "p=q OR a=b OR x=y");
-    });
-  });
-
-  group("Groups", () {
-    test("QueryPredicate.orGroup", () {
-      var p1 = QueryPredicate("p=q", null);
-      var p2 = QueryPredicate("a=b", null);
-      final combined = QueryPredicate.or([p1, p2], isGrouped: true);
-      expect(combined.format, "p=q OR (a=b)");
-    });
-
-    group("QueryPredicate.andGroup", () {
-      test("Simplest", () {
-        var p1 = QueryPredicate("p=q", null);
-        var p2 = QueryPredicate("a=b", null);
-        final combined = QueryPredicate.and([p1, p2], isGrouped: true);
-        expect(combined.format, "p=q AND (a=b)");
-      });
+      expect(combined.format, "(p=q OR a=b OR x=y)");
     });
   });
 }

--- a/aqueduct/test/db/predicate_test.dart
+++ b/aqueduct/test/db/predicate_test.dart
@@ -74,60 +74,23 @@ void main() {
       final combined = QueryPredicate.or([p1, p2, p3]);
       expect(combined.format, "p=q OR a=b OR x=y");
     });
+  });
 
-    test("Duplicate keys are replaced", () {
-      var p1 = QueryPredicate("p=@p", {"p": 1});
-      var p2 = QueryPredicate("p=@p", {"p": 2});
-      final combined = QueryPredicate.or([p1, p2]);
-      expect(combined.format, "p=@p OR p=@p0");
-      expect(combined.parameters, {"p": 1, "p0": 2});
+  group("Groups", () {
+    test("QueryPredicate.orGroup", () {
+      var p1 = QueryPredicate("p=q", null);
+      var p2 = QueryPredicate("a=b", null);
+      final combined = QueryPredicate.orGroup(p1, p2);
+      expect(combined.format, "p=q OR (a=b)");
     });
 
-//    test("Multiple duplicate keys are replaced", () {
-//      var p1 = QueryPredicate("p=@p", {"p": 1});
-//      var p2 = QueryPredicate("p=@p", {"p": 2});
-//      var p3 = QueryPredicate("p=@p", {"p": 3});
-//      final combined = QueryPredicate.and([p1, p2, p3]);
-//      expect(combined.format, "(p=@p AND p=@p0 AND p=@p1)");
-//      expect(combined.parameters, {"p": 1, "p0": 2, "p1": 3});
-//    });
-//
-//    test("If empty list, return empty predicate", () {
-//      expect(QueryPredicate.and([]).format, "");
-//      expect(QueryPredicate.and([]).parameters, {});
-//    });
-//
-//    test("If null, return empty predicate", () {
-//      expect(QueryPredicate.and(null).format, "");
-//      expect(QueryPredicate.and(null).parameters, {});
-//    });
-//
-//    test("If only one element in list, return that element", () {
-//      final valid = QueryPredicate("x=@a", {"a": 0});
-//      final p = QueryPredicate.and([valid]);
-//      expect(p.format, valid.format);
-//      expect(p.parameters, valid.parameters);
-//    });
-//
-//    test("If and'ing empty predicate, ignore it", () {
-//      final valid = QueryPredicate("x=@a", {"a": 0});
-//      final p = QueryPredicate.and([valid, QueryPredicate.empty()]);
-//      expect(p.format, valid.format);
-//      expect(p.parameters, valid.parameters);
-//    });
-//
-//    test("If and'ing null predicate, ignore it", () {
-//      final valid = QueryPredicate("x=@a", {"a": 0});
-//      final p = QueryPredicate.and([valid, null]);
-//      expect(p.format, valid.format);
-//      expect(p.parameters, valid.parameters);
-//    });
-//
-//    test("And'ing predicate with no parameters", () {
-//      final valid = QueryPredicate("x=y", null);
-//      final p = QueryPredicate.and([valid]);
-//      expect(p.format, valid.format);
-//      expect(p.parameters, {});
-//    });
+    group("QueryPredicate.andGroup", () {
+      test("Simplest", () {
+        var p1 = QueryPredicate("p=q", null);
+        var p2 = QueryPredicate("a=b", null);
+        final combined = QueryPredicate.andGroup(p1, p2);
+        expect(combined.format, "p=q AND (a=b)");
+      });
+    });
   });
 }

--- a/aqueduct/test/db/predicate_test.dart
+++ b/aqueduct/test/db/predicate_test.dart
@@ -74,5 +74,60 @@ void main() {
       final combined = QueryPredicate.or([p1, p2, p3]);
       expect(combined.format, "(p=q OR a=b OR x=y)");
     });
+
+    test("Duplicate keys are replaced", () {
+      var p1 = QueryPredicate("p=@p", {"p": 1});
+      var p2 = QueryPredicate("p=@p", {"p": 2});
+      final combined = QueryPredicate.or([p1, p2]);
+      expect(combined.format, "(p=@p OR p=@p0)");
+      expect(combined.parameters, {"p": 1, "p0": 2});
+    });
+
+    test("Multiple duplicate keys are replaced", () {
+      var p1 = QueryPredicate("p=@p", {"p": 1});
+      var p2 = QueryPredicate("p=@p", {"p": 2});
+      var p3 = QueryPredicate("p=@p", {"p": 3});
+      final combined = QueryPredicate.or([p1, p2, p3]);
+      expect(combined.format, "(p=@p OR p=@p0 OR p=@p1)");
+      expect(combined.parameters, {"p": 1, "p0": 2, "p1": 3});
+    });
+
+    test("If empty list, return empty predicate", () {
+      expect(QueryPredicate.or([]).format, "");
+      expect(QueryPredicate.or([]).parameters, {});
+    });
+
+    test("If null, return empty predicate", () {
+      expect(QueryPredicate.or(null).format, "");
+      expect(QueryPredicate.or(null).parameters, {});
+    });
+
+    test("If only one element in list, return that element", () {
+      final valid = QueryPredicate("x=@a", {"a": 0});
+      final p = QueryPredicate.or([valid]);
+      expect(p.format, valid.format);
+      expect(p.parameters, valid.parameters);
+    });
+
+    test("If or'ing empty predicate, ignore it", () {
+      final valid = QueryPredicate("x=@a", {"a": 0});
+      final p = QueryPredicate.or([valid, QueryPredicate.empty()]);
+      expect(p.format, valid.format);
+      expect(p.parameters, valid.parameters);
+    });
+
+    test("If or'ing null predicate, ignore it", () {
+      final valid = QueryPredicate("x=@a", {"a": 0});
+      final p = QueryPredicate.or([valid, null]);
+      expect(p.format, valid.format);
+      expect(p.parameters, valid.parameters);
+    });
+
+    test("Or'ing predicate with no parameters", () {
+      final valid = QueryPredicate("x=y", null);
+      final p = QueryPredicate.or([valid]);
+      expect(p.format, valid.format);
+      expect(p.parameters, {});
+    });
   });
 }


### PR DESCRIPTION
Issue: #545 

Added the following methods to Query
* orWhere: 
    * will separate the expressions with an "OR" operator instead of "AND": a=a OR b=b
* orWhereGroup
    * will separate with an "OR" operator and group the contained expression with parens: a=a OR (b=b OR c=c)
* whereGroup (implicit AND)
    * will separate with an "AND" operator and group the contained expression with parens: a=a OR (b=b OR c=c)

Example of call site:
```
var r = Query<AnotherTestModel>(context)
        ..where((o) => o.email).equalTo("founder@company.com")
        ..orWhereGroup((query) => query
          ..where((o) => o.name).equalTo("Bob")
          ..where((o) => o.rank).greaterThan("9000"))
        ..sortBy((r) => r.name, QuerySortOrder.ascending);
```