### PR TITLE
Fixing the way aqueduct TestRequest serializes list query parameters

### DIFF
--- a/aqueduct_test/lib/src/request.dart
+++ b/aqueduct_test/lib/src/request.dart
@@ -76,12 +76,19 @@ class TestRequest {
 
     var url = _baseUrl.resolve(actualPath).toString();
     if ((query?.length ?? 0) > 0) {
-      final pairs = query.keys.map((key) {
-        final val = query[key];
+      final pairs = <String>[];
+
+      query.forEach((key, val) {
         if (val == null || val == true) {
-          return "$key";
+          pairs.add("$key");
+        } else if (val is List) {
+          val.forEach((innerVal) {
+            final urlEncoded = Uri.encodeComponent('$innerVal');
+            pairs.add("$key=$urlEncoded");
+          });
         } else {
-          return "$key=${Uri.encodeComponent("$val")}";
+          final urlEncoded = Uri.encodeComponent('$val');
+          pairs.add("$key=$urlEncoded");
         }
       });
 

--- a/aqueduct_test/test/request_test.dart
+++ b/aqueduct_test/test/request_test.dart
@@ -57,6 +57,17 @@ void main() {
     expect(received.raw.uri.query, "k=v%20v");
   });
 
+  test("Lsit query parameters are encoded as separate keys", () async {
+    final req = agent.request("/")
+      ..query = {
+        "k": ["v", "w"]
+      };
+    await req.get();
+
+    final received = await server.next();
+    expect(received.raw.uri.query, "k=v&k=w");
+  });
+
   test("Headers get added to request", () async {
     final req = agent.request("/")
       ..headers["k"] = "v"

--- a/aqueduct_test/test/request_test.dart
+++ b/aqueduct_test/test/request_test.dart
@@ -57,7 +57,7 @@ void main() {
     expect(received.raw.uri.query, "k=v%20v");
   });
 
-  test("Lsit query parameters are encoded as separate keys", () async {
+  test("List query parameters are encoded as separate keys", () async {
     final req = agent.request("/")
       ..query = {
         "k": ["v", "w"]


### PR DESCRIPTION
Up until now list query parameters were serialized in such a way:
```
url?query=[1, 2]
```
This is not the way aqueduct expects list parameters to be sent with that pull request the way lists are serialized is:
```
url?query=1&query=2
```