### PR TITLE
Add a 204 No Content convenience constructor to Response

### DIFF
--- a/aqueduct/lib/src/http/response.dart
+++ b/aqueduct/lib/src/http/response.dart
@@ -38,6 +38,10 @@ class Response implements RequestOrResponse {
   Response.accepted({Map<String, dynamic> headers})
       : this(HttpStatus.accepted, headers, null);
 
+  /// Represents a 204 response.
+  Response.noContent({Map<String, dynamic> headers})
+      : this(HttpStatus.noContent, headers, null);
+
   /// Represents a 304 response.
   ///
   /// Where [lastModified] is the last modified date of the resource


### PR DESCRIPTION
I was working with these `Response` objects and noticed there was no named constructor for a 204 No Content response, so I added one.

I know a lot of API design patterns use 204 for deletes, and figured adding this as a convenience constructor will we helpful for people who want to use 204, and want to maintain a consistent feel to their code.

I checked the `response_test.dart` file to see if I should add any tests for this, but it seems like a lot of the other constructors aren't tested, so I decided against adding one. 