### PR TITLE
updata Streaming Responses

### DIFF
--- a/source/docs/snippets/http.md
+++ b/source/docs/snippets/http.md
@@ -156,7 +156,7 @@ class AppChannel extends ApplicationChannel {
 
 ```dart
 class AppChannel extends ApplicationChannel {
-  final StreamController<String> controller = new StreamController<String>();  
+    final StreamController<String> controller = StreamController<String>.broadcast();  
 
   @override
   Future prepare() async {


### PR DESCRIPTION
use 
final StreamController<String> controller = StreamController<String>.broadcast(); 
instead of
final StreamController<String> controller = StreamController<String>();

the error with old code when more than Client connect to /stream
[SEVERE] aqueduct: Failed to send response, draining request. Reason: Bad state: StreamSink is bound to a stream  

to allow Multi listener to Stream