### PR TITLE
Remove deprecated --no-packages-dir flag from cli create

### DIFF
--- a/aqueduct/lib/src/cli/commands/create.dart
+++ b/aqueduct/lib/src/cli/commands/create.dart
@@ -69,7 +69,7 @@ class CLITemplateCreator extends CLICommand with CLIAqueductGlobal {
     }
 
     displayInfo(
-        "Fetching project dependencies (pub get --no-packages-dir ${offline ? "--offline" : ""})...");
+        "Fetching project dependencies (pub get ${offline ? "--offline" : ""})...");
     displayInfo("Please wait...");
     try {
       await fetchProjectDependencies(destDirectory, offline: offline);
@@ -236,7 +236,7 @@ class CLITemplateCreator extends CLICommand with CLIAqueductGlobal {
 
   Future<int> fetchProjectDependencies(Directory workingDirectory,
       {bool offline = false}) async {
-    var args = ["get", "--no-packages-dir"];
+    var args = ["get"];
     if (offline) {
       args.add("--offline");
     }


### PR DESCRIPTION
Fixes #729 

Just removed a flag that was deprecated back in August 2018 that's used in the cli for creating new projects.