### PR TITLE
Allows different authentication processes by scope

### DIFF
--- a/aqueduct/lib/managed_auth.dart
+++ b/aqueduct/lib/managed_auth.dart
@@ -332,7 +332,7 @@ class ManagedAuthDelegate<T extends ManagedAuthResourceOwner>
   }
 
   @override
-  Future<T> getResourceOwner(AuthServer server, String username) {
+  Future<T> getResourceOwner(AuthServer server, String username, [List<AuthScope> requestedScopes]) {
     final query = Query<T>(context)
       ..where((o) => o.username).equalTo(username)
       ..returningProperties(

--- a/aqueduct/lib/src/auth/authorization_server.dart
+++ b/aqueduct/lib/src/auth/authorization_server.dart
@@ -188,7 +188,7 @@ class AuthServer implements AuthValidator, APIComponentDocumenter {
       }
     }
 
-    final authenticatable = await delegate.getResourceOwner(this, username);
+    final authenticatable = await delegate.getResourceOwner(this, username, requestedScopes);
     if (authenticatable == null) {
       throw AuthServerException(AuthRequestError.invalidGrant, client);
     }
@@ -340,7 +340,7 @@ class AuthServer implements AuthValidator, APIComponentDocumenter {
       throw AuthServerException(AuthRequestError.unauthorizedClient, client);
     }
 
-    final authenticatable = await delegate.getResourceOwner(this, username);
+    final authenticatable = await delegate.getResourceOwner(this, username, requestedScopes);
     if (authenticatable == null) {
       throw AuthServerException(AuthRequestError.accessDenied, client);
     }

--- a/aqueduct/lib/src/auth/protocols.dart
+++ b/aqueduct/lib/src/auth/protocols.dart
@@ -41,7 +41,7 @@ abstract class AuthServerDelegate {
   /// Every property declared by [ResourceOwner] must be non-null in the return value.
   ///
   /// [server] is the [AuthServer] invoking this method.
-  FutureOr<ResourceOwner> getResourceOwner(AuthServer server, String username);
+  FutureOr<ResourceOwner> getResourceOwner(AuthServer server, String username, [List<AuthScope> requestedScopes]);
 
   /// Must store [client].
   ///


### PR DESCRIPTION
This little change will allow different authentication processes per scope.

You can override authentication process and create another one based on scope extending class AuthServerDelegate and overriding getResourceOwner method.