### PR TITLE
Escape special characters for LIKE expression for query expressions. …

### DIFF
--- a/aqueduct/CHANGELOG.md
+++ b/aqueduct/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Adds `read` method to `Serializable`.
 - Fixes issues with Dart 2.1.1 mirror type checking changes
+- Adds `like` matcher expression
+- Escapes postgres special characters in LIKE expressions for all other string matcher expressions
+- Fixes security vulnerability where a specific authorization header value would be associated with the wrong token (credit to Philipp Schiffmann)
 
 ## 3.1.0
 

--- a/aqueduct/lib/src/db/postgresql/builders/expression.dart
+++ b/aqueduct/lib/src/db/postgresql/builders/expression.dart
@@ -119,6 +119,6 @@ class ColumnExpressionBuilder extends ColumnBuilder {
   }
 
   String escapeLikeString(String input) {
-    return input.replaceAllMapped(RegExp("(\\\\|%|_)"), (Match m) => "\\${m[0]}");
+    return input.replaceAllMapped(RegExp(r"(\\|%|_)"), (Match m) => "\\${m[0]}");
   }
 }

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -116,6 +116,9 @@ class QueryExpression<T, InstanceType> {
   ///
   /// A query will only return objects where the selected property is like [value].
   ///
+  /// For more documentation on postgres pattern matching, see
+  /// https://www.postgresql.org/docs/10/functions-matching.html.
+  ///
   /// This method can be used on [String] types.
   ///
   /// The flag [caseSensitive] controls whether strings are compared case-sensitively.
@@ -136,6 +139,9 @@ class QueryExpression<T, InstanceType> {
   /// Adds a 'not like' expression to a query.
   ///
   /// A query will only return objects where the selected property is *not* like [value].
+  ///
+  /// For more documentation on postgres pattern matching, see
+  /// https://www.postgresql.org/docs/10/functions-matching.html.
   ///
   /// This method can be used on [String] types.
   ///

--- a/aqueduct/lib/src/db/query/matcher_expression.dart
+++ b/aqueduct/lib/src/db/query/matcher_expression.dart
@@ -79,7 +79,7 @@ class QueryExpression<T, InstanceType> {
       {bool caseSensitive = true}) {
     if (value is String) {
       expression = StringExpression(value, PredicateStringOperator.equals,
-          caseSensitive: caseSensitive);
+          caseSensitive: caseSensitive, allowSpecialCharacters: false);
     } else {
       expression = ComparisonExpression(value, PredicateOperator.equalTo);
     }
@@ -87,7 +87,7 @@ class QueryExpression<T, InstanceType> {
     return _createJunction();
   }
 
-  /// Adds an 'not equal' expression to a query.
+  /// Adds a 'not equal' expression to a query.
   ///
   /// A query will only return objects where the selected property is *not* equal to [value].
   ///
@@ -104,10 +104,52 @@ class QueryExpression<T, InstanceType> {
       {bool caseSensitive = true}) {
     if (value is String) {
       expression = StringExpression(value, PredicateStringOperator.equals,
-          caseSensitive: caseSensitive, invertOperator: true);
+          caseSensitive: caseSensitive, invertOperator: true, allowSpecialCharacters: false);
     } else {
       expression = ComparisonExpression(value, PredicateOperator.notEqual);
     }
+
+    return _createJunction();
+  }
+
+  /// Adds a like expression to a query.
+  ///
+  /// A query will only return objects where the selected property is like [value].
+  ///
+  /// This method can be used on [String] types.
+  ///
+  /// The flag [caseSensitive] controls whether strings are compared case-sensitively.
+  ///
+  /// Example:
+  ///
+  ///       final query = new Query<User>()
+  ///         ..where((u) => u.name ).like("bob");
+  ///
+  QueryExpressionJunction<T, InstanceType> like(String value,
+      {bool caseSensitive = true}) {
+    expression = StringExpression(value, PredicateStringOperator.equals,
+          caseSensitive: caseSensitive, allowSpecialCharacters: true);
+
+    return _createJunction();
+  }
+
+  /// Adds a 'not like' expression to a query.
+  ///
+  /// A query will only return objects where the selected property is *not* like [value].
+  ///
+  /// This method can be used on [String] types.
+  ///
+  /// The flag [caseSensitive] controls whether strings are compared case-sensitively.
+  ///
+  /// Example:
+  ///
+  ///       final query = new Query<Employee>()
+  ///         ..where((e) => e.id).notEqualTo(60000);
+  ///
+  QueryExpressionJunction<T, InstanceType> notLike(String value,
+      {bool caseSensitive = true}) {
+    expression = StringExpression(value, PredicateStringOperator.equals,
+          caseSensitive: caseSensitive, invertOperator: true, allowSpecialCharacters: true);
 
     return _createJunction();
   }
@@ -197,7 +239,7 @@ class QueryExpression<T, InstanceType> {
   QueryExpressionJunction<T, InstanceType> contains(String value,
       {bool caseSensitive = true}) {
     expression = StringExpression(value, PredicateStringOperator.contains,
-        caseSensitive: caseSensitive);
+        caseSensitive: caseSensitive, allowSpecialCharacters: false);
 
     return _createJunction();
   }
@@ -215,7 +257,7 @@ class QueryExpression<T, InstanceType> {
   QueryExpressionJunction<T, InstanceType> beginsWith(String value,
       {bool caseSensitive = true}) {
     expression = StringExpression(value, PredicateStringOperator.beginsWith,
-        caseSensitive: caseSensitive);
+        caseSensitive: caseSensitive, allowSpecialCharacters: false);
 
     return _createJunction();
   }
@@ -233,7 +275,7 @@ class QueryExpression<T, InstanceType> {
   QueryExpressionJunction<T, InstanceType> endsWith(String value,
       {bool caseSensitive = true}) {
     expression = StringExpression(value, PredicateStringOperator.endsWith,
-        caseSensitive: caseSensitive);
+        caseSensitive: caseSensitive, allowSpecialCharacters: false);
 
     return _createJunction();
   }

--- a/aqueduct/lib/src/db/query/matcher_internal.dart
+++ b/aqueduct/lib/src/db/query/matcher_internal.dart
@@ -84,16 +84,17 @@ class SetMembershipExpression implements PredicateExpression {
 
 class StringExpression implements PredicateExpression {
   const StringExpression(this.value, this.operator,
-      {this.caseSensitive = true, this.invertOperator = false});
+    {this.caseSensitive = true, this.invertOperator = false, this.allowSpecialCharacters = true});
 
   final PredicateStringOperator operator;
   final bool invertOperator;
   final bool caseSensitive;
+  final bool allowSpecialCharacters;
   final String value;
 
   @override
   PredicateExpression get inverse {
     return StringExpression(value, operator,
-        caseSensitive: caseSensitive, invertOperator: !invertOperator);
+      caseSensitive: caseSensitive, invertOperator: !invertOperator, allowSpecialCharacters: allowSpecialCharacters);
   }
 }

--- a/aqueduct/test/db/postgresql/matcher_test.dart
+++ b/aqueduct/test/db/postgresql/matcher_test.dart
@@ -67,9 +67,35 @@ void main() {
         ..where((o) => o.email).not.equalTo("0@A.com");
       results = await q.fetch();
       expect(results.length, 6);
+
+      q = Query<TestModel>(context)..where((o) => o.email).equalTo("%.com");
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.equalTo("%.com");
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)..where((o) => o.email).equalTo("\\%.com");
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)..where((o) => o.email).not.equalTo("\\%.com");
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)..where((o) => o.email).equalTo("_@a.com");
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.equalTo("_@a.com");
+      results = await q.fetch();
+      expect(results.length, 6);
     });
 
-    test("String value, case sensitive default", () async {
+    test("String value, case insensitive default", () async {
       var q = Query<TestModel>(context)
         ..where((o) => o.email).equalTo("0@A.com", caseSensitive: false);
       var results = await q.fetch();
@@ -81,6 +107,107 @@ void main() {
       results = await q.fetch();
       expect(results.length, 5);
       expect(results.any((tm) => tm.email == "0@a.com"), false);
+
+      q = Query<TestModel>(context)..where((o) => o.email).equalTo("%.COM");
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.equalTo("%.COM");
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)..where((o) => o.email).equalTo("\\%.COM");
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)..where((o) => o.email).not.equalTo("\\%.COM");
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)..where((o) => o.email).equalTo("_@a.COM");
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.equalTo("_@a.COM");
+      results = await q.fetch();
+      expect(results.length, 6);
+    });
+  });
+
+    group("Like matcher", () {
+    test("case sensitive default", () async {
+      var q = Query<TestModel>(context)
+        ..where((o) => o.email).like("0@a%");
+      var results = await q.fetch();
+      expect(results.length, 1);
+      expect(results.first.id, 1);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.like("0@a%");
+      results = await q.fetch();
+      expect(results.length, 5);
+      expect(results.any((tm) => tm.id == 1), false);
+
+      q = Query<TestModel>(context)..where((o) => o.email).like("0@A%");
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.like("0@A%");
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)..where((o) => o.email).like("%.com");
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.like("%.com");
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)..where((o) => o.email).like("_@a.com");
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.like("_@a.com");
+      results = await q.fetch();
+      expect(results.length, 0);
+    });
+
+    test("case insensitive default", () async {
+      var q = Query<TestModel>(context)
+        ..where((o) => o.email).like("0@A%", caseSensitive: false);
+      var results = await q.fetch();
+      expect(results.length, 1);
+      expect(results.first.id, 1);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.like("0@A%", caseSensitive: false);
+      results = await q.fetch();
+      expect(results.length, 5);
+      expect(results.any((tm) => tm.email == "0@a.com"), false);
+
+      q = Query<TestModel>(context)..where((o) => o.email).like("%.COM", caseSensitive: false);
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.like("%.COM", caseSensitive: false);
+      results = await q.fetch();
+      expect(results.length, 0);
+
+      q = Query<TestModel>(context)..where((o) => o.email).like("_@a.COM", caseSensitive: false);
+      results = await q.fetch();
+      expect(results.length, 6);
+
+      q = Query<TestModel>(context)
+        ..where((o) => o.email).not.like("_@a.COM", caseSensitive: false);
+      results = await q.fetch();
+      expect(results.length, 0);
     });
   });
 

--- a/aqueduct/test/db/query_test.dart
+++ b/aqueduct/test/db/query_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   test(
-      "If context does not contian data model with query type, throw exception",
+      "If context does not contain data model with query type, throw exception",
       () {
     try {
       Query<Missing>(ctx);

--- a/aqueduct/test/managed_auth/managed_auth_storage_test.dart
+++ b/aqueduct/test/managed_auth/managed_auth_storage_test.dart
@@ -261,6 +261,15 @@ void main() {
       } on AuthServerException {}
     });
 
+    test("Create token fails with wildcard password", () async {
+      try {
+        await auth.authenticate(createdUser.username, "%",
+            "com.stablekernel.app1", "kilimanjaro");
+        expect(true, false);
+        // ignore: empty_catches
+      } on AuthServerException {}
+    });
+
     test("Create token fails if client ID doesn't exist", () async {
       try {
         await auth.authenticate(createdUser.username, User.defaultPassword,
@@ -274,6 +283,15 @@ void main() {
       try {
         await auth.authenticate(createdUser.username, User.defaultPassword,
             "com.stablekernel.app1", "nonsense");
+        expect(true, false);
+        // ignore: empty_catches
+      } on AuthServerException {}
+    });
+
+    test("Create token fails with wildcard client secret", () async {
+      try {
+        await auth.authenticate(createdUser.username, User.defaultPassword,
+            "com.stablekernel.app1", "%");
         expect(true, false);
         // ignore: empty_catches
       } on AuthServerException {}
@@ -316,6 +334,18 @@ void main() {
     test("Cannot verify token that doesn't exist", () async {
       try {
         await auth.verify("nonsense");
+        fail("unreachable");
+      } on AuthServerException catch (e) {
+        expect(e.reason, AuthRequestError.invalidGrant);
+      }
+    });
+
+    test("Cannot verify wildcard token", () async {
+      await auth.authenticate(createdUser.username,
+        User.defaultPassword, "com.stablekernel.app1", "kilimanjaro");
+
+      try {
+        await auth.verify("%");
         fail("unreachable");
       } on AuthServerException catch (e) {
         expect(e.reason, AuthRequestError.invalidGrant);
@@ -434,6 +464,14 @@ void main() {
       } on AuthServerException {}
     });
 
+    test("Cannot refresh wildcard token", () async {
+      try {
+        await auth.refresh("%", "com.stablekernel.app1", "kilimanjaro");
+        expect(true, false);
+        // ignore: empty_catches
+      } on AuthServerException {}
+    });
+
     test("Cannot refresh token if client id is missing", () async {
       try {
         await auth.refresh(initialToken.refreshToken, null, "kilimanjaro");
@@ -543,6 +581,17 @@ void main() {
       }
     });
 
+    test("Generate auth code with wildcard password fails", () async {
+      try {
+        await auth.authenticateForCode(
+            createdUser.username, "%", "com.stablekernel.redirect");
+        expect(true, false);
+      } on AuthServerException catch (e) {
+        expect(e.client.id, "com.stablekernel.redirect");
+        expect(e.reason, AuthRequestError.accessDenied);
+      }
+    });
+
     test("Generate auth code with unknown client id fails", () async {
       try {
         await auth.authenticateForCode(
@@ -623,6 +672,15 @@ void main() {
     test("Null code fails", () async {
       try {
         await auth.exchange(null, "com.stablekernel.redirect", "mckinley");
+
+        expect(true, false);
+        // ignore: empty_catches
+      } on AuthServerException {}
+    });
+
+    test("Wildcard code fails", () async {
+      try {
+        await auth.exchange("%", "com.stablekernel.redirect", "mckinley");
 
         expect(true, false);
         // ignore: empty_catches


### PR DESCRIPTION
…Add like query expression that does not escape special characters. Fixes #630 