### PR TITLE
Adds Validate.constant  to properties that use the @primaryKey  annotation.

### DIFF
--- a/aqueduct/CHANGELOG.md
+++ b/aqueduct/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Fixes issues with Dart 2.1.1 mirror type checking changes
 - Adds `like` matcher expression
 - Escapes postgres special characters in LIKE expressions for all other string matcher expressions
-- Fixes security vulnerability where a specific authorization header value would be associated with the wrong token (credit to Philipp Schiffmann)
+- Fixes security vulnerability where a specific authorization header value would be associated with the wrong token when there is only one token stored in the database (credit to Philipp Schiffmann)
+- Adds `Validate.constant` to properties that use the `@primaryKey` annotation.
 
 ## 3.1.0
 

--- a/aqueduct/lib/src/db/managed/attributes.dart
+++ b/aqueduct/lib/src/db/managed/attributes.dart
@@ -104,6 +104,8 @@ class Relate {
 ///
 /// This is a convenience for primary key, database type big integer, and autoincrementing. The corresponding property
 /// type must be [int]. The underlying database indexes and uniques the backing column.
+///
+/// The validator [Validate.constant] is automatically applied to this property.
 const Column primaryKey = Column(
     primaryKey: true,
     databaseType: ManagedPropertyType.bigInteger,

--- a/aqueduct/lib/src/db/managed/builders/property_builder.dart
+++ b/aqueduct/lib/src/db/managed/builders/property_builder.dart
@@ -1,17 +1,12 @@
 import 'dart:mirrors';
 
-import 'package:aqueduct/src/db/managed/attributes.dart';
+import 'package:aqueduct/src/db/managed/attributes.dart' as managed_attributes;
 import 'package:aqueduct/src/db/managed/builders/entity_builder.dart';
 import 'package:aqueduct/src/db/managed/builders/validator_builder.dart';
 import 'package:aqueduct/src/db/managed/entity_mirrors.dart';
 import 'package:aqueduct/src/db/managed/managed.dart';
 import 'package:aqueduct/src/db/managed/relationship_type.dart';
 import 'package:aqueduct/src/utilities/mirror_helpers.dart';
-
-/*
-Move all validation steps into validate.
-Fix issue when compiling relationships, esp. deferred.
- */
 
 class PropertyBuilder {
   PropertyBuilder(this.parent, this.declaration)
@@ -21,8 +16,13 @@ class PropertyBuilder {
     name = _getName();
     type = _getType();
     _validators = validatorsFromDeclaration(declaration).map((v) => ValidatorBuilder(this, v)).toList();
+
     if (type?.isEnumerated ?? false) {
       _validators.add(ValidatorBuilder(this, Validate.oneOf(type.enumerationMap.values.toList())));
+    }
+
+    if (identical(managed_attributes.primaryKey, column)) {
+      _validators.add(ValidatorBuilder(this, const Validate.constant()));
     }
   }
 

--- a/aqueduct/test/db/validate_value_test.dart
+++ b/aqueduct/test/db/validate_value_test.dart
@@ -17,12 +17,27 @@ void main() {
         PresenceHas,
         PresenceBelongsTo,
         AbsenceBelongsTo,
-        AbsenceHas
+        AbsenceHas,
+        NonDefaultPK
       ]),
       DefaultPersistentStore());
 
   tearDownAll(() async {
     await ctx.close();
+  });
+
+  group("Primary key defaults", () {
+    test("@primaryKey defaults to using Validate.constant()", () {
+      final t = T()..id = 1;
+      expect(t.validate(forEvent: Validating.insert).isValid, true);
+      expect(t.validate(forEvent: Validating.update).isValid, false);
+    });
+
+    test("A primary key that isn't @primaryKey does not have Validate.constant()", () {
+      final t = NonDefaultPK()..id = 1;
+      expect(t.validate(forEvent: Validating.insert).isValid, true);
+      expect(t.validate(forEvent: Validating.update).isValid, true);
+    });
   });
 
   group("Foreign keys", () {
@@ -731,4 +746,13 @@ class _AbsenceBelongsTo {
   @Validate.absent(onInsert: true)
   @Relate(#absent)
   AbsenceHas absent;
+}
+
+
+class NonDefaultPK extends ManagedObject<_NonDefaultPK> implements _NonDefaultPK {}
+class _NonDefaultPK {
+  @Column(primaryKey: true)
+  int id;
+
+  String name;
 }


### PR DESCRIPTION
This prevents the a primary key from being overwritten if it is not stripped it from the payload