### PR TITLE
Fix #897: Openapi generator includes private ORM fields

### DIFF
--- a/aqueduct/lib/src/db/managed/entity.dart
+++ b/aqueduct/lib/src/db/managed/entity.dart
@@ -303,6 +303,10 @@ class ManagedEntity implements APIComponentDocumenter {
         return;
       }
 
+      if (def.isPrivate) {
+        return;
+      }
+
       final schemaProperty = def.documentSchemaObject(context);
       schemaProperties[name] = schemaProperty;
     });


### PR DESCRIPTION
This forces the openapi generator to ignore private fields. Fixes #897 