### PR TITLE
Check for primary key earlier in entity building process

### DIFF
--- a/aqueduct/lib/src/db/managed/builders/entity_builder.dart
+++ b/aqueduct/lib/src/db/managed/builders/entity_builder.dart
@@ -21,6 +21,9 @@ class EntityBuilder {
     properties = _getProperties();
     primaryKeyProperty = properties
         .firstWhere((p) => p.column?.isPrimaryKey ?? false, orElse: () => null);
+    if (primaryKeyProperty == null) {
+      throw ManagedDataModelError.noPrimaryKey(entity);
+    }
   }
 
   final ClassMirror instanceType;


### PR DESCRIPTION
This avoids a scenario where some errors can be thrown without good info