### PR TITLE
Get client_id and client_secret from form data

### DIFF
--- a/aqueduct/lib/src/auth/auth_controller.dart
+++ b/aqueduct/lib/src/auth/auth_controller.dart
@@ -64,12 +64,20 @@ class AuthController extends ResourceController {
       @Bind.query("refresh_token") String refreshToken,
       @Bind.query("code") String authCode,
       @Bind.query("grant_type") String grantType,
-      @Bind.query("scope") String scope}) async {
+      @Bind.query("scope") String scope,
+      @Bind.query("client_id") String clientId,
+      @Bind.query("client_secret") String clientSecret = ""}) async {
     AuthBasicCredentials basicRecord;
     try {
       basicRecord = _parser.parse(authHeader);
     } on AuthorizationParserException catch (_) {
-      return _responseForError(AuthRequestError.invalidClient);
+      if(clientId == null)
+        return _responseForError(AuthRequestError.invalidClient);
+      else {
+        basicRecord = AuthBasicCredentials()
+          ..username = clientId
+          ..password = clientSecret;
+      }
     }
 
     try {


### PR DESCRIPTION
If the client_id and client_secret is not send in auth header, try to get it from form data. Some tools and clients send it this way. Eg. SoapUI.

Signed-off-by: Martin Edlman <ac@an.y-co.de>