### PR TITLE
Increase minimum analyzer version in support of aqueduct build

### DIFF
--- a/aqueduct/pubspec.yaml
+++ b/aqueduct/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   args: ^1.5.0
-  analyzer: '>=0.32.0 <0.50.0'
+  analyzer: '>=0.39.4 <0.50.0'
   crypto: ^2.0.6
   logging: ^0.11.3
   isolate_executor: ^2.0.0


### PR DESCRIPTION
Fixes analyzer constraint issue from https://github.com/stablekernel/aqueduct/issues/669#issuecomment-613623806. 

Also resolves https://github.com/stablekernel/aqueduct/issues/733.

```
$ pub run test -j 1
19:45 +1437 ~13: All tests passed!
```