### PR TITLE
Correct typo on Routing example

### DIFF
--- a/source/docs/tour.md
+++ b/source/docs/tour.md
@@ -51,7 +51,7 @@ A [router](http/routing.md) determines which controller object should handle a r
 Controller get entryPoint {
   final router = Router();
 
-  // Handles /users, /users/1, /users/2, etc.
+  // Handles /projects, /projects/1, /projects/2, etc.
   router
     .route("/projects/[:id]")
     .link(() => ProjectController());


### PR DESCRIPTION
The Routing example used "/projects/:[id]" as the route argument, but the comment above it states: "// Handles /users, /users/1, /users/2, etc.". This can cause confusion specially for those who are new to Aqueduct.