### PR TITLE
Adding bulk insert to the Query interface

### DIFF
--- a/aqueduct/lib/src/db/managed/context.dart
+++ b/aqueduct/lib/src/db/managed/context.dart
@@ -123,19 +123,22 @@ class ManagedContext implements APIComponentDocumenter {
   ///
   /// If any insertion fails, no objects will be inserted into the database and an exception
   /// is thrown.
-  Future<List<T>> insertObjects<T extends ManagedObject>(List<T> objects) async {
-    return transaction((transitionCtx) => Future.wait(objects.map((o) => transitionCtx.insertObject(o))));
+  Future<List<T>> insertObjects<T extends ManagedObject>(
+    List<T> objects,
+  ) async {
+    return Query<T>(this).insertMany(objects);
   }
 
   /// Returns an object of type [T] from this context if it exists, otherwise returns null.
   ///
   /// If [T] cannot be inferred, an error is thrown. If [identifier] is not the same type as [T]'s primary key,
   /// null is returned.
-  Future<T> fetchObjectWithID<T extends ManagedObject>(dynamic identifier) async {
+  Future<T> fetchObjectWithID<T extends ManagedObject>(
+      dynamic identifier) async {
     final entity = dataModel.entityForType(T);
     if (entity == null) {
       throw ArgumentError("Unknown entity '$T' in fetchObjectWithID. "
-        "Provide a type to this method and ensure it is in this context's data model.");
+          "Provide a type to this method and ensure it is in this context's data model.");
     }
 
     final primaryKey = entity.primaryKeyAttribute;
@@ -143,7 +146,8 @@ class ManagedContext implements APIComponentDocumenter {
       return null;
     }
 
-    final query = Query<T>(this)..where((o) => o[primaryKey.name]).equalTo(identifier);
+    final query = Query<T>(this)
+      ..where((o) => o[primaryKey.name]).equalTo(identifier);
     return query.fetchOne();
   }
 

--- a/aqueduct/lib/src/db/query/query.dart
+++ b/aqueduct/lib/src/db/query/query.dart
@@ -33,7 +33,11 @@ abstract class Query<InstanceType extends ManagedObject> {
           "Invalid context. The data model of 'context' does not contain '$InstanceType'.");
     }
 
-    return context.persistentStore.newQuery<InstanceType>(context, entity, values: values);
+    return context.persistentStore.newQuery<InstanceType>(
+      context,
+      entity,
+      values: values,
+    );
   }
 
   /// Creates a new [Query] without a static type.
@@ -246,9 +250,11 @@ abstract class Query<InstanceType extends ManagedObject> {
   /// all [ManagedSet] properties and [ManagedObject] properties that do not have a [Relate] annotation. If you attempt
   /// to set a property that isn't allowed on [values], an error is thrown.
   ///
-  /// If a property of [values] is a [ManagedObject] with a [Relate] annotation, you may provide a value for its primary key
-  /// property. This value will be stored in the foreign key column that backs the property. You may set properties
-  /// of this type immediately, without having to create an instance of the related type:
+  /// If a property of [values] is a [ManagedObject] with a [Relate] annotation,
+  /// you may provide a value for its primary key property. This value will be
+  /// stored in the foreign key column that backs the property. You may set
+  /// properties of this type immediately, without having to create an instance
+  /// of the related type:
   ///
   ///         // Assumes that Employee is declared with the following property:
   ///         // @Relate(#employees)
@@ -259,8 +265,8 @@ abstract class Query<InstanceType extends ManagedObject> {
   ///           ..values.manager.id = 10;
   ///         await q.insert();
   ///
-  /// WARNING: You may replace this property with a new instance of [InstanceType]. When doing so, a copy
-  /// of the object is created and assigned to this property.
+  /// WARNING: You may replace this property with a new instance of [InstanceType].
+  /// When doing so, a copy of the object is created and assigned to this property.
   ///
   ///         final o = SomeObject()
   ///           ..id = 1;
@@ -302,6 +308,27 @@ abstract class Query<InstanceType extends ManagedObject> {
   /// If the [InstanceType] has properties with [Validate] metadata, those validations
   /// will be executed prior to sending the query to the database.
   Future<InstanceType> insert();
+
+  /// Inserts an [InstanceType]s into the underlying database.
+  ///
+  /// The [Query] must not have its [values] nor [valueMap] property set. This
+  /// operation will insert a row for each item in [objects] to the database in
+  /// [context]. The return value is a [Future] that completes with the newly
+  /// inserted [InstanceType]s. Example:
+  ///
+  ///       final users = [
+  ///          User()..email = 'user1@example.dev',
+  ///          User()..email = 'user2@example.dev',
+  ///       ];
+  ///       final q = Query<User>();
+  ///       var newUsers = await q.insertMany(users);
+  ///
+  /// If the [InstanceType] has properties with [Validate] metadata, those
+  /// validations will be executed prior to sending the query to the database.
+  ///
+  /// The method guaranties that either all rows will be inserted and returned
+  /// or exception will be thrown and non of the rows will be written to the database.
+  Future<List<InstanceType>> insertMany(List<InstanceType> objects);
 
   /// Updates [InstanceType]s in the underlying database.
   ///

--- a/aqueduct/lib/src/dev/helpers.dart
+++ b/aqueduct/lib/src/dev/helpers.dart
@@ -290,7 +290,8 @@ class InMemoryAuthStorage extends AuthServerDelegate {
 class DefaultPersistentStore extends PersistentStore {
   @override
   Query<T> newQuery<T extends ManagedObject>(
-      ManagedContext context, ManagedEntity entity, {T values}) {
+      ManagedContext context, ManagedEntity entity,
+      {T values}) {
     final q = _MockQuery<T>.withEntity(context, entity);
     if (values != null) {
       q.values = values;
@@ -413,6 +414,11 @@ class _MockQuery<InstanceType extends ManagedObject> extends Object
   @override
   Future<InstanceType> insert() async {
     throw Exception("insert() in _MockQuery");
+  }
+
+  @override
+  Future<List<InstanceType>> insertMany(List<InstanceType> objects) async {
+    throw Exception("insertMany(...) in _MockQuery");
   }
 
   @override

--- a/aqueduct/pubspec.yaml
+++ b/aqueduct/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://aqueduct.io
 documentation:
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   args: ^1.5.0


### PR DESCRIPTION
What is contained in the pull request:

- `insertMany(List)`  method to the `Query` interface
- implementation for the `insertMany` in the postgresql implementation for Query
- tests for the new method (plus reorganization of a few tests).
- changed `insertObjects(..)` method in context to use the new method

What is the benefit:

The new implementation uses the capability to insert more then one record with a single `INSERT` query, so instead of starting a transaction and doing N inserts and then commuting. This allows for much better performance especially for larger counts of rows inserted. Here is a table with benchmark averages:

| Rows  | Old way | New way |
|-------|-----------:|----------:|
| 1     |   5.95 ms  |   4.88 ms |
| 10    |  11.47 ms  |   6.01 ms |
| 100   |  42.41 ms  |  12.93 ms |
| 1000  |  334.36 ms |  58.08 ms |
| 10000 | 3982.86 ms | 559.64 ms |