### PR TITLE
Adds ability to remove multiple properties from backing map in a single call

### DIFF
--- a/aqueduct/lib/src/db/managed/object.dart
+++ b/aqueduct/lib/src/db/managed/object.dart
@@ -124,6 +124,12 @@ abstract class ManagedObject<T> extends Serializable {
     backing.removeProperty(propertyName);
   }
 
+  /// Removes multiple properties from [backing].
+  void removePropertiesFromBackingMap(List<String> propertyNames) {
+    propertyNames
+        .forEach((propertyName) => backing.removeProperty(propertyName));
+  }
+
   /// Checks whether or not a property has been set in this instances' [backing].
   bool hasValueForProperty(String propertyName) {
     return backing.contents.containsKey(propertyName);

--- a/aqueduct/test/db/model_test.dart
+++ b/aqueduct/test/db/model_test.dart
@@ -414,6 +414,71 @@ void main() {
     expect(m["bothOverQualified"], "foo");
   });
 
+  test("Can remove single property from backing map", () {
+    var m = (User()
+      ..id = 1
+      ..name = "Bob"
+      ..dateCreated = DateTime(2018,1,30))
+      ..removePropertyFromBackingMap("name")
+      ..asMap();
+
+    expect(m["id"], 1);
+    expect(m["name"], isNull);
+    expect(m["dateCreated"], DateTime(2018,1,30));
+  });
+
+  test("Removing single non-existent property from backing map has no effect", () {
+    var m = (User()
+      ..id = 1
+      ..name = "Bob"
+      ..dateCreated = DateTime(2018,1,30))
+      ..removePropertyFromBackingMap("dummy")
+      ..asMap();
+
+    expect(m["id"], 1);
+    expect(m["name"], "Bob");
+    expect(m["dateCreated"], DateTime(2018,1,30));
+  });
+
+  test("Can remove multiple properties from backing map", () {
+    var m = (User()
+      ..id = 1
+      ..name = "Bob"
+      ..dateCreated = DateTime(2018,1,30))
+      ..removePropertiesFromBackingMap(["name", "dateCreated"])
+      ..asMap();
+
+    expect(m["id"], 1);
+    expect(m["name"], isNull);
+    expect(m["dateCreated"], isNull);
+  });
+
+  test("Can remove single property from backing map with multi-property method", () {
+    var m = (User()
+      ..id = 1
+      ..name = "Bob"
+      ..dateCreated = DateTime(2018,1,30))
+      ..removePropertiesFromBackingMap(["name"])
+      ..asMap();
+
+    expect(m["id"], 1);
+    expect(m["name"], isNull);
+    expect(m["dateCreated"], DateTime(2018,1,30));
+  });
+
+  test("Removing multiple non-existent properties from backing map has no effect", () {
+    var m = (User()
+      ..id = 1
+      ..name = "Bob"
+      ..dateCreated = DateTime(2018,1,30))
+      ..removePropertiesFromBackingMap(["dummy1", "dummy2"])
+      ..asMap();
+
+    expect(m["id"], 1);
+    expect(m["name"], "Bob");
+    expect(m["dateCreated"], DateTime(2018,1,30));
+  });
+
   test("Transient Properties of all types can be read and returned", () {
     var dateString = "2016-10-31T15:40:45+00:00";
     var m = (TransientTypeTest()

--- a/aqueduct/test/db/model_test.dart
+++ b/aqueduct/test/db/model_test.dart
@@ -415,68 +415,73 @@ void main() {
   });
 
   test("Can remove single property from backing map", () {
-    var m = (User()
+    var u = (User()
       ..id = 1
       ..name = "Bob"
       ..dateCreated = DateTime(2018,1,30))
-      ..removePropertyFromBackingMap("name")
-      ..asMap();
+      ..removePropertyFromBackingMap("name");
 
-    expect(m["id"], 1);
-    expect(m["name"], isNull);
-    expect(m["dateCreated"], DateTime(2018,1,30));
+    var m = u.asMap();
+
+    expect(m.containsKey("id"), true);
+    expect(m.containsKey("name"), false);
+    expect(m.containsKey("dateCreated"), true);
   });
 
   test("Removing single non-existent property from backing map has no effect", () {
-    var m = (User()
+    var u = (User()
       ..id = 1
       ..name = "Bob"
       ..dateCreated = DateTime(2018,1,30))
-      ..removePropertyFromBackingMap("dummy")
-      ..asMap();
+      ..removePropertyFromBackingMap("dummy");
 
-    expect(m["id"], 1);
-    expect(m["name"], "Bob");
-    expect(m["dateCreated"], DateTime(2018,1,30));
+    var m = u.asMap();
+
+    expect(m.containsKey("id"), true);
+    expect(m.containsKey("name"), true);
+    expect(m.containsKey("dateCreated"), true);
   });
 
   test("Can remove multiple properties from backing map", () {
-    var m = (User()
+    var u = (User()
       ..id = 1
       ..name = "Bob"
       ..dateCreated = DateTime(2018,1,30))
-      ..removePropertiesFromBackingMap(["name", "dateCreated"])
-      ..asMap();
+      ..removePropertiesFromBackingMap(["name", "dateCreated"]);
 
-    expect(m["id"], 1);
-    expect(m["name"], isNull);
-    expect(m["dateCreated"], isNull);
+    var m = u.asMap();
+
+    expect(m.containsKey("id"), true);
+    expect(m.containsKey("name"), false);
+    expect(m.containsKey("dateCreated"), false);
   });
 
   test("Can remove single property from backing map with multi-property method", () {
-    var m = (User()
+    var u = (User()
       ..id = 1
       ..name = "Bob"
       ..dateCreated = DateTime(2018,1,30))
-      ..removePropertiesFromBackingMap(["name"])
-      ..asMap();
+      ..removePropertiesFromBackingMap(["name"]);
 
-    expect(m["id"], 1);
-    expect(m["name"], isNull);
-    expect(m["dateCreated"], DateTime(2018,1,30));
+    var m = u.asMap();
+
+    expect(m.containsKey("id"), true);
+    expect(m.containsKey("name"), false);
+    expect(m.containsKey("dateCreated"), true);
   });
 
   test("Removing multiple non-existent properties from backing map has no effect", () {
-    var m = (User()
+    var u = (User()
       ..id = 1
       ..name = "Bob"
       ..dateCreated = DateTime(2018,1,30))
-      ..removePropertiesFromBackingMap(["dummy1", "dummy2"])
-      ..asMap();
+      ..removePropertiesFromBackingMap(["dummy1", "dummy2"]);
 
-    expect(m["id"], 1);
-    expect(m["name"], "Bob");
-    expect(m["dateCreated"], DateTime(2018,1,30));
+    var m = u.asMap();
+
+    expect(m.containsKey("id"), true);
+    expect(m.containsKey("name"), true);
+    expect(m.containsKey("dateCreated"), true);
   });
 
   test("Transient Properties of all types can be read and returned", () {


### PR DESCRIPTION
Example:

`userProfile.removePropertiesFromBackingMap(["createdAt", "updatedAt"]);`