### PR TITLE
use int.tryParse instead in heroes example

### DIFF
--- a/source/docs/tut/getting-started.md
+++ b/source/docs/tut/getting-started.md
@@ -274,7 +274,7 @@ class HeroesController extends ResourceController {
 
   @Operation.get('id')
   Future<Response> getHeroByID() async {
-    final id = int.parse(request.path.variables['id']);
+    final id = int.tryParse(request.path.variables['id']);
     final hero = _heroes.firstWhere((hero) => hero['id'] == id, orElse: () => null);
     if (hero == null) {
       return Response.notFound();

--- a/source/docs/tut/getting-started.md
+++ b/source/docs/tut/getting-started.md
@@ -230,7 +230,7 @@ Since the second segment of the path is optional, the path `/heroes` still match
 @override
 Future<RequestOrResponse> handle(Request request) async {
   if (request.path.variables.containsKey('id')) {
-    final id = int.parse(request.path.variables['id']);
+    final id = int.tryParse(request.path.variables['id']);
     final hero = _heroes.firstWhere((hero) => hero['id'] == id, orElse: () => null);
     if (hero == null) {
       return Response.notFound();


### PR DESCRIPTION
since the endpoint is `/heroes/[:id]`, endpoints like `/heroes/abc` are technically valid, but that currently throws an HTTP 500 error (handler throws an exception), where it should really be a 404 error.

Using `int.tryParse` instead of `int.parse` is an easy fix for this issue.