### PR TITLE
Increase minimum analyzer version in support of aqueduct build

### DIFF
--- a/aqueduct/lib/src/cli/commands/db_upgrade.dart
+++ b/aqueduct/lib/src/cli/commands/db_upgrade.dart
@@ -96,7 +96,7 @@ class CLIDatabaseUpgrade extends CLICommand
     var s = persistentStore;
     if (s is PostgreSQLPersistentStore) {
       return DBInfo("postgres", s.username, s.password, s.host, s.port,
-          s.databaseName, s.timeZone);
+          s.databaseName, s.timeZone, useSSL: s.isSSLConnection);
     }
 
     return null;

--- a/aqueduct/lib/src/cli/scripts/run_upgrade.dart
+++ b/aqueduct/lib/src/cli/scripts/run_upgrade.dart
@@ -42,7 +42,7 @@ class RunUpgradeExecutable extends Executable<Map<String, dynamic>> {
     if (dbInfo != null && dbInfo.flavor == "postgres") {
       store = PostgreSQLPersistentStore(dbInfo.username, dbInfo.password,
           dbInfo.host, dbInfo.port, dbInfo.databaseName,
-          timeZone: dbInfo.timeZone);
+          timeZone: dbInfo.timeZone, useSSL: dbInfo.useSSL);
     }
 
     var migrationTypes = currentMirrorSystem()
@@ -102,7 +102,7 @@ class RunUpgradeExecutable extends Executable<Map<String, dynamic>> {
 
 class DBInfo {
   DBInfo(this.flavor, this.username, this.password, this.host, this.port,
-      this.databaseName, this.timeZone);
+      this.databaseName, this.timeZone, {this.useSSL = false});
 
   DBInfo.fromMap(Map<String, dynamic> map)
       : flavor = map["flavor"] as String,
@@ -111,7 +111,8 @@ class DBInfo {
         host = map["host"] as String,
         port = map["port"] as int,
         databaseName = map["databaseName"] as String,
-        timeZone = map["timeZone"] as String;
+        timeZone = map["timeZone"] as String,
+        useSSL = map["useSSL"] as bool;
 
   final String flavor;
   final String username;
@@ -120,6 +121,7 @@ class DBInfo {
   final int port;
   final String databaseName;
   final String timeZone;
+  final bool useSSL;
 
   Map<String, dynamic> asMap() {
     return {
@@ -129,7 +131,8 @@ class DBInfo {
       "host": host,
       "port": port,
       "databaseName": databaseName,
-      "timeZone": timeZone
+      "timeZone": timeZone,
+      "useSSL": useSSL
     };
   }
 }

--- a/aqueduct/pubspec.yaml
+++ b/aqueduct/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   args: ^1.5.0
-  analyzer: '>=0.32.0 <0.50.0'
+  analyzer: '>=0.39.4 <0.50.0'
   crypto: ^2.0.6
   logging: ^0.11.3
   isolate_executor: ^2.0.0


### PR DESCRIPTION
Fixes analyzer constraint issue as per https://github.com/stablekernel/aqueduct/issues/669#issuecomment-613623806). 

Also resolves https://github.com/stablekernel/aqueduct/issues/733.

```
$ pub run test -j 1
19:45 +1437 ~13: All tests passed!
```