### PR TITLE
Fix ManagedAuthDelegate.getAllowedScopes() check in AuthServer

### DIFF
--- a/aqueduct/CHANGELOG.md
+++ b/aqueduct/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.2-dev
+
+- [#723](https://github.com/stablekernel/aqueduct/pull/723) Fixes issue that prevented the `AuthServer` from granting tokens with sub-scopes when the servers `AuthServerDelegate.getAllowedScopes()` didn't return `AuthScope.any`.
+- Deprecates `AuthScope.allowsScope()`, use `AuthScope.isSubsetOrEqualTo()` instead.
+
 ## 3.2.1
 
 - Fixes issue when using `QueryReduce` inside a transaction.

--- a/aqueduct/lib/src/auth/authorization_server.dart
+++ b/aqueduct/lib/src/auth/authorization_server.dart
@@ -535,10 +535,9 @@ class AuthServer implements AuthValidator, APIComponentDocumenter {
       final validScopesForAuthenticatable =
           delegate.getAllowedScopes(authenticatable);
       if (!identical(validScopesForAuthenticatable, AuthScope.any)) {
-        validScopes = validScopes
-            .where((clientAllowedScope) => validScopesForAuthenticatable
-                .any((userScope) => userScope.allowsScope(clientAllowedScope)))
-            .toList();
+        validScopes.retainWhere((clientAllowedScope) =>
+            validScopesForAuthenticatable
+                .any((userScope) => clientAllowedScope.allowsScope(userScope)));
 
         if (validScopes.isEmpty) {
           throw AuthServerException(AuthRequestError.invalidScope, client);

--- a/aqueduct/lib/src/auth/authorization_server.dart
+++ b/aqueduct/lib/src/auth/authorization_server.dart
@@ -536,8 +536,8 @@ class AuthServer implements AuthValidator, APIComponentDocumenter {
           delegate.getAllowedScopes(authenticatable);
       if (!identical(validScopesForAuthenticatable, AuthScope.any)) {
         validScopes.retainWhere((clientAllowedScope) =>
-            validScopesForAuthenticatable
-                .any((userScope) => clientAllowedScope.allowsScope(userScope)));
+            validScopesForAuthenticatable.any((userScope) =>
+                clientAllowedScope.isSubsetOrEqualTo(userScope)));
 
         if (validScopes.isEmpty) {
           throw AuthServerException(AuthRequestError.invalidScope, client);

--- a/aqueduct/test/auth/authenticate_test.dart
+++ b/aqueduct/test/auth/authenticate_test.dart
@@ -210,6 +210,17 @@ void main() {
       expect(await auth.verify(token.accessToken) is Authorization, true);
     });
 
+    test("Can create with sub-scope of client scope", () async {
+      delegate.allowedScopes = [AuthScope("user")];
+      var token = await auth.authenticate(
+          createdUser.username,
+          InMemoryAuthStorage.defaultPassword,
+          "com.stablekernel.public.scoped",
+          null,
+          requestedScopes: [AuthScope("user.self")]);
+      expect(token.scopes, [AuthScope("user.self")]);
+    });
+
     test("Cannot verify token that doesn't exist", () async {
       try {
         await auth.verify("nonsense");

--- a/aqueduct/test/auth/authenticate_test.dart
+++ b/aqueduct/test/auth/authenticate_test.dart
@@ -210,7 +210,20 @@ void main() {
       expect(await auth.verify(token.accessToken) is Authorization, true);
     });
 
-    test("Can create with sub-scope of client scope", () async {
+    test("Can't create token without scope if client has scope", () async {
+      try {
+        await auth.authenticate(
+            createdUser.username,
+            InMemoryAuthStorage.defaultPassword,
+            "com.stablekernel.public.scoped",
+            null);
+        fail("Should throw AuthServerException");
+      } on AuthServerException catch (e) {
+        expect(e.reason, AuthRequestError.invalidScope);
+      }
+    });
+
+    test("Can create token with sub-scope of client scope", () async {
       delegate.allowedScopes = [AuthScope("user")];
       var token = await auth.authenticate(
           createdUser.username,
@@ -219,6 +232,37 @@ void main() {
           null,
           requestedScopes: [AuthScope("user.self")]);
       expect(token.scopes, [AuthScope("user.self")]);
+    });
+
+    test("Don't grant requested scope if it exceeds client scope", () async {
+      try {
+        await auth.authenticate(
+            createdUser.username,
+            InMemoryAuthStorage.defaultPassword,
+            "com.stablekernel.public.scoped",
+            null,
+            requestedScopes: [AuthScope("admin")]);
+        fail("Should throw AuthServerException");
+      } on AuthServerException catch (e) {
+        expect(e.reason, AuthRequestError.invalidScope);
+      }
+    });
+
+    test(
+        "Don't grant requested scope if it exceeds allowed scope of ResourceOwner",
+        () async {
+      delegate.allowedScopes = [AuthScope("user.self")];
+      try {
+        await auth.authenticate(
+            createdUser.username,
+            InMemoryAuthStorage.defaultPassword,
+            "com.stablekernel.public.scoped",
+            null,
+            requestedScopes: [AuthScope("user")]);
+        fail("Should throw AuthServerException");
+      } on AuthServerException catch (e) {
+        expect(e.reason, AuthRequestError.invalidScope);
+      }
     });
 
     test("Cannot verify token that doesn't exist", () async {

--- a/aqueduct/test/helpers.dart
+++ b/aqueduct/test/helpers.dart
@@ -116,6 +116,7 @@ class InMemoryAuthStorage extends AuthServerDelegate {
   Map<String, AuthClient> clients;
   Map<int, TestUser> users = {};
   List<TestToken> tokens = [];
+  List<AuthScope> allowedScopes;
 
   void createUsers(int count) {
     for (int i = 0; i < count; i++) {
@@ -170,6 +171,7 @@ class InMemoryAuthStorage extends AuthServerDelegate {
     };
     users = {};
     tokens = [];
+    allowedScopes = AuthScope.any;
   }
 
   @override
@@ -280,6 +282,9 @@ class InMemoryAuthStorage extends AuthServerDelegate {
 
   @override
   FutureOr removeClient(AuthServer server, String id) => clients.remove(id);
+
+  @override
+  List<AuthScope> getAllowedScopes(ResourceOwner owner) => allowedScopes;
 }
 
 class DefaultPersistentStore extends PersistentStore {


### PR DESCRIPTION
Hey!

I found a bug where I couldn't create an OAuth token with less scope than that of the client I created it with. For example, if I have a client with scope `user`, I couldn't create a token with scope `user.self`.

The bug was caused by a switched up caller/callee: To check whether the client allowed scope is also allowed for this user, the call must be `clientAllowedScope.allowsScope(userScope)`, not `userScope.allowsScope(clientAllowedScope)`. IMHO, the name is really confusing and should be deprecated in favor of `isSubsetOrEqualTo`.