### PR TITLE
Added getter for inner response in TestResponse

### DIFF
--- a/aqueduct_test/lib/src/response.dart
+++ b/aqueduct_test/lib/src/response.dart
@@ -19,6 +19,9 @@ class TestResponse {
   /// not need to invoke [TestResponseBody.decode] or any of its asynchronous
   /// decoding methods.
   final TestResponseBody body;
+  
+  /// HTTP response.
+  HttpClientResponse get innerResponse => _innerResponse;
 
   /// HTTP response headers.
   HttpHeaders get headers => _innerResponse.headers;


### PR DESCRIPTION
Added getter for inner response in TestResponse, for testing stuff like WebSockets.
See example use case:
``` 
Random r = Random();
String key = base64.encode(List<int>.generate(8, (_) => r.nextInt(255)));
final response = await harness.agent.get("/dev/1", headers: {
    "Connection": "Upgrade",
    "Upgrade": "websocket",
    "sec-websocket-version": 13,
    "sec-websocket-key": key
});

Socket socket = await response.innerResponse.detachSocket();

WebSocket ws = WebSocket.fromUpgradedSocket(
  socket,
  serverSide: false,
);
```