### PR TITLE
The code example has too many brackets.

### DIFF
--- a/source/docs/http/file_upload.md
+++ b/source/docs/http/file_upload.md
@@ -21,7 +21,7 @@ class MyController extends ResourceController {
   }
 
   @Operation.post()
-  Future<Response> postForm() async {}
+  Future<Response> postForm() async {
     final boundary = request.raw.headers.contentType.parameters["boundary"];
     final transformer = MimeMultipartTransformer(boundary);
     final bodyBytes = await request.body.decode<List<int>>();


### PR DESCRIPTION
I did the following change on line 24: 
Future<Response> postForm() async {}
to 
Future<Response> postForm() async {