### PR TITLE
Add accept filter for serializable read

### DIFF
--- a/aqueduct/lib/src/http/resource_controller_bindings.dart
+++ b/aqueduct/lib/src/http/resource_controller_bindings.dart
@@ -115,6 +115,7 @@ class Bind {
   /// If the bound parameter is a property with [requiredBinding], it is required for all methods in an [ResourceController].
   const Bind.query(this.name)
       : bindingType = BindingType.query,
+        accept = null,
         require = null,
         ignore = null,
         reject = null;
@@ -142,6 +143,7 @@ class Bind {
   /// If the bound parameter is a property with [requiredBinding], it is required for all methods in an [ResourceController].
   const Bind.header(this.name)
       : bindingType = BindingType.header,
+        accept = null,
         require = null,
         ignore = null,
         reject = null;
@@ -174,7 +176,7 @@ class Bind {
   /// No operation method will be called in this case.
   ///
   /// If not required and not present in a request, the bound arguments and properties will be null when the operation method is invoked.
-  const Bind.body({this.ignore, this.reject, this.require})
+  const Bind.body({this.accept, this.ignore, this.reject, this.require})
       : name = null,
         bindingType = BindingType.body;
 
@@ -199,6 +201,7 @@ class Bind {
   /// the [Bind.path] argument. If no path variables are present, `getUsers` is invoked.
   const Bind.path(this.name)
       : bindingType = BindingType.path,
+        accept = null,
         require = null,
         ignore = null,
         reject = null;
@@ -206,6 +209,7 @@ class Bind {
   final String name;
   final BindingType bindingType;
 
+  final List<String> accept;
   final List<String> ignore;
   final List<String> reject;
   final List<String> require;

--- a/aqueduct/lib/src/http/serializable.dart
+++ b/aqueduct/lib/src/http/serializable.dart
@@ -30,9 +30,10 @@ abstract class Serializable {
   /// The key name must exactly match the name of the property as defined in the receiver's type.
   /// If [object] contains a key that is unknown to the receiver, an exception is thrown (status code: 400).
   ///
-  /// [ignore], [reject] and [require] are filters on [object]'s keys with the following behaviors:
+  /// [accept], [ignore], [reject] and [require] are filters on [object]'s keys with the following behaviors:
   ///
-  /// If [ignore] is set, each value for that key is ignored and their value is discarded.
+  /// If [accept] is set, all values for the keys that are not given are ignored and discarded.
+  /// If [ignore] is set, all values for the given keys are ignored and discarded.
   /// If [reject] is set, if [object] contains any of these keys, a status code 400 exception is thrown.
   /// If [require] is set, all keys must be present in [object].
   ///
@@ -41,10 +42,11 @@ abstract class Serializable {
   ///     var user = User()
   ///       ..read(values, ignore: ["id"]);
   void read(Map<String, dynamic> object,
-      {Iterable<String> ignore,
+      {Iterable<String> accept,
+      Iterable<String> ignore,
       Iterable<String> reject,
       Iterable<String> require}) {
-    if (ignore == null && reject == null && require == null) {
+    if (accept == null && ignore == null && reject == null && require == null) {
       readFromMap(object);
       return;
     }
@@ -55,10 +57,10 @@ abstract class Serializable {
       if (reject?.contains(key) ?? false) {
         throw SerializableException(["invalid input key '$key'"]);
       }
-      if (ignore?.contains(key) ?? false) {
+      if ((ignore?.contains(key) ?? false) ||
+          !(accept?.contains(key) ?? true)) {
         copy.remove(key);
       }
-
       stillRequired?.remove(key);
     });
 

--- a/aqueduct/lib/src/runtime/resource_controller/bindings.dart
+++ b/aqueduct/lib/src/runtime/resource_controller/bindings.dart
@@ -168,12 +168,17 @@ class BoundQueryParameter extends BoundInput {
 
 class BoundBody extends BoundInput implements APIComponentDocumenter {
   BoundBody(ClassMirror typeMirror,
-      {List<String> ignore, List<String> error, List<String> required})
-      : ignoreFilter = ignore,
+      {List<String> accept,
+      List<String> ignore,
+      List<String> error,
+      List<String> required})
+      : acceptFilter = accept,
+        ignoreFilter = ignore,
         errorFilter = error,
         requiredFilter = required,
         super(typeMirror, null);
 
+  final List<String> acceptFilter;
   final List<String> ignoreFilter;
   final List<String> errorFilter;
   final List<String> requiredFilter;
@@ -193,7 +198,10 @@ class BoundBody extends BoundInput implements APIComponentDocumenter {
 
   @override
   void validate() {
-    if (ignoreFilter != null || errorFilter != null || requiredFilter != null) {
+    if (acceptFilter != null ||
+        ignoreFilter != null ||
+        errorFilter != null ||
+        requiredFilter != null) {
       if (!(_isBoundToSerializable || _isBoundToListOfSerializable)) {
         throw 'Filters can only be used on Serializable or List<Serializable>.';
       }
@@ -210,7 +218,10 @@ class BoundBody extends BoundInput implements APIComponentDocumenter {
       final value =
           boundType.newInstance(const Symbol(""), []).reflectee as Serializable;
       value.read(request.body.as(),
-          ignore: ignoreFilter, reject: errorFilter, require: requiredFilter);
+          accept: acceptFilter,
+          ignore: ignoreFilter,
+          reject: errorFilter,
+          require: requiredFilter);
 
       return value;
     } else if (_isBoundToListOfSerializable) {
@@ -224,7 +235,10 @@ class BoundBody extends BoundInput implements APIComponentDocumenter {
         final value =
             typeArg.newInstance(const Symbol(""), []).reflectee as Serializable;
         value.read(object,
-            ignore: ignoreFilter, reject: errorFilter, require: requiredFilter);
+            accept: acceptFilter,
+            ignore: ignoreFilter,
+            reject: errorFilter,
+            require: requiredFilter);
 
         return value;
       }).toList();

--- a/aqueduct/lib/src/runtime/resource_controller/parameter.dart
+++ b/aqueduct/lib/src/runtime/resource_controller/parameter.dart
@@ -46,11 +46,15 @@ class BoundParameter {
       case BindingType.header:
         return BoundHeader(typeMirror, metadata.name);
       case BindingType.body:
-        return BoundBody(typeMirror, ignore: metadata.ignore, error: metadata.reject, required: metadata.require);
+        return BoundBody(typeMirror,
+            accept: metadata.accept,
+            ignore: metadata.ignore,
+            error: metadata.reject,
+            required: metadata.require);
       case BindingType.path:
         return BoundPath(typeMirror, metadata.name);
     }
     throw StateError(
-      "Invalid controller. Operation parameter binding '${metadata.bindingType}' on '${metadata.name}' is unknown.");
+        "Invalid controller. Operation parameter binding '${metadata.bindingType}' on '${metadata.name}' is unknown.");
   }
 }

--- a/aqueduct/test/http/resource_controller_body_binding_test.dart
+++ b/aqueduct/test/http/resource_controller_body_binding_test.dart
@@ -86,6 +86,14 @@ void main() {
       expect((await postJSON({"key": ""})).statusCode, 400);
     });
 
+    test("Can use accept filters", () async {
+      server = await enableController("/", FilterController);
+      final response =
+          await postJSON({"required": "", "accept": "", "noAccept": ""});
+
+      expect(json.decode(response.body), {"required": "", "accept": ""});
+    });
+
     test("Can use ignore filters on List<Serializable>", () async {
       server = await enableController("/", () => FilterListController());
       final response = await postJSON([
@@ -121,6 +129,19 @@ void main() {
           400);
     });
 
+    test("Can use accept filters on List<Serializable>", () async {
+      server = await enableController("/", FilterListController);
+      final response = await postJSON([
+        {"required": "", "accept": ""},
+        {"required": "", "noAccept": ""}
+      ]);
+
+      expect(json.decode(response.body), [
+        {"required": "", "accept": ""},
+        {"required": ""}
+      ]);
+    });
+
     test("Can bind primitive map", () async {
       server = await enableController("/", () => MapController());
       var m = {"name": "Bob"};
@@ -129,15 +150,12 @@ void main() {
       expect(json.decode(response.body), m);
     });
 
-
     test("Can get a list of bytes from an octet-stream", () async {
       server = await enableController("/", () => ByteListController());
 
-      final response = await http
-        .post("http://localhost:4040",
-        headers: {"Content-Type": "application/octet-stream"},
-        body: [1, 2, 3])
-        .catchError((err) => null);
+      final response = await http.post("http://localhost:4040",
+          headers: {"Content-Type": "application/octet-stream"},
+          body: [1, 2, 3]).catchError((err) => null);
 
       expect(response.statusCode, 200);
       expect(response.bodyBytes, [1, 2, 3]);
@@ -313,7 +331,18 @@ class CrashController extends ResourceController {
 class FilterController extends ResourceController {
   @Operation.post()
   Future<Response> create(
-      @Bind.body(ignore: ["ignore"], require: ["required"], reject: ["error"])
+      @Bind.body(accept: [
+    "accept",
+    "ignore",
+    "required",
+    "error"
+  ], ignore: [
+    "ignore"
+  ], require: [
+    "required"
+  ], reject: [
+    "error"
+  ])
           TestSerializable tm) async {
     return Response.ok(tm);
   }
@@ -322,7 +351,18 @@ class FilterController extends ResourceController {
 class FilterListController extends ResourceController {
   @Operation.post()
   Future<Response> create(
-      @Bind.body(ignore: ["ignore"], require: ["required"], reject: ["error"])
+      @Bind.body(accept: [
+    "accept",
+    "ignore",
+    "required",
+    "error"
+  ], ignore: [
+    "ignore"
+  ], require: [
+    "required"
+  ], reject: [
+    "error"
+  ])
           List<TestSerializable> tm) async {
     return Response.ok(tm);
   }
@@ -342,7 +382,8 @@ class ByteListController extends ResourceController {
 
   @Operation.post()
   Future<Response> create(@Bind.body() List<int> tm) async {
-    return Response.ok(tm)..contentType = ContentType("application", "octet-stream");
+    return Response.ok(tm)
+      ..contentType = ContentType("application", "octet-stream");
   }
 }
 

--- a/aqueduct/test/http/resource_controller_body_binding_test.dart
+++ b/aqueduct/test/http/resource_controller_body_binding_test.dart
@@ -87,7 +87,7 @@ void main() {
     });
 
     test("Can use accept filters", () async {
-      server = await enableController("/", FilterController);
+      server = await enableController("/", () => FilterController());
       final response =
           await postJSON({"required": "", "accept": "", "noAccept": ""});
 
@@ -130,7 +130,7 @@ void main() {
     });
 
     test("Can use accept filters on List<Serializable>", () async {
-      server = await enableController("/", FilterListController);
+      server = await enableController("/", () => FilterListController());
       final response = await postJSON([
         {"required": "", "accept": ""},
         {"required": "", "noAccept": ""}
@@ -387,7 +387,8 @@ class ByteListController extends ResourceController {
   }
 }
 
-Future<HttpServer> enableController(String pattern, Controller instantiate()) async {
+Future<HttpServer> enableController(
+    String pattern, Controller instantiate()) async {
   var router = Router();
   router.route(pattern).link(instantiate);
   router.didAddToChannel();

--- a/aqueduct/test/http/serializable_test.dart
+++ b/aqueduct/test/http/serializable_test.dart
@@ -90,7 +90,30 @@ void main() {
       expect(object.contents, {"key": "", "next": ""});
     });
   });
-  
+
+  group("accept", () {
+    test("empty", () {
+      object.read({}, accept: []);
+      expect(object.contents, {});
+    });
+
+    test("input violation", () {
+      object.read({"notKey": ""}, accept: ["key"]);
+      expect(object.contents, {});
+
+      object.read({"1": "", "2": "", "3": ""}, accept: ["1", "2"]);
+      expect(object.contents, {"1": "", "2": ""});
+    });
+
+    test("valid input", () {
+      object.read({"1": "", "2": ""}, accept: ["1", "2"]);
+      expect(object.contents, {"1": "", "2": ""});
+
+      object.read({"1": "", "2": ""}, accept: ["1", "2", "3"]);
+      expect(object.contents, {"1": "", "2": ""});
+    });
+  });
+
   test("ignore + error conflict is resolved to error", () {
     try {
       object.read({"key": ""}, ignore: ["key"], reject: ["key"]);
@@ -99,20 +122,35 @@ void main() {
       expect(e.response.statusCode, 400);
     }
   });
+
+  test("accept + error conflict is resolved to error", () {
+    try {
+      object.read({"key": ""}, accept: [], reject: ["key"]);
+      fail('unreachable');
+    } on SerializableException catch (e) {
+      expect(e.response.statusCode, 400);
+    }
+  });
+
+  test("accept + ignore", () {
+    object.read({"key": ""}, accept: ["key"], ignore: ["key"]);
+    expect(object.contents, {});
+
+    object.read({"1": "", "2": ""}, accept: ["1"], ignore: []);
+    expect(object.contents, {"1": ""});
+  });
 }
 
 class TestSerializable extends Serializable {
   Map<String, dynamic> contents;
 
   @override
-  void readFromMap(Map<String, dynamic> object)
-  {
+  void readFromMap(Map<String, dynamic> object) {
     contents = object;
   }
 
   @override
-  Map<String, dynamic> asMap()
-  {
+  Map<String, dynamic> asMap() {
     return null;
   }
 }


### PR DESCRIPTION
Added accept filter option to read method of serializable interface. The way it is done is backward compatible (if no accept filters are given the behavior stays the same as before).

P.S.: I open a new pull request as the last one was closed after I reorganized my fork.